### PR TITLE
Fix filters for national forests and parks

### DIFF
--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -28,11 +28,11 @@ assert_has_feature(
 # area 86685400
 assert_has_feature(
     8, 71, 98, 'landuse',
-    { 'kind': 'national_park', 'id': 34416231,
+    { 'kind': 'forest', 'id': 34416231,
       'tier': 2, 'min_zoom': 8 })
 # this one is clipped by the polygon min_zoom, and so appears at the same
 # level.
 assert_has_feature(
     8, 71, 98, 'pois',
-    { 'kind': 'national_park', 'id': 34416231,
+    { 'kind': 'forest', 'id': 34416231,
       'tier': 2, 'min_zoom': 8 })

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -1,13 +1,13 @@
-# http://www.openstreetmap.org/way/167274589
-# area 300363008
+# http://www.openstreetmap.org/relation/1453306
+# area 1.75564e+10
 assert_has_feature(
-    4, 2, 5, 'landuse',
-    { 'kind': 'national_park', 'id': 167274589, 'tier': 1,
+    4, 3, 5, 'landuse',
+    { 'kind': 'national_park', 'id': -1453306, 'tier': 1,
       'min_zoom': 3 })
 assert_has_feature(
-    6, 10, 21, 'pois',
-    { 'kind': 'national_park', 'id': 167274589, 'tier': 1,
-      'min_zoom': 6.67 })
+    6, 12, 23, 'pois',
+    { 'kind': 'national_park', 'id': -1453306, 'tier': 1,
+      'min_zoom': 3.74 })
 
 # http://www.openstreetmap.org/relation/921675
 # area 30089300

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -122,18 +122,18 @@ assert_has_feature(
 # http://www.openstreetmap.org/way/296096756
 assert_has_feature(
     10, 164, 397, 'pois',
-    {'id': 296096756, 'kind': 'national_park'})
+    {'id': 296096756, 'kind': 'park'})
 
 # Label placement national_park in landuse
 assert_no_matching_feature(
     15, 5267, 12722, 'landuse',
-    {'id': 296096756, 'kind': 'national_park', 'label_placement': True})
+    {'id': 296096756, 'kind': 'park', 'label_placement': True})
 
 # Node:617506856 national_park in POIS
 # http://www.openstreetmap.org/node/617506856
 assert_has_feature(
-    10, 210, 386, 'pois',
-    {'id': 617506856, 'kind': 'national_park', 'min_zoom': 10})
+    14, 3374, 6184, 'pois',
+    {'id': 617506856, 'kind': 'park', 'min_zoom': 14})
 
 # Way:40260866 nature_reserve in POIS
 # http://www.openstreetmap.org/way/40260866

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -57,10 +57,13 @@ assert_has_feature(
 # a national park. Alternatively boundary:type=protected_area could give us
 # kind: protected_area instead.
 #
+# This feature also has protection_title=National Forest, and the name is
+# "Arapaho National Forest", so it should probably be classed as a forest.
+#
 # http://www.openstreetmap.org/relation/396026
 assert_has_feature(
     13, 1683, 3103, 'landuse',
-    { 'kind': 'park', 'id': -396026 })
+    { 'kind': 'forest', 'id': -396026 })
 
 # leisure=nature_reserve in North Farallon Islands State Marine Reserve has
 # boundary=protected_area with protect_class=4 in tile 11/323/791. It's
@@ -70,7 +73,7 @@ assert_has_feature(
 # https://www.openstreetmap.org/way/436801947
 assert_has_feature(
     11, 323, 791, 'landuse',
-    { 'kind': 'nature_reserve', 'id': -436801947 })
+    { 'kind': 'nature_reserve', 'id': 436801947 })
 
 # leisure=nature_reserve in Mount Tamalpais Watershed has
 # boundary=national_park with boundary:type=protected_area and operator=Marin
@@ -164,9 +167,10 @@ assert_has_feature(
 # boundary=national_park in Adirondack Park should end up with kind:park.
 #
 # https://www.openstreetmap.org/relation/1695394
-assert_has_feature(
-    13, 2410, 3001, 'landuse',
-    { 'kind': 'park', 'id': -1695394 })
+# TODO: not enough information???
+#assert_has_feature(
+#    13, 2410, 3001, 'landuse',
+#    { 'kind': 'park', 'id': -1695394 })
 
 # operator=United States National Park Service and protect_class=2 in
 # Shenandoah National Park with boundary=national_park and leisure=park should

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -1,0 +1,202 @@
+# Example Stanislaus National Forest in California near Yosemite should be
+# kind:forest.
+#
+# http://www.openstreetmap.org/relation/972008
+assert_has_feature(
+    10, 170, 394, 'landuse',
+    { 'kind': 'forest', 'id': -972008 })
+
+# But this other Humboldt forest in Nevada has protect_class 5 so that's not
+# guaranteed, should be kind:forest.
+#
+# http://www.openstreetmap.org/relation/2389847
+assert_has_feature(
+    11, 369, 769, 'landuse',
+    { 'kind': 'forest', 'id': -2389847 })
+
+# leisure=nature_reserve in Smith River is already taken care of by operator
+# (should be kind:forest).
+#
+# http://www.openstreetmap.org/relation/6213964
+assert_has_feature(
+    14, 2559, 6099, 'landuse',
+    { 'kind': 'forest', 'id': -6213964 })
+
+# Counter example is Mojave National Preserve which is operated by United
+# States National Park Service so we don't want it to become a forest (it
+# should be kind:national_park).
+#
+# http://www.openstreetmap.org/relation/175098
+assert_has_feature(
+    12, 733, 1617, 'landuse',
+    { 'kind': 'national_park', 'id': -175098 })
+
+# Point Reyes is also leisure=nature_reserve but without an operator but with
+# a protect_class of 2 (it should be kind:national_park, but might need some
+# data work?), until data is fixed I think it'd come thru as
+# kind:nature_reserve?
+#
+# http://www.openstreetmap.org/relation/1250137
+assert_has_feature(
+    15, 5192, 12627, 'landuse',
+    { 'kind': 'national_park', 'id': -1250137 })
+
+# leisure=park in San Luis Reservoir State Recreational Area has
+# boundary=national_park and leisure=park and park:type=state_recreational_area
+# and no protect_class. This shouldn't be a kind national_park, just a
+# kind:park!
+#
+# http://www.openstreetmap.org/relation/3004556
+assert_has_feature(
+    15, 5359, 12747, 'landuse',
+    { 'kind': 'park', 'id': -3004556 })
+
+# Example forest in Colorado that only gets demoted because of protect_class
+# is present as 6 but operator is missing. Gets demoted to what, though?
+# propose kind:park since there isn't an operator to say forest, and it's not
+# a national park. Alternatively boundary:type=protected_area could give us
+# kind: protected_area instead.
+#
+# http://www.openstreetmap.org/relation/396026
+assert_has_feature(
+    13, 1683, 3103, 'landuse',
+    { 'kind': 'park', 'id': -396026 })
+
+# leisure=nature_reserve in North Farallon Islands State Marine Reserve has
+# boundary=protected_area with protect_class=4 in tile 11/323/791. It's
+# operator=California Department of Fish & Wildlife so we'd just want this to
+# be kind:nature_reserve.
+#
+# https://www.openstreetmap.org/way/436801947
+assert_has_feature(
+    11, 323, 791, 'landuse',
+    { 'kind': 'nature_reserve', 'id': -436801947 })
+
+# leisure=nature_reserve in Mount Tamalpais Watershed has
+# boundary=national_park with boundary:type=protected_area and operator=Marin
+# Municipal Water District and protect_class=4. It should just be
+# kind:nature_reserve.
+#
+# https://www.openstreetmap.org/way/297463477
+assert_has_feature(
+    13, 1305, 3161, 'landuse',
+    { 'kind': 'nature_reserve', 'id': 297463477 })
+
+# leisure=common in Blithedale Summit Open Space Preserve with
+# boundary=national_park and boundary:type=protected_area and protect_class=5
+# and operator=Marin County Parks should just be kind:common.
+#
+# https://www.openstreetmap.org/way/297452972
+assert_has_feature(
+    15, 5229, 12648, 'landuse',
+    { 'kind': 'common', 'id': 297452972 })
+
+# leisure=nature_reserve in Glen Canyon National Recreation Area with
+# boundary=national_park and boundary:type=protected_area and protect_class=5
+# and protection_title=National Recreation Area which I think should default
+# to kind:nature_reserve.
+#
+# http://www.openstreetmap.org/relation/5273153
+assert_has_feature(
+    12, 784, 1585, 'landuse',
+    { 'kind': 'nature_reserve', 'id': -5273153 })
+
+# leisure=nature_reserve in Parque Natural Sierra de Andújar with finally
+# kind:nature_reserve.
+#
+# https://www.openstreetmap.org/way/373769670
+assert_has_feature(
+    13, 4003, 3151, 'landuse',
+    { 'kind': 'nature_reserve', 'id': 373769670 })
+
+# boundary=protected_area in Naturpark Steigerwald with protect_class=5
+# should end up with kind: protected_area
+#
+# https://www.openstreetmap.org/relation/3875431
+assert_has_feature(
+    13, 4336, 2787, 'landuse',
+    { 'kind': 'protected_area', 'id': -3875431 })
+
+# boundary=national_park in Muir Woods National Monument with
+# leisure=nature_reserve and operator=National Park Service and
+# protect_class=3 should end up with kind:national_park
+#
+# https://www.openstreetmap.org/relation/6229828
+assert_has_feature(
+    16, 10452, 25302, 'landuse',
+    { 'kind': 'national_park', 'id': -6229828 })
+
+# leisure=park in Henry W. Coe State Park with boundary=protected_area and
+# protect_class=5 should end up with kind:park.
+#
+# https://www.openstreetmap.org/relation/318202
+assert_has_feature(
+    13, 1332, 3184, 'landuse',
+    { 'kind': 'park', 'id': -318202 })
+
+# operator=United States National Park Service and protect_class=2 in
+# Yosemite National Park with boundary=national_park and
+# leisure=nature_reserve should end up with kind:national_park.
+#
+# https://www.openstreetmap.org/relation/1643367
+assert_has_feature(
+    13, 1371, 3164, 'landuse',
+    { 'kind': 'national_park', 'id': -1643367 })
+
+# operator=United States National Park Service and protect_class=2 in Redwood
+# National Park with boundary=national_park and leisure=nature_reserve should
+# end up with kind:national_park.
+#
+# https://www.openstreetmap.org/relation/215231
+assert_has_feature(
+    13, 1274, 3066, 'landuse',
+    { 'kind': 'national_park', 'id': -215231 })
+
+# operator=United States National Park Service and protect_class=2 in
+# Yellowstone National Park with boundary=national_park and
+# leisure=nature_reserve should end up with kind:national_park.
+#
+# https://www.openstreetmap.org/relation/1453306
+assert_has_feature(
+    13, 1591, 2972, 'landuse',
+    { 'kind': 'national_park', 'id': -1453306 })
+
+# boundary=national_park in Adirondack Park should end up with kind:park.
+#
+# https://www.openstreetmap.org/relation/1695394
+assert_has_feature(
+    13, 2410, 3001, 'landuse',
+    { 'kind': 'park', 'id': -1695394 })
+
+# operator=United States National Park Service and protect_class=2 in
+# Shenandoah National Park with boundary=national_park and leisure=park should
+# end up with kind:national_park.
+#
+# https://www.openstreetmap.org/relation/5548542
+assert_has_feature(
+    13, 2313, 3142, 'landuse',
+    { 'kind': 'national_park', 'id': -5548542 })
+
+# designation=national_park in Cairngorms National Park with
+# boundary=national_park should end up with kind:national_park.
+#
+# https://www.openstreetmap.org/relation/1947603
+assert_has_feature(
+    13, 4014, 2512, 'landuse',
+    { 'kind': 'national_park', 'id': -1947603 })
+
+# boundary=national_park in North Wessex Downs AONB with
+# designation=area_of_outstanding_natural_beauty should end up with kind:park.
+#
+# https://www.openstreetmap.org/relation/2904192
+assert_has_feature(
+    13, 4054, 2728, 'landuse',
+    { 'kind': 'park', 'id': -2904192 })
+
+# operator:en=Parks Canada and boundary=national_park in Riding Mountain
+# National Park with leisure=nature_reserve.
+#
+# http://www.openstreetmap.org/way/185735773
+assert_has_feature(
+    13, 1812, 2748, 'landuse',
+    { 'kind': 'national_park', 'id': 185735773 })

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -167,10 +167,9 @@ assert_has_feature(
 # boundary=national_park in Adirondack Park should end up with kind:park.
 #
 # https://www.openstreetmap.org/relation/1695394
-# TODO: not enough information???
-#assert_has_feature(
-#    13, 2410, 3001, 'landuse',
-#    { 'kind': 'park', 'id': -1695394 })
+assert_has_feature(
+    13, 2410, 3001, 'landuse',
+    { 'kind': 'park', 'id': -1695394 })
 
 # operator=United States National Park Service and protect_class=2 in
 # Shenandoah National Park with boundary=national_park and leisure=park should

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -149,7 +149,7 @@ filters:
   - filter:
       boundary: national_park
       protect_class: '6'
-      protction_title: National Forest
+      protection_title: National Forest
     min_zoom: *tier2_min_zoom
     output:
       kind: forest
@@ -207,14 +207,20 @@ filters:
   ############################################################
   - filter:
       historic: battlefield
-      not: { operator: *us_forest_service }
     min_zoom: *tier1_min_zoom
     output:
       kind: battlefield
       tier: 1
   - filter:
       boundary: national_park
-      not: { operator: *us_forest_service }
+      any:
+        all:
+          not: { operator: *us_forest_service }
+          protect_class: ['2', '3', '5']
+        operator: *us_parks_service
+        operator:en: Parks Canada
+        designation: national_park
+        protection_title: National Park
     min_zoom: *tier1_min_zoom
     output:
       kind: national_park
@@ -225,7 +231,8 @@ filters:
   ############################################################
   - filter:
       boundary: national_park
-      not: { operator: *us_parks_service }
+      not: { operator: *us_forest_service }
+      protect_class: ['2', '3', '5']
     min_zoom: *tier2_min_zoom
     output:
       kind: national_park
@@ -234,7 +241,7 @@ filters:
       any:
         leisure: park
         landuse: park
-      not: { operator: *us_parks_service }
+        boundary: national_park
     min_zoom: *tier2_min_zoom
     output:
       kind: park

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -125,6 +125,84 @@ filters:
     output: {kind: fort}
 
   ############################################################
+  # TIER 2 OVERRIDES
+  #
+  # These are things which are "more specific" than things in
+  # tier 1, so they should match first.
+  ############################################################
+  - filter:
+      boundary: national_park
+      operator: *us_forest_service
+    min_zoom: *tier2_min_zoom
+    output:
+      kind: forest
+      tier: 2
+  - filter:
+      any:
+        leisure: park
+        landuse: park
+      park:type: state_recreational_area
+    min_zoom: *tier2_min_zoom
+    output:
+      kind: park
+      tier: 2
+  - filter:
+      boundary: national_park
+      protect_class: '6'
+      protction_title: National Forest
+    min_zoom: *tier2_min_zoom
+    output:
+      kind: forest
+      tier: 2
+  - filter:
+      boundary: national_park
+      protect_class: '6'
+      protection_title: National Forest
+    min_zoom: *tier2_min_zoom
+    output:
+      kind: forest
+      tier: 2
+  - filter:
+      boundary: national_park
+      any:
+        - protect_class: '6'
+        - designation: area_of_outstanding_natural_beauty
+    min_zoom: *tier2_min_zoom
+    output:
+      kind: park
+      tier: 2
+  - filter:
+      any:
+        - boundary:type: protected_area
+        - boundary: protected_area
+      leisure: nature_reserve
+      protect_class: ['4', '5']
+      not:
+        any:
+          - operator: *us_forest_service
+          - operator: *us_parks_service
+    min_zoom: *tier2_min_zoom
+    output: {kind: nature_reserve, tier: 2}
+
+  ############################################################
+  # TIER 6 OVERRIDES
+  #
+  # These are things which are "more specific" than things in
+  # tier 1, so they should match first.
+  ############################################################
+  # common
+  - filter:
+      boundary:type: protected_area
+      leisure: common
+      protect_class: '5'
+      not:
+        any:
+          - operator: *us_forest_service
+          - operator: *us_parks_service
+    min_zoom: *tier6_min_zoom
+    output: {kind: common, tier: 6}
+
+  ############################################################
   # TIER 1
   ############################################################
   - filter:
@@ -169,12 +247,12 @@ filters:
     min_zoom: { max: [ 10, { lit: *tier2_min_zoom } ] }
     output: { kind: forest, tier: 2 }
 
-  - filter: {boundary: protected_area}
-    min_zoom: *tier2_min_zoom
-    output: {kind: protected_area, tier: 2}
   - filter: {leisure: nature_reserve}
     min_zoom: *tier2_min_zoom
     output: {kind: nature_reserve, tier: 2}
+  - filter: {boundary: protected_area}
+    min_zoom: *tier2_min_zoom
+    output: {kind: protected_area, tier: 2}
 
   - filter: { landuse: wood, operator: *us_forest_service }
     min_zoom: { max: [ 6, { lit: *tier2_min_zoom } ] }

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -180,7 +180,14 @@ filters:
     output: {kind: battlefield, tier: 1}
   - filter:
       boundary: national_park
-      not: {operator: *us_forest_service}
+      any:
+        all:
+          not: { operator: *us_forest_service }
+          protect_class: ['2', '3', '5']
+        operator: *us_parks_service
+        operator:en: Parks Canada
+        designation: national_park
+        protection_title: National Park
     min_zoom: { min: [ { max: [ { lit: zoom + 3.5 }, { lit: *tier1_min_zoom } ] }, 10 ] }
     output:
       kind: national_park
@@ -191,7 +198,8 @@ filters:
   ############################################################
   - filter:
       boundary: national_park
-      not: {operator: *us_parks_service}
+      not: { operator: *us_forest_service }
+      protect_class: ['2', '3', '5']
     min_zoom: { min: [ { max: [ { lit: zoom + 3.5 }, { lit: *tier2_min_zoom } ] }, 10 ] }
     output:
       kind: national_park
@@ -200,7 +208,7 @@ filters:
       any:
         leisure: park
         landuse: park
-      not: { operator: *us_parks_service }
+        boundary: national_park
     min_zoom: { min: [ { max: [ 9, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
     output:
       kind: park

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -111,6 +111,66 @@ filters:
     output: {kind: observatory}
 
   ############################################################
+  # TIER 2 OVERRIDES
+  #
+  # These are things which are "more specific" than things in
+  # tier 1, so they should match first.
+  ############################################################
+  - filter:
+      boundary: national_park
+      operator: *us_forest_service
+    min_zoom: { min: [ { max: [ 7, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
+    output:
+      kind: forest
+      tier: 2
+  - filter:
+      any:
+        leisure: park
+        landuse: park
+      park:type: state_recreational_area
+    min_zoom: { min: [ { max: [ 9, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
+    output:
+      kind: park
+      tier: 2
+  - filter:
+      boundary: national_park
+      protect_class: '6'
+      protction_title: National Forest
+    min_zoom: { min: [ { max: [ 7, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
+    output:
+      kind: forest
+      tier: 2
+  - filter:
+      boundary: national_park
+      protect_class: '6'
+      protection_title: National Forest
+    min_zoom: { min: [ { max: [ 7, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
+    output:
+      kind: forest
+      tier: 2
+  - filter:
+      boundary: national_park
+      any:
+        - protect_class: '6'
+        - designation: area_of_outstanding_natural_beauty
+    min_zoom: { min: [ { max: [ 9, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
+    output:
+      kind: park
+      tier: 2
+  - filter:
+      any:
+        - boundary:type: protected_area
+        - boundary: protected_area
+      leisure: nature_reserve
+      protect_class: ['4', '5']
+      not:
+        any:
+          - operator: *us_forest_service
+          - operator: *us_parks_service
+    min_zoom: { min: [ { max: [ { lit: zoom + 5 }, { lit: *tier2_min_zoom } ] }, 10 ] }
+    output: {kind: nature_reserve, tier: 2}
+
+  ############################################################
   # TIER 1
   ############################################################
   - filter:
@@ -161,14 +221,14 @@ filters:
     min_zoom: { min: [ { max: [ 10, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
     output: { kind: forest, tier: 2 }
 
-  # protected areas
-  - filter: {boundary: protected_area}
-    min_zoom: { min: [ { max: [ 7, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
-    output: { kind: protected_area, tier: 2 }
   # nature reserves
   - filter: {leisure: nature_reserve}
     min_zoom: { min: [ { max: [ { lit: zoom + 5 }, { lit: *tier2_min_zoom } ] }, 10 ] }
     output: { kind: nature_reserve, tier: 2 }
+  # protected areas
+  - filter: {boundary: protected_area}
+    min_zoom: { min: [ { max: [ 7, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
+    output: { kind: protected_area, tier: 2 }
 
   # woods
   - filter:


### PR DESCRIPTION
Makes filters much stricter to be a national park - now `boundary=national_park` is no longer sufficient, and some combination of `operator`, `protect_class`, `protection_title` and `designation` are needed to be a national park.

Connects to #987.

@nvkelso could you take a look and make sure I captured all the examples, and that the resulting `kind`s and `tier`s are what you expected, please?
