### PR TITLE
include building enclosures as well

### DIFF
--- a/queries/buildings-z15.pgsql
+++ b/queries/buildings-z15.pgsql
@@ -14,22 +14,4 @@ FROM
 
 WHERE
     (building IS NOT NULL OR "building:part" IS NOT NULL)
-
-    -- building "shells" that enclose building parts should not be rendered
-    AND NOT (
-        building_outer.building IS NOT NULL
-        AND building_outer."building:part" IS NULL
-        AND EXISTS (
-            SELECT
-                building_part_inner.osm_id
-            FROM
-                planet_osm_polygon AS building_part_inner
-            WHERE
-                building_part_inner.osm_id != building_outer.osm_id
-                AND building_part_inner."building:part" IS NOT NULL
-                AND ST_Intersects(building_outer.way, building_part_inner.way)
-            LIMIT 1
-        )
-    )
-
     AND way_area > 100 -- 4px

--- a/queries/buildings-z16.pgsql
+++ b/queries/buildings-z16.pgsql
@@ -14,22 +14,4 @@ FROM
 
 WHERE
     (building IS NOT NULL OR "building:part" IS NOT NULL)
-
-    -- building "shells" that enclose building parts should not be rendered
-    AND NOT (
-        building_outer.building IS NOT NULL
-        AND building_outer."building:part" IS NULL
-        AND EXISTS (
-            SELECT
-                building_part_inner.osm_id
-            FROM
-                planet_osm_polygon AS building_part_inner
-            WHERE
-                building_part_inner.osm_id != building_outer.osm_id
-                AND building_part_inner."building:part" IS NOT NULL
-                AND ST_Intersects(building_outer.way, building_part_inner.way)
-            LIMIT 1
-        )
-    )
-
     AND way_area > 25 -- 4px

--- a/queries/buildings-z17.pgsql
+++ b/queries/buildings-z17.pgsql
@@ -14,20 +14,3 @@ FROM
 
 WHERE
     (building IS NOT NULL OR "building:part" IS NOT NULL)
-
-    -- building "shells" that enclose building parts should not be rendered
-    AND NOT (
-        building_outer.building IS NOT NULL
-        AND building_outer."building:part" IS NULL
-        AND EXISTS (
-            SELECT
-                building_part_inner.osm_id
-            FROM
-                planet_osm_polygon AS building_part_inner
-            WHERE
-                building_part_inner.osm_id != building_outer.osm_id
-                AND building_part_inner."building:part" IS NOT NULL
-                AND ST_Intersects(building_outer.way, building_part_inner.way)
-            LIMIT 1
-        )
-    )

--- a/queries/vtm/buildings-z17.pgsql
+++ b/queries/vtm/buildings-z17.pgsql
@@ -17,20 +17,3 @@ FROM
 
 WHERE
     (building IS NOT NULL OR "building:part" IS NOT NULL)
-
-    -- building "shells" that enclose building parts should not be rendered
-    AND NOT (
-        building_outer.building IS NOT NULL
-        AND building_outer."building:part" IS NULL
-        AND EXISTS (
-            SELECT
-                building_part_inner.osm_id
-            FROM
-                planet_osm_polygon AS building_part_inner
-            WHERE
-                building_part_inner.osm_id != building_outer.osm_id
-                AND building_part_inner."building:part" IS NOT NULL
-                AND ST_Intersects(building_outer.way, building_part_inner.way)
-            LIMIT 1
-        )
-    )


### PR DESCRIPTION
There were cases where the building shells overlapped with other
building parts, and weren't being displayed as a result. This also has
the side effect of speeding up the queries.
