### PR TITLE
Omit default shapefile encoding.

### DIFF
--- a/data/Makefile-import-data.jinja2
+++ b/data/Makefile-import-data.jinja2
@@ -5,8 +5,12 @@ import: import-shapefiles.sh
 import-shapefiles.sh: {{ tgt_shapefile_shps }}
 	@> import-shapefiles.sh
 	@chmod +x import-shapefiles.sh
+	@echo "#!/bin/sh" >> import-shapefiles.sh
+	@echo "shp2pgsql | grep RELEASE: | awk '{split(\$$2,v,\".\"); if (v[1] < 2) { exit 1; }}'" >> import-shapefiles.sh
+	@echo "if [ \$$? -ne 0 ]; then echo 'Your version of shp2pgsql is too old, we need at least version 2 or later.'; exit 1; fi" >> import-shapefiles.sh
+	@echo "set -e" >> import-shapefiles.sh
 {% for shapefile in shapefiles %}
-	@echo 'shp2pgsql -dID -s 3857 -W UTF-8 -g the_geom {{ shapefile['tgt_shp'] }} {{ shapefile['name'] }}' >> import-shapefiles.sh
+	@echo 'shp2pgsql -dID -s 3857 -g the_geom {{ shapefile['tgt_shp'] }} {{ shapefile['name'] }}' >> import-shapefiles.sh
 {% endfor %}
 	@echo './import-shapefiles.sh | psql -d <database>'
 

--- a/data/shapefile_schema/README.md
+++ b/data/shapefile_schema/README.md
@@ -8,6 +8,6 @@ tar zxf ../shapefiles.tar.gz
 for i in *.zip; do unzip $i; done
 for i in `find . -name "*.shp"`; do
   j=`echo $i | sed "s,.*/,,;s,-merc,,;s,\.shp\$,,"`
-  shp2pgsql -p -s 3857 -W Windows-1252 -g the_geom $i $j >> $j.sql
+  shp2pgsql -p -s 3857 -g the_geom $i $j >> $j.sql
 done
 ```

--- a/scripts/setup_and_run_tests.sh
+++ b/scripts/setup_and_run_tests.sh
@@ -34,6 +34,11 @@ for prog in createdb cat dropdb python osm2pgsql shp2pgsql xargs zip; do
    which "${prog}" >/dev/null || die "Unable to find '${prog}' program in PATH."
 done
 
+shp2pgsql | grep RELEASE: | awk '{split($2,v,"."); if (v[1] < 2) { exit 1; }}'
+if [ $? -ne 0 ]; then
+    die 'Your version of shp2pgsql is too old, we need at least version 2 or later.'
+fi
+
 echo "=== Creating database \"${dbname}\"..."
 createdb -E UTF-8 -T template0 "${dbname}"
 cat >empty.osm <<EOF


### PR DESCRIPTION
Omit shapefile encoding when it's `-W UTF-8`, as that has been the default since version 2. Add check for shp2pgsql version. This can cause a crash with recent (>2.2) versions of shp2pgsql when the default is superfluously specified _and_ the shapefile contains a code page.

Connects to #946.

@rmarianski could you review, please?
