### PR TITLE
Update bicycle_repair_station test

### DIFF
--- a/integration-test/662-basic-outdoor-pois.py
+++ b/integration-test/662-basic-outdoor-pois.py
@@ -3,10 +3,11 @@ assert_has_feature(
     16, 10550, 25297, 'pois',
     { 'kind': 'bbq', 'min_zoom': 18 })
 
-#http://www.openstreetmap.org/node/3497698404
+# Node: Valencia Cyclery (3443701422)
+# http://www.openstreetmap.org/node/3443701422
 assert_has_feature(
-    16, 10471, 25343, 'pois',
-    { 'kind': 'bicycle_repair_station', 'min_zoom': 18 })
+    16, 10481, 25335, 'pois',
+    { 'id': 3443701422, 'kind': 'bicycle_repair_station', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/2910259124
 assert_has_feature(

--- a/integration-test/806-building-height.py
+++ b/integration-test/806-building-height.py
@@ -1,8 +1,8 @@
-# Way: R5 (161390790)
-# https://www.openstreetmap.org/way/161390790
+# Way: R5 Tower A (431358377)
+# https://www.openstreetmap.org/way/431358377
 assert_has_feature(
     16, 55897, 25449, 'buildings',
-    { 'id': 161390790, 'height': 77.0, 'kind': 'office',
+    { 'id': 431358377, 'height': 77.0, 'kind': 'office',
       'building:levels': type(None), 'building_levels': type(None) })
 
 # http://www.openstreetmap.org/way/336433763


### PR DESCRIPTION
The node we were using for the bicycle_repair_station test was deleted. This updates the test to use a different one.

Based off of https://github.com/tilezen/vector-datasource/pull/902 which fixes a different test failure.

@nvkelso, @zerebubuth could you review please?