### PR TITLE
Support 'all' layers requests for MVT tiles

### DIFF
--- a/integration-test.py
+++ b/integration-test.py
@@ -214,7 +214,8 @@ def layers_in_tile(z, x, y):
 @contextmanager
 def features_in_mvt_layer(z, x, y, layer):
     assert config_url, "Tile URL is not configured, is your config file set up?"
-    url = config_url % {'layer': layer, 'z': z, 'x': x, 'y': y}
+    request_layer = 'all' if config_all_layers else layer
+    url = config_url % {'layer': request_layer, 'z': z, 'x': x, 'y': y}
     url = url.replace(".json", ".mvt")
     r = requests.get(url)
 

--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -1,3 +1,5 @@
+from mapbox_vector_tile.decoder import POLYGON
+
 # Caspian Sea
 assert_has_feature(
     5, 20, 12, 'water',
@@ -12,11 +14,8 @@ assert_has_feature(
 def area_of_ring(ring):
     area = 0
 
-    try:
-        for [px, py], [nx, ny] in zip(ring, ring[1:] + [ring[0]]):
-            area += px * ny - nx * py
-    except TypeError:
-        pass
+    for [px, py], [nx, ny] in zip(ring, ring[1:] + [ring[0]]):
+        area += px * ny - nx * py
 
     return 0.5 * area
 
@@ -40,6 +39,9 @@ with features_in_mvt_layer(5, 17, 9, 'water') as features:
     ocean_area = 0
 
     for feature in features:
+        if feature['type'] != POLYGON:
+            continue
+
         props = feature['properties']
         if props.get('kind') == 'ocean':
             ocean_area += area_of(feature['geometry'])


### PR DESCRIPTION
Calculate area for polygons only. Request all layers when configured to do so.

Connects to #1060.

@iandees & @rmarianski could you review, please?