### PR TITLE
Remove id property from merge functions

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -618,7 +618,7 @@ post_process:
       values: ['closed', 'historical']
       target_min_zoom: 17
       drop_below_zoom: 16
-  - fn: vectordatasource.transform.merge_features
+  - fn: vectordatasource.transform.merge_line_features
     params:
       source_layer: transit
       start_zoom: 0
@@ -672,7 +672,7 @@ post_process:
       target_attribute: landuse_kind
       cutting_attrs: { sort_key: 'sort_key', reverse: True }
 
-  - fn: vectordatasource.transform.merge_features
+  - fn: vectordatasource.transform.merge_line_features
     params:
       source_layer: roads
       start_zoom: 8

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -2816,89 +2816,6 @@ def _thaw(thing):
     return thing
 
 
-def merge_features(ctx):
-    """
-    Merge (linear) features with the same properties together, attempting to
-    make the resulting geometry as large as possible. Note that this will
-    remove the IDs from any merged features.
-
-    At the moment, only merging for linear features is implemented, although
-    it would be possible to extend to other geometry types.
-    """
-
-    feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
-    source_layer = ctx.params.get('source_layer')
-    start_zoom = ctx.params.get('start_zoom', 0)
-    end_zoom = ctx.params.get('end_zoom')
-
-    assert source_layer, 'merge_features: missing source layer'
-
-    if zoom < start_zoom:
-        return None
-
-    if end_zoom is not None and zoom > end_zoom:
-        return None
-
-    layer = _find_layer(feature_layers, source_layer)
-    if layer is None:
-        return None
-
-    # a dictionary mapping the properties of a feature to a tuple of
-    # the feature IDs and a list of shapes. When we merge the
-    # features, they will lose their individual IDs, so only keep the
-    # first.
-    features_by_property = {}
-
-    # a list of all the features that we can't currently merge (at this time;
-    # points and polygons) which will be skipped by this procedure.
-    skipped_features = []
-
-    for shape, props, fid in layer['features']:
-        dims = _geom_dimensions(shape)
-        if dims != _LINE_DIMENSION:
-            skipped_features.append((shape, props, fid))
-            continue
-
-        # keep the 'id' property as well as the feature ID, as these are often
-        # distinct.
-        p_id = props.pop('id', None)
-
-        # because dicts are mutable and therefore not hashable, we have to
-        # transform their items into a frozenset instead.
-        frozen_props = _freeze(props)
-
-        if frozen_props in features_by_property:
-            features_by_property[frozen_props][2].append(shape)
-        else:
-            features_by_property[frozen_props] = (fid, p_id, [shape])
-
-    new_features = []
-    for frozen_props, (fid, p_id, shapes) in features_by_property.iteritems():
-        # we only have lines, so _linemerge is the best we can
-        # attempt. however, the `shapes` we're operating on may be
-        # linestrings, multi-linestrings or even empty, so the first
-        # thing to do is to flatten them into a single geometry.
-        list_of_linestrings = []
-        for shape in shapes:
-            list_of_linestrings.extend(_flatten_geoms(shape))
-        multi = MultiLineString(list_of_linestrings)
-
-        # thaw the frozen properties to use in the new feature.
-        props = _thaw(frozen_props)
-
-        # restore any 'id' property.
-        if p_id is not None:
-            props['id'] = p_id
-
-        new_features.append((_linemerge(multi), props, fid))
-
-    new_features.extend(skipped_features)
-    layer['features'] = new_features
-
-    return layer
-
-
 def quantize_val(val, step):
     result = int(step * round(val / float(step)))
     return result
@@ -2916,27 +2833,53 @@ def quantize_height_round_nearest_meter(height):
     return round(height)
 
 
-def _merge_features_by_property(features, drop_props_fn=None,
-                                update_merged_props_fn=None):
+def _merge_lines(linestring_shapes):
+    list_of_linestrings = []
+    for shape in linestring_shapes:
+        list_of_linestrings.extend(_flatten_geoms(shape))
+    multi = MultiLineString(list_of_linestrings)
+    result = _linemerge(multi)
+    return result
+
+
+def _merge_polygons(polygon_shapes):
+    list_of_polys = []
+    for shape in polygon_shapes:
+        list_of_polys.extend(_flatten_geoms(shape))
+    result = shapely.ops.unary_union(list_of_polys)
+    return result
+
+
+def _merge_features_by_property(
+        features, geom_dim,
+        update_props_pre_fn=None,
+        update_props_post_fn=None):
+
+    assert geom_dim in (_POLYGON_DIMENSION, _LINE_DIMENSION)
+    if geom_dim == _LINE_DIMENSION:
+        _merge_shape_fn = _merge_lines
+    else:
+        _merge_shape_fn = _merge_polygons
+
     features_by_property = {}
     skipped_features = []
     for feature in features:
         shape, props, fid = feature
-        dims = _geom_dimensions(shape)
-        if dims != _POLYGON_DIMENSION:
+        shape_dim = _geom_dimensions(shape)
+        if shape_dim != geom_dim:
             skipped_features.append(feature)
             continue
 
         orig_props = props.copy()
         p_id = props.pop('id', None)
-        if drop_props_fn:
-            props = drop_props_fn(props)
+        if update_props_pre_fn:
+            props = update_props_pre_fn((shape, props, fid))
 
         if props is None:
-            skipped_features.append(feature)
+            skipped_features.append((shape, orig_props, fid))
             continue
 
-        frozen_props = frozenset(props.items())
+        frozen_props = _freeze(props)
         if frozen_props in features_by_property:
             features_by_property[frozen_props][-1].append(shape)
         else:
@@ -2952,20 +2895,13 @@ def _merge_features_by_property(features, drop_props_fn=None,
             new_features.append((shapes[0], orig_props, fid))
             continue
 
-        list_of_polys = []
-        for shape in shapes:
-            list_of_polys.extend(_flatten_geoms(shape))
-
-        merged_shape = shapely.ops.unary_union(list_of_polys)
+        merged_shape = _merge_shape_fn(shapes)
 
         # thaw the frozen properties to use in the new feature.
-        props = dict(frozen_props)
+        props = _thaw(frozen_props)
 
-        if p_id is not None:
-            props['id'] = p_id
-
-        if update_merged_props_fn:
-            props = update_merged_props_fn(merged_shape, props)
+        if update_props_post_fn:
+            props = update_props_post_fn((merged_shape, props, fid))
 
         new_features.append((merged_shape, props, fid))
 
@@ -2998,7 +2934,7 @@ def merge_building_features(ctx):
         if quantize_fn_dotted_name:
             quantize_height_fn = resolve(quantize_fn_dotted_name)
 
-    def _drop_props(props):
+    def _props_pre((shape, props, fid)):
         if exclusions:
             for prop in exclusions:
                 if prop in props:
@@ -3020,7 +2956,7 @@ def merge_building_features(ctx):
 
         return props
 
-    def _update_merged_props(merged_shape, props):
+    def _props_post((merged_shape, props, fid)):
         # add the area and volume back in
         area = int(merged_shape.area)
         props['area'] = area
@@ -3030,7 +2966,7 @@ def merge_building_features(ctx):
         return props
 
     layer['features'] = _merge_features_by_property(
-        layer['features'], _drop_props, _update_merged_props)
+        layer['features'], _POLYGON_DIMENSION, _props_pre, _props_post)
     return layer
 
 
@@ -3058,19 +2994,45 @@ def merge_polygon_features(ctx):
     if end_zoom is not None and zoom > end_zoom:
         return None
 
-    def _drop_props(props):
+    def _props_pre((shape, props, fid)):
         # drop area while merging, as we'll recalculate after.
         props.pop('area', None)
         return props
 
-    def _update_merged_props(merged_shape, props):
+    def _props_post((merged_shape, props, fid)):
         # add the area back in
         area = int(merged_shape.area)
         props['area'] = area
         return props
 
     layer['features'] = _merge_features_by_property(
-        layer['features'], _drop_props, _update_merged_props)
+        layer['features'], _POLYGON_DIMENSION, _props_pre, _props_post)
+    return layer
+
+
+def merge_line_features(ctx):
+    """
+    Merge linestrings having the same properties, in the source_layer
+    between start_zoom and end_zoom inclusive.
+    """
+
+    zoom = ctx.tile_coord.zoom
+    source_layer = ctx.params.get('source_layer')
+    start_zoom = ctx.params.get('start_zoom', 0)
+    end_zoom = ctx.params.get('end_zoom')
+
+    assert source_layer, 'merge_line_features: missing source layer'
+    layer = _find_layer(ctx.feature_layers, source_layer)
+    if layer is None:
+        return None
+
+    if zoom < start_zoom:
+        return None
+    if end_zoom is not None and zoom > end_zoom:
+        return None
+
+    layer['features'] = _merge_features_by_property(
+        layer['features'], _LINE_DIMENSION)
     return layer
 
 


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/952

I took the liberty of consolidating all the merge functions as part of this pr. It was already pretty well factored with pre/post hooks, so I grew support for merging either lines or polygons.

@zerebubuth could you review please?