### PR TITLE
connects to #1012 for boundary sort_key updates and tests

### DIFF
--- a/integration-test/1012-sort_key-boundary.py
+++ b/integration-test/1012-sort_key-boundary.py
@@ -1,0 +1,32 @@
+# Adds tests for OSM features (but not NE features)
+
+# country boundary of USA
+#https://www.openstreetmap.org/relation/148838
+assert_has_feature(
+    8, 39, 95, "boundaries",
+    {"kind": "country", "id": -148838,
+     "sort_key": 262})
+
+# region boundary between Nevada - California
+#https://www.openstreetmap.org/relation/165473
+#https://www.openstreetmap.org/relation/165475
+assert_has_feature(
+    8, 42, 96, "boundaries",
+    {"kind": "region", "id": -165473,
+     "sort_key": 256})
+
+# county boundary between Mendocino County - Humboldt County
+#https://www.openstreetmap.org/relation/396458
+#https://www.openstreetmap.org/relation/396489
+assert_has_feature(
+    10, 159, 387, "boundaries",
+    {"kind": "county", "id": -165473,
+     "sort_key": 254})
+
+# locality boundary between San Francisco - Daly City
+#https://www.openstreetmap.org/relation/111968
+#https://www.openstreetmap.org/relation/112271
+assert_has_feature(
+    10, 163, 396, "boundaries",
+    {"kind": "locality", "id": -111968,
+     "sort_key": 252})

--- a/integration-test/1012-sort_key-boundary.py
+++ b/integration-test/1012-sort_key-boundary.py
@@ -4,29 +4,25 @@
 #https://www.openstreetmap.org/relation/148838
 assert_has_feature(
     8, 39, 95, "boundaries",
-    {"kind": "country", "id": -148838,
-     "sort_key": 262})
+    {"kind": "country", "sort_key": 262})
 
 # region boundary between Nevada - California
 #https://www.openstreetmap.org/relation/165473
 #https://www.openstreetmap.org/relation/165475
 assert_has_feature(
     8, 42, 96, "boundaries",
-    {"kind": "region", "id": -165473,
-     "sort_key": 256})
+    {"kind": "region", "sort_key": 256})
 
 # county boundary between Mendocino County - Humboldt County
 #https://www.openstreetmap.org/relation/396458
 #https://www.openstreetmap.org/relation/396489
 assert_has_feature(
     10, 159, 387, "boundaries",
-    {"kind": "county", "id": -165473,
-     "sort_key": 254})
+    {"kind": "county", "sort_key": 254})
 
 # locality boundary between San Francisco - Daly City
 #https://www.openstreetmap.org/relation/111968
 #https://www.openstreetmap.org/relation/112271
 assert_has_feature(
     10, 163, 396, "boundaries",
-    {"kind": "locality", "id": -111968,
-     "sort_key": 252})
+    {"kind": "locality", "sort_key": 252})

--- a/spreadsheets/sort_key/boundaries.csv
+++ b/spreadsheets/sort_key/boundaries.csv
@@ -1,18 +1,13 @@
 kind,sort_key
-municipality,252
+locality,252
 county,254
-Admin-1 boundary,256
-state,256
-1st Order Admin Line,256
-Admin-1 region boundary,257
-Indefinite (please verify),259
-Indeterminant frontier,259
-Lease limit,259
-Overlay limit,259
-Line of control (please verify),260
-Disputed (please verify),261
-Admin-0 country,262
+region,256
+macroregion,257
+indefinite,259
+indeterminate,259
+lease_limit,259
+overlay_limit,259
+line_of_control,260
+disputed,261
 country,262
-International boundary (verify),262
-dam,263
 *,250


### PR DESCRIPTION
- [x] **Update tests**
- [x] **Update data migrations** - not needed
- [x] **Update docs** - not needed, other PRs already did the kind remapping.

I renamed all the kinds in the boundaries.csv to match current behavior, and removed outdated kinds.

I also removed `dam` as we moved that to the landuse layer (and it's correctly setup in that spreadsheet).