### PR TITLE
Adding mulitprovider layer - lite that consumes buildings-lite

### DIFF
--- a/tilestache.cfg
+++ b/tilestache.cfg
@@ -215,8 +215,8 @@
                         null, null, null, null,
                         null, null, null, 
 
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, TO_NUMBER(height, '999999D99S')::float AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 1600   -- 1px at z15",
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, TO_NUMBER(height, '999999D99S')::float AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 0"
+                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, (height::float*100)::int AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 1000  -- 1px at z15",
+                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, (height::float*100)::int AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 0   -- 1px at z16"
                     ]
                 }
             }


### PR DESCRIPTION
The idea here is to slim down the amount of data served by the multiprovider layers. We can do this in many different ways
1. By querying only the necessary data by zoomlevel (buildings-lite is an example)
2. By removing fluff from our queries (TODO using just 'kind' and not individual columns in our queries)
3. By optimizing the SQL to run faster (identifying and adding crucial indexes)

This pull request currently only tackles 1 of 3 mentioned above. (I'm working on 2 but cant push it because it involves a lot of changes to the stylesheet/xml file and Ekta wouldn't be too happy)
