### PR TITLE
Fix four failing dev tests.

### DIFF
--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -32,7 +32,10 @@ assert_has_feature(
       'tier': 2, 'min_zoom': 8 })
 # this one is clipped by the polygon min_zoom, and so appears at the same
 # level.
+#
+# note that the feature _is_ present in the zoom 8 tile, but gets merged
+# with a nearby feature of the same name, so instead we test this at z9.
 assert_has_feature(
-    8, 71, 98, 'pois',
+    9, 142, 196, 'pois',
     { 'kind': 'forest', 'id': 34416231,
       'tier': 2, 'min_zoom': 8 })

--- a/integration-test/605-crosswalk-sidewalk.py
+++ b/integration-test/605-crosswalk-sidewalk.py
@@ -1,7 +1,7 @@
-# http://www.openstreetmap.org/way/367770916
+# http://www.openstreetmap.org/way/367477828
 assert_has_feature(
-    16, 10478, 25323, 'roads',
-    { 'id': 367770916, 'kind': 'path', 'crossing': 'zebra' })
+    16, 10471, 25331, 'roads',
+    { 'id': 367477828, 'kind': 'path', 'crossing': 'zebra' })
 
 # Way: The Embarcadero (397140734)
 # http://www.openstreetmap.org/way/397140734

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -21,11 +21,14 @@ assert_no_matching_feature(
     15, 5240, 12666, 'landuse',
     {'id': 79457493, 'kind': 'grave_yard', 'label_placement': True})
 
-# Way:41654965 Cemetery in POIs
+# Arlington National Cemetery - there are two objects representing this in
+# the same place. The code will de-duplicate one or the other of them.
+#
 # http://www.openstreetmap.org/way/41654965
+# http://www.openstreetmap.org/relation/2475077
 assert_has_feature(
     12, 1171, 1567, 'pois',
-    {'id': 41654965, 'kind': 'cemetery', 'min_zoom': 12})
+    {'id': set([41654965, -2475077]), 'kind': 'cemetery', 'min_zoom': 12})
 
 # Label placement Cemetery in landuse
 # http://www.openstreetmap.org/way/44580948

--- a/integration-test/841-normalize-boundaries-kind.py
+++ b/integration-test/841-normalize-boundaries-kind.py
@@ -4,10 +4,12 @@ assert_has_feature(
     16, 10237, 24570, 'boundaries',
     {'id': 174550914, 'kind': 'aboriginal_lands', 'kind_detail': '4'})
 
-# http://www.openstreetmap.org/way/286097885
+# use relation instead of way, as osm2pgsql treats the relation as superseding
+# the way and removes its tags when both are present.
+# http://www.openstreetmap.org/relation/3854097
 assert_has_feature(
     16, 10483, 22987, 'boundaries',
-    {'id': 286097885, 'kind': 'aboriginal_lands', 'kind_detail': type(None)})
+    {'id': -3854097, 'kind': 'aboriginal_lands', 'kind_detail': type(None)})
 
 # Way: Upper Sumas 6 (55602811)
 # http://www.openstreetmap.org/way/55602811

--- a/integration-test/992-boundaries-min_zoom-and-name.py
+++ b/integration-test/992-boundaries-min_zoom-and-name.py
@@ -25,7 +25,7 @@
 
 # map_unit min_zoom
 
-# Mexico region (scalerank=4, 1:10m NE only)
+# England-Wales boundary in United Kingdom (scalerank=4, 1:10m NE only)
 assert_has_feature(
     5, 15, 10, 'boundaries',
     { 'kind': 'map_unit', 'min_zoom': 5, 'sort_rank': 258})

--- a/integration-test/993-remove-props-road-merge.py
+++ b/integration-test/993-remove-props-road-merge.py
@@ -1,24 +1,40 @@
 # Way: I 81 (302933871)
 # http://www.openstreetmap.org/way/302933871
+#
+# testing that it dropped oneway, but hasn't dropped is_bridge. note that
+# the ID gets dropped due to a merge with the other carriageway.
 assert_has_feature(
     14, 4496, 6381, 'roads',
-    { 'id': 302933871, 'kind': 'highway', 'oneway': type(None) })
+    { 'kind': 'highway', 'oneway': type(None), 'is_bridge': True })
 
 # http://www.openstreetmap.org/way/434308106
+#
+# note that the ID gets dropped due to merging with other pedestrian
+# paths. best way to test this lacking the ID seems to be to assert the
+# presence of a path, but the absence of any crossing.
 assert_has_feature(
     14, 4933, 6066, 'roads',
-    { 'id': 434308106, 'kind': 'path', 'crossing': type(None) })
+    { 'kind': 'path' })
+assert_no_matching_feature(
+    14, 4933, 6066, 'roads',
+    { 'kind': 'path', 'crossing': None })
 
 # Way: The Embarcadero (397140734)
 # http://www.openstreetmap.org/way/397140734
 assert_has_feature(
     14, 2621, 6331, 'roads',
+    { 'name': 'The Embarcadero', 'kind': 'major_road' })
+assert_no_matching_feature(
+    14, 2621, 6331, 'roads',
     { 'name': 'The Embarcadero', 'kind': 'major_road',
-      'sidewalk': type(None) })
+      'sidewalk': None })
 
 # Way: Carrie Furnace Boulevard (438362919)
 # http://www.openstreetmap.org/way/438362919
 assert_has_feature(
     14, 4556, 6178, 'roads',
-    { 'id': 438362919, 'kind': 'major_road',
-      'sidewalk_left': type(None), 'sidewalk_right': type(None) })
+    { 'name': 'Carrie Furnace Blvd.', 'kind': 'major_road' })
+assert_no_matching_feature(
+    14, 4556, 6178, 'roads',
+    { 'name': 'Carrie Furnace Blvd.', 'kind': 'major_road',
+      'sidewalk_left': None, 'sidewalk_right': None })


### PR DESCRIPTION
This fixes:

* **473-landuse-tier** so that a point is tested in isolation at a higher zoom. At the lower zoom, it has the same name as a nearby feature and so is merged with it.
* **742-predictable-layers-pois** so that Arlington National Cemetery is tested against one of the two IDs it can have. There are two features in the same place from OSM, but the POIs get merged.
* **841-normalize-boundaries-kind** to use the containing relation for the test. The outer boundary way is also tagged, but is discarded by `osm2pgsql`.
* **993-remove-props-road-merge** switch tests to avoid merging problems. Instead of testing that a specific object with an ID does not have the property, the tests now assert that the general object exists and that no object exists with the dropped property.
* **987-national-forests** was failing, but now is passing. Magic!

Further failures:

* **845-buildings-z13** appears to be failing because the min zooms are wrong - the migration for this this probably needs to be run. If it was already run then there might be some error which is preventing it from updating properly.
* **976-fractional-pois** is failing because the New York boundary isn't present in the output. However, it is present in the database, and appears to have the right properties and min zoom. It isn't clear why the boundary code is failing to cut this with the New Jersey boundary.
* **992-boundaries-min_zoom-and-name** is failing because there are no `Admin-1 boundary` items in the `ne_50m_admin_1_states_provinces_lines` table. There are none in the shapefile, so perhaps this indicates a shapefile processing error?
* **524-peak-kind-tile-rank** is failing because dev pulls in an extra "padded" bounds to make MVTB tiles. This means it pulls in extra nearby peaks, ranks them and discards those ranked >5. It then discards those ranked 2-5 when it clips the padded bounds to the tile bounds to make JSON format. This might need a code change to only rank features _within_ the tile.

@rmarianski could you review, please?

@nvkelso what should we do about the `kind_tile_rank` failure? Should we be only ranking within tile boundaries? This will cause weirdness at MVTB boundaries, as peaks in the "padded" area can't get assigned their usual `kind_tile_rank` without pulling in a whole tile's worth of padding.