### PR TITLE
Update migration to include min zoom for places.

### DIFF
--- a/integration-test/981-remove-unstyled-ne-places.py
+++ b/integration-test/981-remove-unstyled-ne-places.py
@@ -2,7 +2,8 @@ def assert_add_place(z, x, y, name):
     assert_has_feature(
         z, x, y, 'places',
         { 'kind': 'locality', 'name': name,
-          'source': 'naturalearthdata.com' })
+          'source': 'naturalearthdata.com',
+          'min_zoom': z })
     assert_no_matching_feature(
         z-1, x/2, y/2, 'places',
         { 'kind': 'locality', 'name': name,

--- a/integration-test/982-remove-unstyled-localities.py
+++ b/integration-test/982-remove-unstyled-localities.py
@@ -5,7 +5,7 @@
 assert_has_feature(
     8, 39, 96, 'places',
     { 'kind': 'locality', 'kind_detail': 'town', 'name': 'Arcata',
-      'id': 141029389 })
+      'id': 141029389, 'min_zoom': 8 })
 
 # zoom 9 and 10:
 # include only those localities with name and kind_detail IN (city, town)
@@ -19,7 +19,7 @@ assert_no_matching_feature(
 assert_has_feature(
     9, 80, 191, 'places',
     { 'kind': 'locality', 'kind_detail': 'town', 'name': 'Hoopa',
-      'id': 4270230299 })
+      'id': 4270230299, 'min_zoom': 9 })
 
 # zoom 11:
 # include only those localities with name and kind_detail IN (city, town)
@@ -35,7 +35,7 @@ assert_no_matching_feature(
 assert_has_feature(
     11, 326, 790, 'places',
     { 'kind': 'locality', 'kind_detail': 'village', 'name': 'Fairfax',
-      'id': 150949805 })
+      'id': 150949805, 'min_zoom': 11 })
 
 # zoom 12:
 # include only those localities with name and kind_detail IN (city, town,
@@ -53,7 +53,7 @@ assert_no_matching_feature(
 assert_has_feature(
     12, 647, 1573, 'places',
     { 'kind': 'locality', 'kind_detail': 'hamlet', 'name': 'Duncans Mills',
-      'id': 150966610 })
+      'id': 150966610, 'min_zoom': 12 })
 
 # example: http://www.openstreetmap.org/node/150973394 - Inverness
 # hamlet with NO population should NOT show up
@@ -69,4 +69,4 @@ assert_no_matching_feature(
 assert_has_feature(
     13, 1300, 3156, 'places',
     { 'kind': 'locality', 'kind_detail': 'hamlet', 'name': 'Inverness',
-      'id': 150973394 })
+      'id': 150973394, 'min_zoom': 13 })

--- a/queries/places.jinja2
+++ b/queries/places.jinja2
@@ -11,7 +11,7 @@ SELECT
     NULL AS region_capital,
     NULL::integer AS mz_n_photos,
     NULL::bigint AS area,
-    NULL::smallint AS min_zoom,
+    mz_places_min_zoom AS min_zoom,
     NULL::smallint AS max_zoom,
     NULL::boolean AS is_landuse_aoi,
     NULL AS tags
@@ -44,7 +44,7 @@ SELECT
     (CASE WHEN tags->'state_capital' = 'yes' THEN true END) AS region_capital,
     NULL::integer AS mz_n_photos,
     NULL::bigint AS area,
-    NULL::smallint AS min_zoom,
+    mz_places_min_zoom AS min_zoom,
     NULL::smallint AS max_zoom,
     NULL::boolean AS is_landuse_aoi,
     %#tags AS tags


### PR DESCRIPTION
D'oh! I thought this was a faulty migration, but in fact it was simply that we weren't including `min_zoom` in the query. The silver lining is that it means no migration is needed to fix it :smile: 

Updated the test so it checks for `min_zoom` too.

Connects to #981.

@rmarianski & @iandees could you review, please?