### PR TITLE
Fix ocean/earth merge test by looking further east into the ocean

### DIFF
--- a/integration-test/1106-merge-ocean-earth.py
+++ b/integration-test/1106-merge-ocean-earth.py
@@ -1,7 +1,7 @@
 # There should be a single, merged feature in each of these tiles
 
 # Natural Earth
-assert_less_than_n_features(5, 11, 11, 'water', {'kind': 'ocean'}, 2)
+assert_less_than_n_features(5, 12, 11, 'water', {'kind': 'ocean'}, 2)
 assert_less_than_n_features(5, 8, 11, 'earth', {'kind': 'earth'}, 2)
 
 # OpenStreetMap


### PR DESCRIPTION
- [x] Update tests
- ~[ ] Update data migrations~
- ~[ ] Update docs~

I picked a tile in the low zoom tests I added in #1124 that was too close to the coast, so I got some unexpected polygons in there. This adjusts the test so it looks further east into the Atlantic, where there should only be a single water polygon.