### PR TITLE
Add test for missing building part seen in production.

### DIFF
--- a/integration-test/912-missing-building-part.py
+++ b/integration-test/912-missing-building-part.py
@@ -1,0 +1,13 @@
+# http://www.openstreetmap.org/way/287494678
+z = 18
+x = 77193
+y = 98529
+while z >= 16:
+    assert_has_feature(
+        z, x, y, 'buildings',
+        { 'kind': 'building',
+          'id': 287494678 })
+
+    z -= 1
+    x /= 2
+    y /= 2


### PR DESCRIPTION
Connects to #912.

This just checks that the building data is present in the tiles, which it appears to be across zooms 18, 17 and 16.

@rmarianski could you review, please?
