### PR TITLE
Fixes for interaction with the label placement work

### DIFF
--- a/integration-test/583-merge-landuse.py
+++ b/integration-test/583-merge-landuse.py
@@ -648,8 +648,13 @@ with features_in_tile_layer(9, 245, 166, 'landuse') as landuse:
     feature_props = set()
 
     for feature in landuse:
-        # ignore ID, area when checking for uniqueness
         p = feature['properties'].copy()
+
+        # ignore label placements
+        if p.get('label_placement'):
+            continue
+
+        # ignore ID, area when checking for uniqueness
         p.pop('id', None)
         p.pop('area', None)
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -432,23 +432,6 @@ post_process:
         - transit
         - water
 
-  # drop the names and less important additional tags of small landuse polygons
-  - fn: vectordatasource.transform.drop_properties
-    params:
-      source_layer: landuse
-      start_zoom: 9
-      end_zoom: 12
-      properties: [name, sport, religion, surface]
-      where: >-
-        pixel_area > area
-      geom_types: [Polygon, MultiPolygon]
-  # merge any remaining polygons by their properties.
-  - fn: vectordatasource.transform.merge_polygon_features
-    params:
-      source_layer: landuse
-      start_zoom: 4
-      end_zoom: 12
-
   - fn: vectordatasource.transform.drop_properties
     params:
       source_layer: roads
@@ -486,6 +469,24 @@ post_process:
       property_keys: [name, kind]
       geometry_types: [Point]
       min_distance: 256.0
+
+  # drop the names and less important additional tags of small landuse polygons
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: landuse
+      start_zoom: 4
+      end_zoom: 12
+      properties: [name, sport, religion, surface]
+      where: >-
+        pixel_area > area
+      geom_types: [Polygon, MultiPolygon]
+  # merge any remaining polygons by their properties.
+  - fn: vectordatasource.transform.merge_polygon_features
+    params:
+      source_layer: landuse
+      start_zoom: 4
+      end_zoom: 12
+
   - fn: vectordatasource.transform.drop_features_where
     params:
       source_layer: water


### PR DESCRIPTION
Shift merging to after label placement extraction and ignore landuse points in test. Should fix failing CI tests.

Connects to #583.

@rmarianski could you review, please?