### PR TITLE
A couple more test fixes

### DIFF
--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -1,6 +1,4 @@
-from __future__ import print_function
 from mapbox_vector_tile.decoder import POLYGON
-import sys
 
 # Caspian Sea
 assert_has_feature(
@@ -15,8 +13,6 @@ assert_has_feature(
 
 def area_of_ring(ring):
     area = 0
-
-    print(ring, file=sys.stderr)
 
     for [px, py], [nx, ny] in zip(ring, ring[1:] + [ring[0]]):
         area += px * ny - nx * py
@@ -48,8 +44,11 @@ with features_in_mvt_layer(5, 17, 9, 'water') as features:
 
         props = feature['properties']
         if props.get('kind') == 'ocean':
-            ocean_area += area_of(feature['geometry'])
+            geom = feature['geometry']
+            geom_type = geom['type']
+            assert 'Polygon' in geom_type
+            ocean_area += area_of(geom['coordinates'])
 
-    expected = 1576712559132672   # was 7936264
+    expected = 7936264
     if abs(abs(ocean_area) - expected) / expected > 0.05:
         raise Exception("Ocean area %f, expected %f." % (abs(ocean_area), expected))

--- a/integration-test/546-road-sort-keys-bridges.py
+++ b/integration-test/546-road-sort-keys-bridges.py
@@ -11,11 +11,11 @@ assert_has_feature(
     {"kind": "major_road", "kind_detail": "trunk", "id": 59801274,
      "name": "Crossover Dr.", "is_bridge": True, "sort_rank": 443})
 
-#http://www.openstreetmap.org/way/163994970
+#http://www.openstreetmap.org/way/399640204
 assert_has_feature(
-    18, 70118, 101513, "roads",
-    {"kind": "major_road", "kind_detail": "primary", "id": 163994970,
-     "name": "Broadway", "is_bridge": True, "sort_rank": 430})
+    18, 45061, 104884, "roads",
+    {"kind": "major_road", "kind_detail": "primary", "id": 399640204,
+     "name": "North Los Coyotes Diagonal", "is_bridge": True, "sort_rank": 430})
 
 #https://www.openstreetmap.org/way/27613581
 assert_has_feature(


### PR DESCRIPTION
Fixes:

1. Road example in bridges sort key test has [been updated](http://www.openstreetmap.org/way/163994970/history) to add `layer=1`. That changes the sort key and makes the test fail. Picked a different example instead.
2. [Changes to the MVT code](https://github.com/tilezen/mapbox-vector-tile/pull/85) means that `decode` now returns a GeoJSON-y object instead of a list of lists of coordinates.