### PR TITLE
Don't use tile coordinates in post-processing

### DIFF
--- a/integration-test/843-normalize-underscore.py
+++ b/integration-test/843-normalize-underscore.py
@@ -13,7 +13,7 @@ assert_has_feature(
     16, 18763, 24784, 'roads',
     { 'id': 256717307, 'kind': 'aerialway', 'kind_detail': 'j_bar' })
 
-# http://www.openstreetmap.org/way/258132198
+# http://www.openstreetmap.org/way/232074914
 assert_has_feature(
-    16, 10910, 25120, 'roads',
-    { 'id': 258132198, 'kind': 'aerialway', 'kind_detail': type(None) })
+    16, 13304, 24998, 'roads',
+    { 'id': 232074914, 'kind': 'aerialway', 'kind_detail': type(None) })

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -217,7 +217,6 @@ class DropFeaturesMinPixelsTest(unittest.TestCase):
 
     def _call_fut(self, feature_layers, zoom):
         from tilequeue.process import Context
-        from ModestMaps.Core import Coordinate
         from vectordatasource.transform import drop_features_mz_min_pixels
         params = dict(property='mz_min_pixels', source_layers=('layer-name',))
         ctx = Context(
@@ -295,7 +294,6 @@ class SortKeyTest(unittest.TestCase):
 class BuildingsUnifyTest(unittest.TestCase):
 
     def _call_fut(self, building_shapes, building_part_shapes):
-        from tilequeue.tile import deserialize_coord
         from tilequeue.process import Context
 
         building_features = []
@@ -387,7 +385,6 @@ class DropMergedIdTest(unittest.TestCase):
 
     def _assert_no_id_in_props(self, features, merge_fn):
         from tilequeue.process import Context
-        from tilequeue.tile import deserialize_coord
         layer_name = 'layername'
         feature_layer = dict(
             features=features,
@@ -477,7 +474,6 @@ class DropMergedIdTest(unittest.TestCase):
     def test_no_merge_preserve_props(self):
         import shapely.geometry
         from tilequeue.process import Context
-        from tilequeue.tile import deserialize_coord
         from vectordatasource.transform import merge_polygon_features
 
         buildings = []
@@ -629,7 +625,6 @@ class RankBoundsTest(unittest.TestCase):
 
     def _call_fut(self, shape, bounds):
         from tilequeue.process import Context
-        from tilequeue.tile import deserialize_coord
         from vectordatasource.transform import rank_features
         props = dict(foo='bar')
         feature = shape, props, 1

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -222,7 +222,7 @@ class DropFeaturesMinPixelsTest(unittest.TestCase):
         params = dict(property='mz_min_pixels', source_layers=('layer-name',))
         ctx = Context(
             feature_layers=feature_layers,
-            tile_coord=Coordinate(column=1, row=1, zoom=zoom),
+            nominal_zoom=zoom,
             params=params,
             unpadded_bounds=None,
             resources=None,
@@ -329,7 +329,7 @@ class BuildingsUnifyTest(unittest.TestCase):
 
         ctx = Context(
             feature_layers=feature_layers,
-            tile_coord=deserialize_coord('0/0/0'),
+            nominal_zoom=0,
             unpadded_bounds=None,
             params=dict(source_layer='buildings'),
             resources=None)
@@ -396,7 +396,7 @@ class DropMergedIdTest(unittest.TestCase):
         feature_layers = [feature_layer]
         ctx = Context(
             feature_layers=feature_layers,
-            tile_coord=deserialize_coord('0/0/0'),
+            nominal_zoom=0,
             unpadded_bounds=None,
             params=dict(source_layer=layer_name),
             resources=None)
@@ -506,7 +506,7 @@ class DropMergedIdTest(unittest.TestCase):
         feature_layers = [feature_layer]
         ctx = Context(
             feature_layers=feature_layers,
-            tile_coord=deserialize_coord('0/0/0'),
+            nominal_zoom=0,
             unpadded_bounds=None,
             params=dict(source_layer=layer_name),
             resources=None)
@@ -644,7 +644,7 @@ class RankBoundsTest(unittest.TestCase):
         )
         ctx = Context(
             feature_layers=[feature_layer],
-            tile_coord=deserialize_coord('0/0/0'),
+            nominal_zoom=0,
             unpadded_bounds=bounds,
             params=params,
             resources=None,

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -1328,7 +1328,7 @@ def exterior_boundaries(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     base_layer = ctx.params.get('base_layer')
     assert base_layer, 'Missing base_layer parameter'
     new_layer_name = ctx.params.get('new_layer_name')
@@ -1729,7 +1729,7 @@ def admin_boundaries(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     base_layer = ctx.params.get('base_layer')
     assert base_layer, 'Parameter base_layer missing.'
     start_zoom = ctx.params.get('start_zoom', 0)
@@ -1858,7 +1858,7 @@ def handle_label_placement(ctx):
     Converts a geometry label column into a separate feature.
     """
     layers = ctx.params.get('layers', None)
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     location_property = ctx.params.get('location_property', None)
     label_property_name = ctx.params.get('label_property_name', None)
     label_property_value = ctx.params.get('label_property_value', None)
@@ -1926,7 +1926,7 @@ def generate_address_points(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     assert source_layer, 'generate_address_points: missing source_layer'
     start_zoom = ctx.params.get('start_zoom', 0)
@@ -2021,7 +2021,7 @@ def drop_features_where(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     assert source_layer, 'drop_features_where: missing source layer'
     start_zoom = ctx.params.get('start_zoom', 0)
@@ -2060,7 +2060,7 @@ def _project_properties(ctx, action):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     where = ctx.params.get('where')
     source_layer = ctx.params.get('source_layer')
     assert source_layer, '_project_properties: missing source layer'
@@ -2229,7 +2229,7 @@ def remove_duplicate_features(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     source_layers = ctx.params.get('source_layers')
     start_zoom = ctx.params.get('start_zoom', 0)
@@ -2339,7 +2339,7 @@ def merge_duplicate_stations(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     assert source_layer, \
         'normalize_and_merge_duplicate_stations: missing source layer'
@@ -2440,7 +2440,7 @@ def normalize_station_properties(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     assert source_layer, \
         'normalize_and_merge_duplicate_stations: missing source layer'
@@ -2528,7 +2528,7 @@ def keep_n_features(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     assert source_layer, 'keep_n_features: missing source layer'
     start_zoom = ctx.params.get('start_zoom', 0)
@@ -2589,7 +2589,7 @@ def rank_features(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     assert source_layer, 'rank_features: missing source layer'
     start_zoom = ctx.params.get('start_zoom', 0)
@@ -2656,7 +2656,7 @@ def numeric_min_filter(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     assert source_layer, 'rank_features: missing source layer'
     filters = ctx.params.get('filters')
@@ -2939,7 +2939,7 @@ def _merge_features_by_property(
 
 
 def merge_building_features(ctx):
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     start_zoom = ctx.params.get('start_zoom', 0)
     end_zoom = ctx.params.get('end_zoom')
@@ -3008,7 +3008,7 @@ def merge_polygon_features(ctx):
     are unique in the merge.
     """
 
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     start_zoom = ctx.params.get('start_zoom', 0)
     end_zoom = ctx.params.get('end_zoom')
@@ -3045,7 +3045,7 @@ def merge_line_features(ctx):
     between start_zoom and end_zoom inclusive.
     """
 
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     start_zoom = ctx.params.get('start_zoom', 0)
     end_zoom = ctx.params.get('end_zoom')
@@ -3099,7 +3099,7 @@ def build_fence(ctx):
     details.
     """
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     base_layer = ctx.params.get('base_layer')
     new_layer_name = ctx.params.get('new_layer_name')
     prop_transform = ctx.params.get('prop_transform')
@@ -3427,7 +3427,7 @@ def csv_match_properties(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     start_zoom = ctx.params.get('start_zoom', 0)
     end_zoom = ctx.params.get('end_zoom')
@@ -3468,7 +3468,7 @@ def update_parenthetical_properties(ctx):
     """
 
     feature_layers = ctx.feature_layers
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
     start_zoom = ctx.params.get('start_zoom', 0)
     end_zoom = ctx.params.get('end_zoom')
@@ -3609,7 +3609,7 @@ def drop_features_mz_min_pixels(ctx):
     prop_name = ctx.params.get('property')
     assert prop_name, 'drop_features_mz_min_pixels: missing property'
 
-    meters_per_pixel_area = calc_meters_per_pixel_area(ctx.tile_coord.zoom)
+    meters_per_pixel_area = calc_meters_per_pixel_area(ctx.nominal_zoom)
 
     feature_layers = ctx.feature_layers
     for source_layer_name in source_layer_names:
@@ -3647,7 +3647,7 @@ def drop_features_mz_min_pixels(ctx):
 def simplify_and_clip(ctx):
     """simplify geometries according to zoom level and clip"""
 
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     simplify_before = ctx.params.get('simplify_before')
 
     assert simplify_before, 'simplify_and_clip: missing simplify_before param'
@@ -3922,7 +3922,7 @@ def buildings_unify(ctx):
     root_id property which will be the id of building parent they are
     associated with.
     """
-    zoom = ctx.tile_coord.zoom
+    zoom = ctx.nominal_zoom
     start_zoom = ctx.params.get('start_zoom', 0)
 
     if zoom < start_zoom:


### PR DESCRIPTION
This is another step towards having separate concepts for the "nominal zoom" which refers to the display scale, and the coordinate of the tile. When these things are separate, it will be easier to make tiles where the spatial bounds and display scale are not in the same proportion as with a "regular" 256px tile.

Matches up with https://github.com/tilezen/tilequeue/pull/156.

@rmarianski, @iandees could you take a look, please?