### PR TITLE
Replace links and words about API keys and rate limits

### DIFF
--- a/docs/api-keys-and-rate-limits.md
+++ b/docs/api-keys-and-rate-limits.md
@@ -2,12 +2,7 @@
 
 ## Obtain an API key
 
-To use the Mapzen Vector Tile service, you should first obtain a free developer API key. Sign in at https://mapzen.com/developers to create and manage your API keys.
-
-1. Go to https://mapzen.com/developers.
-2. Sign in with your GitHub account. If you have not done this before, you need to agree to the terms first.
-3. Create a new key and optionally, give it a name so you can remember the purpose of the project.
-4. Copy the key into your code.
+To use the Mapzen Vector Tile service, you should [first obtain a free developer API key](https://mapzen.com/documentation/overview/).
 
 ## Rate limits
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,11 +23,11 @@ To start integrating vector tiles to your app, you need a [developer API key](ht
 
 The URL pattern to request tiles is:
 
-`https://tile.mapzen.com/mapzen/vector/v1/{layers}/{z}/{x}/{y}.{format}?api_key=mapzen-xxxxxxx`
+`https://tile.mapzen.com/mapzen/vector/v1/{layers}/{z}/{x}/{y}.{format}`
 
 Here’s a sample tile in TopoJSON:
 
-`https://tile.mapzen.com/mapzen/vector/v1/all/16/19293/24641.topojson?api_key=mapzen-xxxxxxx`
+`https://tile.mapzen.com/mapzen/vector/v1/all/16/19293/24641.topojson`
 
 More information is available about how to [use the vector tile service](use-service.md) and specify custom layers in the service (though we recommend the default `all` layer).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ With vector tiles you have the power to customize the content and visual appeara
 
 ### Use Mapzen's Vector Tile Service
 
-To start integrating vector tiles to your app, you need a [developer API key](https://mapzen.com/developers). API keys come in the pattern: `mapzen-xxxxxxx`.
+To start integrating vector tiles to your app, you need a [developer API key](https://mapzen.com/documentation/overview/).
 
 * [API keys and rate limits](api-keys-and-rate-limits.md) - Don't abuse the shared service!
 * [Attribution requirements](attribution.md) - Terms of service for OpenStreetMap and other projects require attribution.

--- a/docs/use-service.md
+++ b/docs/use-service.md
@@ -4,22 +4,22 @@ To use the vector tile service, you first need to obtain an API key from Mapzen.
 
 Now, just append your API key into this URL pattern to get started, where `mapzen-xxxxxxx` represents your key.
 
-`https://tile.mapzen.com/mapzen/vector/v1/{layers}/{z}/{x}/{y}.{format}?api_key=mapzen-xxxxxxx`
+`https://tile.mapzen.com/mapzen/vector/v1/{layers}/{z}/{x}/{y}.{format}`
 
 The [OpenStreetMap Wiki](http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) has more information on this url scheme.
 
 Here’s a sample tile in GeoJSON:
 
-`https://tile.mapzen.com/mapzen/vector/v1/all/16/19293/24641.json?api_key=mapzen-xxxxxxx`
+`https://tile.mapzen.com/mapzen/vector/v1/all/16/19293/24641.json`
 
 ## Specify layers in the service
 
 Layers to return can specified as `all`, or as one or more layer names separated by commas. The `all` layer is more performant.
 
 
-`buildings`: https://tile.mapzen.com/mapzen/vector/v1/buildings/16/19293/24641.json?api_key=mapzen-xxxxxxx
+`buildings`: https://tile.mapzen.com/mapzen/vector/v1/buildings/16/19293/24641.json
 
-`earth,landuse`: https://tile.mapzen.com/mapzen/vector/v1/earth,landuse/16/19293/24641.json?api_key=mapzen-xxxxxxx
+`earth,landuse`: https://tile.mapzen.com/mapzen/vector/v1/earth,landuse/16/19293/24641.json
 
 ### Layers in the service's response
 

--- a/docs/use-service.md
+++ b/docs/use-service.md
@@ -1,8 +1,6 @@
 # Use the vector tile service
 
-To use the vector tile service, you first need to obtain an API key from Mapzen. Sign in at https://mapzen.com/developers to create and manage your API keys.
-
-Now, just append your API key into this URL pattern to get started, where `mapzen-xxxxxxx` represents your key.
+Request a single tile with this URL pattern to get started:
 
 `https://tile.mapzen.com/mapzen/vector/v1/{layers}/{z}/{x}/{y}.{format}`
 
@@ -11,6 +9,8 @@ The [OpenStreetMap Wiki](http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
 Here’s a sample tile in GeoJSON:
 
 `https://tile.mapzen.com/mapzen/vector/v1/all/16/19293/24641.json`
+
+To use the vector tile service in a project, [obtain an API key from Mapzen](https://mapzen.com/documentation/overview/).
 
 ## Specify layers in the service
 


### PR DESCRIPTION
To make sample URLs in various docs easier to test, we've enabled keyless access across all Mapzen APIs. I’ve also swapped out some extended words about the key signup process and replaced them with links to a single source of information.
