### PR TITLE
Update tilejson layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.10.4
+-------
+* **Release date**: 2016-06-28
+* Update tilejson layers. See [#874](https://github.com/tilezen/vector-datasource/issues/872).
+
 v0.10.3
 -------
 * **Release date**: 2016-05-20.

--- a/tilejson/tilejson.json.erb
+++ b/tilejson/tilejson.json.erb
@@ -124,5 +124,5 @@
             "description" : ""
         }
     ],
-    "version" : "1"
+    "version" : "1.1.0"
 }

--- a/tilejson/tilejson.json.erb
+++ b/tilejson/tilejson.json.erb
@@ -12,7 +12,7 @@
     ],
     "description" : "mapzen",
     "format" : "<%= @params[:format] %>",
-    "maxzoom" : 20.000000,
+    "maxzoom" : 16.000000,
     "minzoom" : 0.000000,
     "name" : "<%= @params[:name] %>",
     "private" : true,
@@ -30,16 +30,27 @@
                 "kind" : "String",
                 "area" : "Number"
             },
-            "maxzoom" : 20.000000,
+            "maxzoom" : 16.000000,
             "minzoom" : 0.000000,
             "description" : ""
         },
         {
             "id" : "earth",
             "fields" : {
-                "land" : "String"
+                "kind" : "String"
             },
-            "maxzoom" : 20.000000,
+            "maxzoom" : 16.000000,
+            "minzoom" : 0.000000,
+            "description" : ""
+        },
+        {
+            "id" : "places",
+            "fields" : {
+                "name" : "String",
+                "kind" : "String",
+                "admin_level" : "Number"
+            },
+            "maxzoom" : 16.000000,
             "minzoom" : 0.000000,
             "description" : ""
         },
@@ -50,7 +61,7 @@
                 "kind" : "String",
                 "area" : "Number"
             },
-            "maxzoom" : 20.000000,
+            "maxzoom" : 16.000000,
             "minzoom" : 0.000000,
             "description" : ""
         },
@@ -66,7 +77,7 @@
                 "is_link" : "String",
                 "sort_key" : "Number"
             },
-            "maxzoom" : 20.000000,
+            "maxzoom" : 16.000000,
             "minzoom" : 0.000000,
             "description" : ""
         },
@@ -78,7 +89,7 @@
                 "height" : "Number",
                 "minheight" : "Number"
             },
-            "maxzoom" : 20.000000,
+            "maxzoom" : 16.000000,
             "minzoom" : 0.000000,
             "description" : ""
         },
@@ -88,18 +99,27 @@
                 "name" : "String",
                 "kind" : "String"
             },
-            "maxzoom" : 20.000000,
+            "maxzoom" : 16.000000,
             "minzoom" : 0.000000,
             "description" : ""
         },
         {
-            "id" : "places",
+            "id" : "boundaries",
             "fields" : {
                 "name" : "String",
-                "kind" : "String",
-                "admin_level" : "Number"
+                "kind" : "String"
             },
-            "maxzoom" : 20.000000,
+            "maxzoom" : 16.000000,
+            "minzoom" : 0.000000,
+            "description" : ""
+        },
+        {
+            "id" : "transit",
+            "fields" : {
+                "name" : "String",
+                "kind" : "String"
+            },
+            "maxzoom" : 16.000000,
             "minzoom" : 0.000000,
             "description" : ""
         }


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/872

This updates the tilejson files with the immediate obvious changes.

* Add the transit and boundaries layers
* Update the max zoom to 16 for all layers
* Update the earth layer to use `kind` instead of `land`

@nvkelso could you review please? Let me know if there's something else that we should add in at this point.