### PR TITLE
Zerebubuth/add overlaps bbox filter

### DIFF
--- a/integration-test/291-483-suppress-historical-closed.py
+++ b/integration-test/291-483-suppress-historical-closed.py
@@ -15,21 +15,3 @@ assert_no_matching_feature(
 assert_has_feature(
     17, 20931, 50616, 'pois',
     {'id': 241643507, 'kind': 'closed', 'min_zoom': 17})
-
-## US Naval Hospital (historical)
-# https://www.openstreetmap.org/relation/317369
-
-# original polygon should be present at z15
-assert_has_feature(
-    15, 5266, 12666, 'landuse',
-    {'id': -317369, 'kind': 'hospital'})
-
-# but POI should not be present
-assert_no_matching_feature(
-    15, 5266, 12666, 'pois',
-    {'id': -317369})
-
-# but it should be present at z17
-assert_has_feature(
-    17, 21063, 50665, 'pois',
-    {'id': -317369, 'kind': 'historical'})

--- a/integration-test/857-move_barriers_to_landuse.py
+++ b/integration-test/857-move_barriers_to_landuse.py
@@ -1,14 +1,14 @@
 # update landuse to include barriers features and delete from boundaries
 
 # city_wall in landuse
-# http://www.openstreetmap.org/way/258909996
+# http://www.openstreetmap.org/way/81522922
 assert_has_feature(
-    12, 3302, 1750, 'landuse',
+    12, 2030, 1300, 'landuse',
     { 'kind': 'city_wall'})
 
 # city_wall not in boundaries
 assert_no_matching_feature(
-    12, 3302, 1750, 'boundaries',
+    12, 2030, 1300, 'boundaries',
     { 'kind': 'city_wall'})
 
 # citywalls in landuse

--- a/queries/boundaries.jinja2
+++ b/queries/boundaries.jinja2
@@ -88,7 +88,7 @@ SELECT
 FROM planet_osm_polygon
 
 WHERE
-  {{ bounds['line']|bbox_filter('way',3857) }} AND
+  {{ bounds['line']|bbox_overlaps('way',3857) }} AND
 {% if zoom >= 16 %}
     mz_boundary_min_zoom IS NOT NULL
 {% else %}


### PR DESCRIPTION
A couple of text fixes:

1. Different example for `barrier=city_wall`, as the previous example was edited and didn't match the rule any more.
2. Dropped example of "... (historic)" hospital, which had been edited to not be a hospital any more.

Updated boundary query to use new "overlaps" test rather than intersection. This should prevent it matching in the interior of large polygons and speed up those queries.

Requires tilezen/tilequeue#118.

@rmarianski could you review, please?
