### PR TITLE
Use a more focused buildings migration

### DIFF
--- a/data/migrations/v1.0.0-polygon.sql
+++ b/data/migrations/v1.0.0-polygon.sql
@@ -29,7 +29,9 @@ UPDATE
 UPDATE planet_osm_polygon
   SET mz_building_min_zoom = mz_calculate_min_zoom_buildings(planet_osm_polygon.*)
   WHERE
-    COALESCE(mz_building_min_zoom, 999) <> COALESCE(mz_building_min_zoom(planet_osm_polygon.*), 999);
+    tags ? 'location'
+    AND mz_building_min_zoom IS NOT NULL
+    AND COALESCE(mz_building_min_zoom, 999) <> COALESCE(mz_building_min_zoom(planet_osm_polygon.*), 999);
 
 UPDATE planet_osm_polygon
   SET mz_label_placement = ST_PointOnSurface(way)


### PR DESCRIPTION
In https://github.com/tilezen/vector-datasource/pull/1036 the buildings migration was broadened to be safer, but we can narrow its scope to cover any affected features to speed it up.

@zerebubuth could you review please?