### PR TITLE
Fix migrations for post-1.0.0-pre3 work.

### DIFF
--- a/data/migrations/v1.0.0-polygon.sql
+++ b/data/migrations/v1.0.0-polygon.sql
@@ -29,9 +29,13 @@ UPDATE
 UPDATE planet_osm_polygon
   SET mz_building_min_zoom = mz_calculate_min_zoom_buildings(planet_osm_polygon.*)
   WHERE
-    tags ? 'location'
-    AND mz_building_min_zoom IS NOT NULL
-    AND COALESCE(mz_building_min_zoom, 999) <> COALESCE(mz_building_min_zoom(planet_osm_polygon.*), 999);
+    COALESCE(mz_building_min_zoom, 999) <> COALESCE(mz_building_min_zoom(planet_osm_polygon.*), 999);
+
+UPDATE planet_osm_polygon
+  SET mz_boundary_min_zoom = mz_calculate_min_zoom_boundaries(planet_osm_polygon.*)
+  WHERE
+    COALESCE(tags->'boundary' = 'protected_area', FALSE) AND
+    COALESCE(tags->'protect_class' = '24', FALSE);
 
 UPDATE planet_osm_polygon
   SET mz_label_placement = ST_PointOnSurface(way)


### PR DESCRIPTION
This makes the buildings migration more general - the last one didn't catch all the things which could have changed and had to be re-run.

This adds a very specific migration for polygons which have protect class 24, which is to allow them to be recognised as political boundaries.

@rmarianski could you review, please?