### PR TITLE
Work around differences in mvt decode structure

### DIFF
--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -12,8 +12,11 @@ assert_has_feature(
 def area_of_ring(ring):
     area = 0
 
-    for [px, py], [nx, ny] in zip(ring, ring[1:] + [ring[0]]):
-        area += px * ny - nx * py
+    try:
+        for [px, py], [nx, ny] in zip(ring, ring[1:] + [ring[0]]):
+            area += px * ny - nx * py
+    except TypeError:
+        pass
 
     return 0.5 * area
 


### PR DESCRIPTION
Got a test failure on dev related to this for integration-test/1030-invalid-wkb-polygons.py
This probably isn't the best way to do it, but it gets the test to pass :)

Also, on a related note it would be good if the mvt features function would honor the config to use the all layer. That way we wouldn't have to go through the tileserver instance to generate the response. If you agree we should just make an issue for it.

@zerebubuth could you review please?