### PR TITLE
Fix admin boundary test failure

### DIFF
--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -1781,6 +1781,7 @@ def admin_boundaries(ctx):
 
         for i, feature in enumerate(features):
             boundary, props, fid = feature
+            prop_id = props['id']
             envelope = envelopes[i]
 
             # intersect with *preceding* features to remove
@@ -1788,6 +1789,9 @@ def admin_boundaries(ctx):
             # are no duplicate parts.
             for j in range(0, i):
                 cut_shape, cut_props, cut_fid = features[j]
+                # don't intersect with self
+                if prop_id == cut_props['id']:
+                    continue
                 cut_envelope = envelopes[j]
                 if envelope.intersects(cut_envelope):
                     boundary = boundary.difference(cut_shape)
@@ -1800,6 +1804,9 @@ def admin_boundaries(ctx):
             # that we want to keep.
             for j in range(i+1, num_features):
                 cut_shape, cut_props, cut_fid = features[j]
+                # don't intersect with self
+                if prop_id == cut_props['id']:
+                    continue
                 cut_envelope = envelopes[j]
 
                 if envelope.intersects(cut_envelope):


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/1063

I was able to replicate the failure locally. I stepped through the transform, and took a guess at what was going on based on what I saw. It seemed like there were multiple features with the same id, and they were self intersecting and becoming empty and eliminating themselves. But this was just an assumption that got the test to pass for me to pass locally, and I'm not sure if this was the wrong approach or if it has other consequences.

@zerebubuth could you review please?