### PR TITLE
Update tests to deal with changeset 41943013

### DIFF
--- a/integration-test/990-add-art-galleries.py
+++ b/integration-test/990-add-art-galleries.py
@@ -3,7 +3,7 @@ assert_has_feature(
     16, 10485, 25328, 'pois',
     { 'id': 2026996113, 'kind': 'gallery', 'min_zoom': 17 })
 
-# http://www.openstreetmap.org/way/31510288
+# https://www.openstreetmap.org/way/83488820
 assert_has_feature(
-    15, 16371, 10895, 'pois',
-    { 'id': 31510288, 'kind': 'gallery' })
+    15, 16370, 10894, 'pois',
+    { 'id': 83488820, 'kind': 'gallery' })


### PR DESCRIPTION
In which the Royal Academy of Arts was changed to a museum. The case could be made that it's more of a gallery than a museum, but rather than change the data I thought it better to update the test.

@iandees could you review, please?