### PR TITLE
add building:part geometries to building queries

### DIFF
--- a/queries/buildings-z13.pgsql
+++ b/queries/buildings-z13.pgsql
@@ -1,0 +1,37 @@
+SELECT
+    name,
+
+    (CASE WHEN COALESCE("building:part", building) != 'yes' THEN COALESCE("building:part", building) ELSE NULL END) AS kind,
+    building,
+    "building:part" AS building_part,
+
+    -- strip commas from heights (TODO: may need to strip other characters and/or do unit conversions)
+    TO_NUMBER(REPLACE(height, ',', '.'), '999999D99S')::float AS height,
+    TO_NUMBER(REPLACE(min_height, ',', '.'), '999999D99S')::float AS min_height,
+
+    way AS __geometry__
+
+FROM
+    planet_osm_polygon AS building_outer
+
+WHERE
+    (building IS NOT NULL OR "building:part" IS NOT NULL)
+
+    -- building "shells" that enclose building parts should not be rendered
+    AND NOT (
+        building_outer.building IS NOT NULL
+        AND building_outer."building:part" IS NULL
+        AND EXISTS (
+            SELECT
+                building_part_inner.osm_id
+            FROM
+                planet_osm_polygon AS building_part_inner
+            WHERE
+                building_part_inner.osm_id != building_outer.osm_id
+                AND building_part_inner."building:part" IS NOT NULL
+                AND ST_Intersects(building_outer.way, building_part_inner.way)
+            LIMIT 1
+        )
+    )
+
+    AND ST_Area(way) > 1600 -- 4px

--- a/queries/buildings-z14.pgsql
+++ b/queries/buildings-z14.pgsql
@@ -1,0 +1,37 @@
+SELECT
+    name,
+
+    (CASE WHEN COALESCE("building:part", building) != 'yes' THEN COALESCE("building:part", building) ELSE NULL END) AS kind,
+    building,
+    "building:part" AS building_part,
+
+    -- strip commas from heights (TODO: may need to strip other characters and/or do unit conversions)
+    TO_NUMBER(REPLACE(height, ',', '.'), '999999D99S')::float AS height,
+    TO_NUMBER(REPLACE(min_height, ',', '.'), '999999D99S')::float AS min_height,
+
+    way AS __geometry__
+
+FROM
+    planet_osm_polygon AS building_outer
+
+WHERE
+    (building IS NOT NULL OR "building:part" IS NOT NULL)
+
+    -- building "shells" that enclose building parts should not be rendered
+    AND NOT (
+        building_outer.building IS NOT NULL
+        AND building_outer."building:part" IS NULL
+        AND EXISTS (
+            SELECT
+                building_part_inner.osm_id
+            FROM
+                planet_osm_polygon AS building_part_inner
+            WHERE
+                building_part_inner.osm_id != building_outer.osm_id
+                AND building_part_inner."building:part" IS NOT NULL
+                AND ST_Intersects(building_outer.way, building_part_inner.way)
+            LIMIT 1
+        )
+    )
+
+    AND ST_Area(way) > 400 -- 4px

--- a/queries/buildings-z15.pgsql
+++ b/queries/buildings-z15.pgsql
@@ -1,0 +1,37 @@
+SELECT
+    name,
+
+    (CASE WHEN COALESCE("building:part", building) != 'yes' THEN COALESCE("building:part", building) ELSE NULL END) AS kind,
+    building,
+    "building:part" AS building_part,
+
+    -- strip commas from heights (TODO: may need to strip other characters and/or do unit conversions)
+    TO_NUMBER(REPLACE(height, ',', '.'), '999999D99S')::float AS height,
+    TO_NUMBER(REPLACE(min_height, ',', '.'), '999999D99S')::float AS min_height,
+
+    way AS __geometry__
+
+FROM
+    planet_osm_polygon AS building_outer
+
+WHERE
+    (building IS NOT NULL OR "building:part" IS NOT NULL)
+
+    -- building "shells" that enclose building parts should not be rendered
+    AND NOT (
+        building_outer.building IS NOT NULL
+        AND building_outer."building:part" IS NULL
+        AND EXISTS (
+            SELECT
+                building_part_inner.osm_id
+            FROM
+                planet_osm_polygon AS building_part_inner
+            WHERE
+                building_part_inner.osm_id != building_outer.osm_id
+                AND building_part_inner."building:part" IS NOT NULL
+                AND ST_Intersects(building_outer.way, building_part_inner.way)
+            LIMIT 1
+        )
+    )
+
+    AND ST_Area(way) > 100 -- 4px

--- a/queries/buildings-z16.pgsql
+++ b/queries/buildings-z16.pgsql
@@ -1,0 +1,37 @@
+SELECT
+    name,
+
+    (CASE WHEN COALESCE("building:part", building) != 'yes' THEN COALESCE("building:part", building) ELSE NULL END) AS kind,
+    building,
+    "building:part" AS building_part,
+
+    -- strip commas from heights (TODO: may need to strip other characters and/or do unit conversions)
+    TO_NUMBER(REPLACE(height, ',', '.'), '999999D99S')::float AS height,
+    TO_NUMBER(REPLACE(min_height, ',', '.'), '999999D99S')::float AS min_height,
+
+    way AS __geometry__
+
+FROM
+    planet_osm_polygon AS building_outer
+
+WHERE
+    (building IS NOT NULL OR "building:part" IS NOT NULL)
+
+    -- building "shells" that enclose building parts should not be rendered
+    AND NOT (
+        building_outer.building IS NOT NULL
+        AND building_outer."building:part" IS NULL
+        AND EXISTS (
+            SELECT
+                building_part_inner.osm_id
+            FROM
+                planet_osm_polygon AS building_part_inner
+            WHERE
+                building_part_inner.osm_id != building_outer.osm_id
+                AND building_part_inner."building:part" IS NOT NULL
+                AND ST_Intersects(building_outer.way, building_part_inner.way)
+            LIMIT 1
+        )
+    )
+
+    AND ST_Area(way) > 25 -- 4px

--- a/queries/buildings-z17.pgsql
+++ b/queries/buildings-z17.pgsql
@@ -1,0 +1,35 @@
+SELECT
+    name,
+
+    (CASE WHEN COALESCE("building:part", building) != 'yes' THEN COALESCE("building:part", building) ELSE NULL END) AS kind,
+    building,
+    "building:part" AS building_part,
+
+    -- strip commas from heights (TODO: may need to strip other characters and/or do unit conversions)
+    TO_NUMBER(REPLACE(height, ',', '.'), '999999D99S')::float AS height,
+    TO_NUMBER(REPLACE(min_height, ',', '.'), '999999D99S')::float AS min_height,
+
+    way AS __geometry__
+
+FROM
+    planet_osm_polygon AS building_outer
+
+WHERE
+    (building IS NOT NULL OR "building:part" IS NOT NULL)
+
+    -- building "shells" that enclose building parts should not be rendered
+    AND NOT (
+        building_outer.building IS NOT NULL
+        AND building_outer."building:part" IS NULL
+        AND EXISTS (
+            SELECT
+                building_part_inner.osm_id
+            FROM
+                planet_osm_polygon AS building_part_inner
+            WHERE
+                building_part_inner.osm_id != building_outer.osm_id
+                AND building_part_inner."building:part" IS NOT NULL
+                AND ST_Intersects(building_outer.way, building_part_inner.way)
+            LIMIT 1
+        )
+    )

--- a/tilestache.cfg
+++ b/tilestache.cfg
@@ -186,11 +186,11 @@
                         null, null, null, null,
                         null, null, null, null,
 
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, TO_NUMBER(height, '999999D99S')::float AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 1600 -- 1px at z12",
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, TO_NUMBER(height, '999999D99S')::float AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 400  -- 1px at z13",
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, TO_NUMBER(height, '999999D99S')::float AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 100  -- 1px at z14",
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, TO_NUMBER(height, '999999D99S')::float AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 25   -- 1px at z15",
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, TO_NUMBER(height, '999999D99S')::float AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 0"
+                        "queries/buildings-z13.pgsql",
+                        "queries/buildings-z14.pgsql",
+                        "queries/buildings-z15.pgsql",
+                        "queries/buildings-z16.pgsql",
+                        "queries/buildings-z17.pgsql"
                     ]
                 }
             }
@@ -217,9 +217,9 @@
                         null, null, null, null,
                         null, null, null, null,
                         null, null, null, null,
-                        null, null, null, 
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, (TO_NUMBER(height, '999999D99S')::float*100)::int AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 1000  -- 1px at z15",
-                        "SELECT name, (CASE WHEN building != 'yes' THEN building ELSE NULL END) AS kind, (TO_NUMBER(height, '999999D99S')::float*100)::int AS height, building, way AS __geometry__ FROM planet_osm_polygon WHERE building IS NOT null AND ST_Area(way) > 0   -- 1px at z16"
+                        null, null, null,
+                        "queries/buildings-z16.pgsql",
+                        "queries/buildings-z17.pgsql"
                     ]
                 }
             }


### PR DESCRIPTION
exclude building "shells" that enclose building parts, as these should not be rendered
