### PR TITLE
Data was updated - fix test to match.

### DIFF
--- a/integration-test/522-hotels.py
+++ b/integration-test/522-hotels.py
@@ -3,7 +3,7 @@ assert_has_feature(
     15, 5242, 12663, 'pois',
     { 'kind': 'hotel', 'name': 'Ritz-Carlton' })
 
-#https://www.openstreetmap.org/relation/3827943
+#https://www.openstreetmap.org/relation/6480430
 assert_has_feature(
     16, 10484, 25327, 'pois',
-    { 'kind': 'hotel', 'name': 'The Stanford Court Renaissance' })
+    { 'kind': 'hotel', 'name': 'Stanford Court San Francisco Hotel' })


### PR DESCRIPTION
The test for hotels from #522 included a test for the "Stanford Court Renaissance", which has since [been deleted](https://www.openstreetmap.org/changeset/41355932), and a [new object added](https://www.openstreetmap.org/relation/6480430) with the name "Stanford Court San Francisco Hotel". Perhaps it changed owners or something?

@rmarianski could you review, please?
