### PR TITLE
update attribution requirements

### DIFF
--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -1,6 +1,6 @@
 # Attribution
 
-Attribution is required for many of our data providers. Example language is provided below, but you are responsible for researching each project to follow their license terms. More details are available on the [Data Sources](data-sources.md) page.
+Attribution is required for using Mapzen's hosted vector tile service as well as for many of our data providers. Example language is provided below, but you are responsible for researching each project to follow their license terms. More details are available on the [Data Sources](data-sources.md) and the [Mapzen rights](https://mapzen.com/rights) pages.
 
 **Required attribution:**
 
@@ -12,7 +12,7 @@ Attribution is required for many of our data providers. Example language is prov
 
 ### Where to attribute
 
-Attribution needs to "appear in a place that is reasonable to the medium or means you are utilising." [Specific examples](http://wiki.osmfoundation.org/wiki/License#Where_to_put_it.3F) are given by the OSM Foundation and are generally best practices for giving credit to any source.
+Attribution needs to "appear in a place that is reasonable to the medium or means you are utilising." [Specific examples](http://wiki.osmfoundation.org/wiki/License#Where_to_put_it.3F) are given by the OSM Foundation and are generally best practices for giving credit to any source. More information on attribution is on our [rights](https://mapzen.com/rights) page.
 
 ## The fine print
 

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -1,15 +1,14 @@
 # Attribution
 
-
 Attribution is required for many of our data providers. Example language is provided below, but you are responsible for researching each project to follow their license terms. More details are available on the [Data Sources](data-sources.md) page.
 
 **Required attribution:**
 
->  © OpenStreetMap contributors, Who's On First
+>  © Mapzen, OpenStreetMap contributors, Who's On First
 
 **Full attribution for all projects:**
 
->  © OpenStreetMap contributors, Who's On First, Natural Earth, and openstreetmapdata.com
+>  © Mapzen, OpenStreetMap contributors, Who's On First, Natural Earth, and openstreetmapdata.com
 
 ### Where to attribute
 
@@ -30,7 +29,7 @@ Attribution needs to "appear in a place that is reasonable to the medium or mean
 
 ### openstreetmapdata.com
 
-We include OSM-derived water and earth polygons from [openstreetmapdata.com](http://openstreetmapdata.com) at mid- and high-zooms. This data is under the OSM ODbL license. 
+We include OSM-derived water and earth polygons from [openstreetmapdata.com](http://openstreetmapdata.com) at mid- and high-zooms. This data is under the OSM ODbL license.
 
 ```
 © OpenStreetMap contributors
@@ -63,14 +62,10 @@ More details can be found on the Natural Earth [Terms of Use](http://www.natural
 
 `source:whosonfirst`
 
-Crediting [Who's On First](http://whosonfirst.mapzen.com) is recommended and linking back to their License is required. 
+Crediting [Who's On First](http://whosonfirst.mapzen.com) is recommended and linking back to their License is required.
 
 ```
 Data from Who's On First. <a href="http://whosonfirst.mapzen.com#License">License</a>
 ```
 
 Who's On First makes use of a number of open data sources, some of whom **do** require attribution. Neighbourhood sources include: [Zetashapes](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md#zetashapes) (geometry), [Quattroshapes](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md#quattroshapes) (geometry), and [GeoPlanet](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md#geoplanet) (names). Please note that original sources may be modified.
-
-===
-
-See something funky? Please notify us if you believe that an open data project has not been properly noted!

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -6,10 +6,6 @@ Attribution is required for using Mapzen's hosted vector tile service as well as
 
 >  Mapzen, © OpenStreetMap contributors, Who's On First
 
-**Full attribution for all projects:**
-
->  Mapzen, © OpenStreetMap contributors, Who's On First, Natural Earth, and openstreetmapdata.com
-
 ### Where to attribute
 
 Attribution needs to "appear in a place that is reasonable to the medium or means you are utilising." [Specific examples](http://wiki.osmfoundation.org/wiki/License#Where_to_put_it.3F) are given by the OSM Foundation and are generally best practices for giving credit to any source. More information on attribution is on our [rights](https://mapzen.com/rights) page.

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -2,9 +2,13 @@
 
 Attribution is required for using Mapzen's hosted vector tile service as well as for many of our data providers. Example language is provided below, but you are responsible for researching each project to follow their license terms. More details are available on the [Data Sources](data-sources.md) and the [Mapzen rights](https://mapzen.com/rights) pages.
 
-**Required attribution:**
+***Required attribution for Mapzen's hosted service:***
 
->  Mapzen, © OpenStreetMap contributors, Who's On First
+> Mapzen, © OpenStreetMap contributors, Who's On First
+
+***Optional full attribution including all data projects:***
+
+> Mapzen, © OpenStreetMap contributors, Who's On First, Natural Earth, and openstreetmapdata.com
 
 ### Where to attribute
 

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -4,11 +4,11 @@ Attribution is required for using Mapzen's hosted vector tile service as well as
 
 **Required attribution:**
 
->  © Mapzen, OpenStreetMap contributors, Who's On First
+>  Mapzen, © OpenStreetMap contributors, Who's On First
 
 **Full attribution for all projects:**
 
->  © Mapzen, OpenStreetMap contributors, Who's On First, Natural Earth, and openstreetmapdata.com
+>  Mapzen, © OpenStreetMap contributors, Who's On First, Natural Earth, and openstreetmapdata.com
 
 ### Where to attribute
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -6,9 +6,9 @@ Mapzen Vector Tiles are powered by several major open data sets and we owe a tre
 
 ## What is sourced at what zooms?
 
-Generally speaking, **Natural Earth** is used at low-zooms, and **OpenStreetMap** is relied on in mid- and high-zooms. Data from **openstreetmapdata.com** is used at the same zooms as the raw OSM data, and is derived from the OSM data. **Who's On First** neighbourhood labels generally come in at high-zooms. 
+Generally speaking, **Natural Earth** is used at low-zooms, and **OpenStreetMap** is relied on in mid- and high-zooms. Data from **openstreetmapdata.com** is used at the same zooms as the raw OSM data, and is derived from the OSM data. **Who's On First** neighbourhood labels generally come in at high-zooms.
 
-When possible, we annotate individual map features in each tile with a `source` property. 
+When possible, we annotate individual map features in each tile with a `source` property.
 
 
 ## OpenStreetMap
@@ -25,9 +25,9 @@ All OpenStreetMap data is licensed under the [ODbL](http://opendatacommons.org/l
 
 `source:openstreetmapdata.com`
 
-We include coastline-derived water polygons from [openstreetmapdata.com](http://openstreetmapdata.com) at mid- and high-zooms. This service was created by Jochen Topf and Christoph Hormann for the OpenStreetMap community and the general public and it rocks! 
+We include coastline-derived water polygons from [openstreetmapdata.com](http://openstreetmapdata.com) at mid- and high-zooms. This service was created by Jochen Topf and Christoph Hormann for the OpenStreetMap community and the general public and it rocks!
 
-As they say, "The coastline in OpenStreetMap is often broken. The update process will try to repair it, but this does not always work. If the OSM data can't be repaired automatically, the data here will not be updated." 
+As they say, "The coastline in OpenStreetMap is often broken. The update process will try to repair it, but this does not always work. If the OSM data can't be repaired automatically, the data here will not be updated."
 
 
 ## Natural Earth
@@ -46,8 +46,3 @@ More details can be found at: http://www.naturalearthdata.com/about/terms-of-use
 `source:whosonfirst`
 
 [Who's On First](http://whosonfirst.mapzen.com) is Mapzen's place gazetteer, and is used to source neighbourhood labels.
-
-
-===
-
-Please notify us if you believe that an open data project has not been properly noted.


### PR DESCRIPTION
fixes #1113, updates the attribution requirements for Vector Tiles

- also removed 'footers' because the docs pages have that information in the generator. 