### PR TITLE
Only delete features within bounds. Boundaries fixes.

### DIFF
--- a/integration-test/524-peak-kind-tile-rank.py
+++ b/integration-test/524-peak-kind-tile-rank.py
@@ -32,6 +32,12 @@
 # 4227, https://www.openstreetmap.org/node/358914519, Pacific Peak
 # 4239, https://www.openstreetmap.org/node/358914419, Fletcher Mountain
 # 4348, https://www.openstreetmap.org/node/358914530, Quandary Peak
+#
+# these are outside of the tile, used to test that the ranking code doesn't
+# consider items which are in the buffer.
+#
+# 4348, http://www.openstreetmap.org/node/358914747, Mount Lincoln
+# 4335, http://www.openstreetmap.org/node/358914751, Mount Cameron
 
 def count_matching(features, props):
     num_matches = 0

--- a/integration-test/841-normalize-boundaries-kind.py
+++ b/integration-test/841-normalize-boundaries-kind.py
@@ -1,8 +1,11 @@
-# Way: Hoopa Valley Tribe (174550914)
-# http://www.openstreetmap.org/way/174550914
+# Relation: Hoopa Valley Tribe
+# http://www.openstreetmap.org/relation/6214773
+#
+# Note: this is tagged as a "protected_area" rather than a political boundary,
+# but it seems that some "protect_class" values indicate political "protection"
 assert_has_feature(
     16, 10237, 24570, 'boundaries',
-    {'id': 174550914, 'kind': 'aboriginal_lands', 'kind_detail': '4'})
+    {'id': -6214773, 'kind': 'aboriginal_lands', 'kind_detail': type(None)})
 
 # use relation instead of way, as osm2pgsql treats the relation as superseding
 # the way and removes its tags when both are present.
@@ -29,10 +32,11 @@ assert_has_feature(
     16, 12553, 24147, 'boundaries',
     {'id': -161991, 'kind': 'region', 'kind_detail': '4'})
 
-# http://www.openstreetmap.org/way/395754575
+# http://www.openstreetmap.org/relation/396487 -- SF City/County
+# http://www.openstreetmap.org/relation/396498 -- San Mateo County
 assert_has_feature(
     16, 10484, 25346, 'boundaries',
-    {'id': 395754575, 'kind': 'county', 'kind_detail': '6'})
+    {'id': set([-396487,-396498]), 'kind': 'county', 'kind_detail': '6'})
 
 # Relation: Brisbane (2834528)
 # http://www.openstreetmap.org/relation/2834528

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -112,27 +112,4 @@ FROM buffered_land
 WHERE
   {{ bounds['polygon']|bbox_filter('the_geom',3857) }}
 
-UNION ALL
-
-SELECT
-  tags->'name' AS name,
-  'openstreetmap.org' AS source,
-  mz_boundary_min_zoom as min_zoom,
-  NULL AS maritime_boundary,
-  mz_calculate_json_boundaries(planet_osm_line.*) AS mz_properties,
-  {% filter geometry %}way{% endfilter %} AS __geometry__,
-  osm_id AS __id__,
-  %#tags AS tags
-
-FROM
-  planet_osm_line
-
-WHERE
-  {{ bounds['line']|bbox_filter('way',3857) }} AND
-{% if zoom >= 16 %}
-    mz_boundary_min_zoom IS NOT NULL
-{% else %}
-    mz_boundary_min_zoom < {{ zoom + 1 }}
-{% endif %}
-
 {% endif %}

--- a/scripts/test_server.py
+++ b/scripts/test_server.py
@@ -18,6 +18,21 @@ config = {
         'config': 'queries.yaml',
         'template-path': 'queries',
         'reload-templates': False
+    },
+    'formats': ['json', 'topojson', 'mvt', 'mvtb'],
+    'buffer': {
+        'mvtb': {
+            'layer': {
+                'earth': { 'point': 256 },
+                'water': { 'point': 256 },
+                'places': { 'point': 128 }
+            },
+            'geometry': {
+                'point': 64,
+                'line': 8,
+                'polygon': 8
+            }
+        }
     }
 }
 

--- a/scripts/test_server.py
+++ b/scripts/test_server.py
@@ -23,9 +23,9 @@ config = {
     'buffer': {
         'mvtb': {
             'layer': {
-                'earth': { 'point': 256 },
-                'water': { 'point': 256 },
-                'places': { 'point': 128 }
+                'earth': {'point': 256},
+                'water': {'point': 256},
+                'places': {'point': 128}
             },
             'geometry': {
                 'point': 64,

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -2513,6 +2513,10 @@ def keep_n_features(ctx):
     This is done by counting each feature which matches _all_
     the key-value pairs in `items_matching` and, when the
     count is larger than `max_items`, dropping those features.
+
+    Only features which are within the unpadded bounds of the
+    tile are considered for keeping or dropping. Features
+    entirely outside the bounds of the tile are always kept.
     """
 
     feature_layers = ctx.feature_layers
@@ -2523,6 +2527,7 @@ def keep_n_features(ctx):
     end_zoom = ctx.params.get('end_zoom')
     items_matching = ctx.params.get('items_matching')
     max_items = ctx.params.get('max_items')
+    unpadded_bounds = Box(*ctx.unpadded_bounds)
 
     # leaving items_matching or max_items as None (or zero)
     # would mean that this filter would do nothing, so assume
@@ -2549,7 +2554,8 @@ def keep_n_features(ctx):
     for shape, props, fid in layer['features']:
         keep_feature = True
 
-        if _match_props(props, items_matching):
+        if _match_props(props, items_matching) and \
+           shape.intersects(unpadded_bounds):
             count += 1
             if count > max_items:
                 keep_feature = False
@@ -2567,6 +2573,10 @@ def rank_features(ctx):
     the rank as a property with the key `rank_key`. This is
     useful for the client, so that it can selectively display
     only the top features, or de-emphasise the later features.
+
+    Only features which are within the unpadded bounds of the
+    tile are ranked. Features entirely outside the bounds of
+    the tile are not modified.
     """
 
     feature_layers = ctx.feature_layers
@@ -2576,6 +2586,7 @@ def rank_features(ctx):
     start_zoom = ctx.params.get('start_zoom', 0)
     items_matching = ctx.params.get('items_matching')
     rank_key = ctx.params.get('rank_key')
+    unpadded_bounds = Box(*ctx.unpadded_bounds)
 
     # leaving items_matching or rank_key as None would mean
     # that this filter would do nothing, so assume that this
@@ -2592,7 +2603,8 @@ def rank_features(ctx):
 
     count = 0
     for shape, props, fid in layer['features']:
-        if _match_props(props, items_matching):
+        if _match_props(props, items_matching) and \
+           shape.intersects(unpadded_bounds):
             count += 1
             props[rank_key] = count
 

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -24,10 +24,13 @@ filters:
   # osm
   - filter:
       any:
-        all:
-          boundary: administrative
-          'tags->boundary:type': aboriginal_lands
-        boundary: aboriginal_lands
+        - all:
+            boundary: administrative
+            boundary:type: aboriginal_lands
+        - all:
+            boundary: protected_area
+            protect_class: '24'
+        - boundary: aboriginal_lands
     min_zoom: 8
     output:
       kind: aboriginal_lands


### PR DESCRIPTION
Note that this is a PR into @rmarianski's #1067 PR - which seemed to make sense since we'd mostly solved the problem in the same way.

In addition to only ranking features within the bounds, it's necessary to only delete features within the bounds when they don't satisfy the ranking.

This patch adds configuration to the testing tile server to make it capable of generating MVTB tiles. This exposed another issue, which is that the admin boundary code was getting confused with the mix of oriented polygonal boundaries and non-oriented linear boundaries. The linear boundaries used in the tests could be replaced by polygonal alternatives, so the linear boundaries were dropped. This makes it more likely that the polygonal admin boundaries will be correctly processed.

Connects to #1065. Relates to #1063.

@rmarianski, @iandees could you review, please?