### PR TITLE
Fix test for King Arthur Carousel

### DIFF
--- a/integration-test/440-zoos-and-other-attractions.py
+++ b/integration-test/440-zoos-and-other-attractions.py
@@ -54,7 +54,7 @@ for layer in ['pois', 'landuse']:
 # TAGS: attraction=carousel, building=yes, name=King Arthur Carrousel,
 # tourism=attraction
 assert_has_feature(
-    19, 90412, 209763, 'pois',
+    19, 90412, 209764, 'pois',
     { 'id': 129691054,
       'kind': 'carousel' })
 


### PR DESCRIPTION
Update tile to include centroid of carousel which moved across tile boundaries.

Although the carousel way itself was not edited, it looks like every node in it was moved [3 days ago](https://www.openstreetmap.org/changeset/43669560).

@rmarianski could you review, please?