### PR TITLE
Fix tests after changeset 41843926.

### DIFF
--- a/integration-test/502-water-boundaries-slow.py
+++ b/integration-test/502-water-boundaries-slow.py
@@ -3,7 +3,7 @@
 # polygon, but zero water boundaries actually in the tile.
 no_boundary_tiles = [
     #https://www.openstreetmap.org/way/51858784
-    #https://www.openstreetmap.org/way/21635049
+    #https://www.openstreetmap.org/way/440165276
     [18, 74987, 100321], # Near Washington DC. USA
     #https://www.openstreetmap.org/relation/6333922
     # other polygon is coastline


### PR DESCRIPTION
Fix test to deal with changeset 41843926, in which one of the water polygons was deleted.

This should make the tests pass again.

@iandees could you review, please?