### PR TITLE
Update assets to point to new buffered_land

### DIFF
--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
 bucket: mapzen-tiles-assets
-datestamp: 20160914
+datestamp: 20161109
 
 shapefiles:
 
@@ -22,8 +22,9 @@ shapefiles:
     shapefile-name: land-polygons-split-3857/land_polygons.shp
 
   - name: buffered_land
-    url: http://s3.amazonaws.com/mapzen-tiles-assets/curated/buffered_land.zip
+    url: http://s3.amazonaws.com/mapzen-tiles-assets/curated/buffered_land_10272016.zip
     prj: 3857
+    shapefile-name: buffered_land_10272016/buffered_land_10272016.shp
 
   - name: ne_110m_lakes
     url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/physical/ne_110m_lakes.zip


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/294

Updated source zip in https://s3.amazonaws.com/mapzen-tiles-assets/curated/buffered_land_10272016.zip to contain just updated buffered land shape file.

@zerebubuth, @iandees, @nvkelso could you review please?