### PR TITLE
remove label placements early for landuse and buildings

### DIFF
--- a/integration-test/679-less-landuse-building-label-placements.py
+++ b/integration-test/679-less-landuse-building-label-placements.py
@@ -2,7 +2,7 @@
 # http://www.openstreetmap.org/way/82206919
 assert_no_matching_feature(
     14, 2620, 6330, 'landuse',
-    {'id': 82206919, 'kind': 'pier', 'label_placement': type(None)})
+    {'id': 82206919, 'kind': 'pier', 'label_placement': True})
 
 assert_has_feature(
     15, 5240, 12661, 'landuse',
@@ -13,7 +13,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/way/260520160
 assert_no_matching_feature(
     15, 5242, 12663, 'buildings',
-    {'id': 260520160, 'kind': 'building', 'label_placement': type(None)})
+    {'id': 260520160, 'kind': 'building', 'label_placement': True})
 
 assert_has_feature(
     16, 10484, 25326, 'buildings',

--- a/integration-test/679-less-landuse-building-label-placements.py
+++ b/integration-test/679-less-landuse-building-label-placements.py
@@ -2,7 +2,7 @@
 # http://www.openstreetmap.org/way/82206919
 assert_no_matching_feature(
     14, 2620, 6330, 'landuse',
-    {'id': 82206919, 'kind': 'pier', 'label_placement': None})
+    {'id': 82206919, 'kind': 'pier', 'label_placement': type(None)})
 
 assert_has_feature(
     15, 5240, 12661, 'landuse',
@@ -13,7 +13,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/way/260520160
 assert_no_matching_feature(
     15, 5242, 12663, 'buildings',
-    {'id': 260520160, 'kind': 'building', 'label_placement': None})
+    {'id': 260520160, 'kind': 'building', 'label_placement': type(None)})
 
 assert_has_feature(
     16, 10484, 25326, 'buildings',

--- a/integration-test/679-less-landuse-building-label-placements.py
+++ b/integration-test/679-less-landuse-building-label-placements.py
@@ -1,0 +1,21 @@
+# The landuse for a pier
+# http://www.openstreetmap.org/way/82206919
+assert_no_matching_feature(
+    14, 2620, 6330, 'landuse',
+    {'id': 82206919, 'kind': 'pier', 'label_placement': None})
+
+assert_has_feature(
+    15, 5240, 12661, 'landuse',
+    {'id': 82206919, 'kind': 'pier', 'label_placement': True})
+
+
+# The building known as 650 California Street
+# http://www.openstreetmap.org/way/260520160
+assert_no_matching_feature(
+    15, 5242, 12663, 'buildings',
+    {'id': 260520160, 'kind': 'building', 'label_placement': None})
+
+assert_has_feature(
+    16, 10484, 25326, 'buildings',
+    {'id': 260520160, 'kind': 'building', 'label_placement': True})
+

--- a/queries.yaml
+++ b/queries.yaml
@@ -460,16 +460,36 @@ post_process:
   - fn: vectordatasource.transform.handle_label_placement
     params:
       layers:
-        - landuse
         - water
         - earth
-        - buildings
+      location_property: mz_label_placement
+      label_property_name: label_placement
+      label_property_value: true
+      label_where: >-
+        'name' in properties
+
+  - fn: vectordatasource.transform.handle_label_placement
+    params:
+      layers:
+        - landuse
+      start_zoom: 15
       location_property: mz_label_placement
       label_property_name: label_placement
       label_property_value: true
       label_where: >-
         'name' in properties or
         ('sport' in properties and properties.get('kind', 'rock') not in ('rock', 'stone'))
+
+  - fn: vectordatasource.transform.handle_label_placement
+    params:
+      layers:
+        - buildings
+      start_zoom: 16
+      location_property: mz_label_placement
+      label_property_name: label_placement
+      label_property_value: true
+      label_where: >-
+        'name' in properties
 
   - fn: vectordatasource.transform.remove_duplicate_features
     params:

--- a/queries.yaml
+++ b/queries.yaml
@@ -480,6 +480,15 @@ post_process:
         'name' in properties or
         ('sport' in properties and properties.get('kind', 'rock') not in ('rock', 'stone'))
 
+  # drop mz_label placement at zooms we don't apply handle_label_placement
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: landuse
+      start_zoom: 0
+      end_zoom: 14
+      properties: [mz_label_placement]
+      geom_types: [Polygon, MultiPolygon]
+
   - fn: vectordatasource.transform.handle_label_placement
     params:
       layers:
@@ -490,6 +499,15 @@ post_process:
       label_property_value: true
       label_where: >-
         'name' in properties
+
+  # drop mz_label placement at zooms we don't apply handle_label_placement
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: buildings
+      start_zoom: 0
+      end_zoom: 15
+      properties: [mz_label_placement]
+      geom_types: [Polygon, MultiPolygon]
 
   - fn: vectordatasource.transform.remove_duplicate_features
     params:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -1847,10 +1847,15 @@ def handle_label_placement(ctx):
     Converts a geometry label column into a separate feature.
     """
     layers = ctx.params.get('layers', None)
+    zoom = ctx.tile_coord.zoom
     location_property = ctx.params.get('location_property', None)
     label_property_name = ctx.params.get('label_property_name', None)
     label_property_value = ctx.params.get('label_property_value', None)
     label_where = ctx.params.get('label_where', None)
+    start_zoom = ctx.params.get('start_zoom', 0)
+
+    if zoom < start_zoom:
+        return None
 
     assert layers, 'handle_label_placement: Missing layers'
     assert location_property, \


### PR DESCRIPTION
Connects with #679 to remove label placements early for landuse and buildings.

- [x] **Update tests** - new test added.
- [ ] **Update data migrations** - none required, these are all post processing steps.
- [ ] **Update docs** - we don't make promises about zoom ranges of label positions.