### PR TITLE
Added warning to Circle config.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
+#
+# WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
+# this repo has permissive fork builds set. DO NOT add any private
+# information into CircleCI for this repo without first making sure
+# that permissive fork builds has been turned off.
+#
 machine:
   python:
     version: 2.7.10


### PR DESCRIPTION
This is to warn everyone that permissive fork builds has been enabled for this repo. This will mean that our internal Overpass server is used for CI builds, but also that any "private" information such as AWS keys (of which there currently are none) would also be.

@rmarianski could you review, please?