### PR TITLE
Update >z16 test failure coords to use z16

### DIFF
--- a/integration-test/160-motorway-junctions.py
+++ b/integration-test/160-motorway-junctions.py
@@ -1,6 +1,6 @@
 # http://www.openstreetmap.org/node/733619113
 assert_has_feature(
-    18, 41935, 101329, 'pois',
+    16, 10483, 25332, 'pois',
     { 'kind': 'motorway_junction' })
 
 assert_has_feature(

--- a/integration-test/244-railway-plaforms.py
+++ b/integration-test/244-railway-plaforms.py
@@ -1,5 +1,5 @@
 # Hunterspoint Avenue LIRR
 # https://www.openstreetmap.org/way/326365794
 assert_has_feature(
-    18, 77224, 98532, 'transit',
+    16, 19306, 24633, 'transit',
     { 'kind': 'platform' })

--- a/integration-test/291-483-suppress-historical-closed.py
+++ b/integration-test/291-483-suppress-historical-closed.py
@@ -13,5 +13,5 @@ assert_no_matching_feature(
 
 # but POI should be present at z17 and marked as closed
 assert_has_feature(
-    17, 20931, 50616, 'pois',
+    16, 10465, 25308, 'pois',
     {'id': 241643507, 'kind': 'closed', 'min_zoom': 17})

--- a/integration-test/344-winter-sports-pois.py
+++ b/integration-test/344-winter-sports-pois.py
@@ -1,7 +1,7 @@
 # ski shop in Big Bear Lake, CA
 # https://www.openstreetmap.org/node/2720341705
 assert_has_feature(
-    18, 45955, 104504, 'pois',
+    16, 11488, 26126, 'pois',
     { 'kind': 'ski',
       'name': None })
 

--- a/integration-test/366-beaches.py
+++ b/integration-test/366-beaches.py
@@ -1,5 +1,5 @@
 # Baker beach, SF
 # https://www.openstreetmap.org/relation/6260732
 assert_has_feature(
-    18, 41881, 101308, 'landuse',
+    16, 10470, 25327, 'landuse',
     { 'kind': 'beach' })

--- a/integration-test/367-military-landuse.py
+++ b/integration-test/367-military-landuse.py
@@ -1,5 +1,5 @@
 # Naval Weapons Station Concord, CA
 # https://www.openstreetmap.org/way/154836419
 assert_has_feature(
-    17, 21107, 50548, 'landuse',
+    16, 10553, 25274, 'landuse',
     { 'kind': 'military' })

--- a/integration-test/368-disused-railway-stations.py
+++ b/integration-test/368-disused-railway-stations.py
@@ -1,11 +1,11 @@
 # Old South Ferry (1) (disused=yes)
 assert_no_matching_feature(
-    19, 154354, 197144, 'pois',
+    16, 19294, 24643, 'pois',
     {'kind': 'station', 'id': 2086974744})
 
 # Valle, AZ (disused=station)
 assert_no_matching_feature(
-    19, 98740, 206504, 'pois',
+    16, 12342, 25813, 'pois',
     {'id': 366220389})
 
 # Sadly, we seem to be lacking a disused=no object in

--- a/integration-test/374-electronics-shops.py
+++ b/integration-test/374-electronics-shops.py
@@ -1,6 +1,6 @@
 tiles = [
     # https://www.openstreetmap.org/way/25821942
-    (17, 20966, 50665, 'Best Buy'),
+    (16, 10483, 25332, 'Best Buy'),
     # https://www.openstreetmap.org/way/143811375
     (15, 5236, 12676, 'Best Buy'),
     # https://www.openstreetmap.org/way/25821942

--- a/integration-test/404-toys-not-found.py
+++ b/integration-test/404-toys-not-found.py
@@ -1,14 +1,14 @@
 tiles = [
-    (17, 20946, 50678), # https://www.openstreetmap.org/way/215472849
-    (17, 20959, 50673), # https://www.openstreetmap.org/node/1713279804
-    (17, 20961, 50675), # https://www.openstreetmap.org/node/3188857553
-    (17, 20969, 50656), # https://www.openstreetmap.org/node/3396659022
-    (17, 21013, 50637), # https://www.openstreetmap.org/node/1467717312
-    (17, 21019, 50617), # https://www.openstreetmap.org/node/2286100659
-    (17, 21028, 50645), # https://www.openstreetmap.org/node/3711137981
-    (17, 38597, 49266), # https://www.openstreetmap.org/node/3810578539
-    (17, 38600, 49261), # https://www.openstreetmap.org/node/1429062988
-    (17, 38601, 49258), # https://www.openstreetmap.org/node/1058296287
+    (16, 10473, 25339), # https://www.openstreetmap.org/way/215472849
+    (16, 10479, 25336), # https://www.openstreetmap.org/node/1713279804
+    (16, 10480, 25337), # https://www.openstreetmap.org/node/3188857553
+    (16, 10484, 25328), # https://www.openstreetmap.org/node/3396659022
+    (16, 10506, 25318), # https://www.openstreetmap.org/node/1467717312
+    (16, 10509, 25308), # https://www.openstreetmap.org/node/2286100659
+    (16, 10514, 25322), # https://www.openstreetmap.org/node/3711137981
+    (16, 19298, 24633), # https://www.openstreetmap.org/node/3810578539
+    (16, 19300, 24630), # https://www.openstreetmap.org/node/1429062988
+    (16, 19300, 24629), # https://www.openstreetmap.org/node/1058296287
 ]
 
 for z, x, y in tiles:

--- a/integration-test/440-zoos-and-other-attractions-attraction.py
+++ b/integration-test/440-zoos-and-other-attractions-attraction.py
@@ -18,12 +18,12 @@ for layer in ['pois', 'landuse']:
 
     # whitelist attraction values
     attraction_values = [
-        (17, 42456, 47103, 342984911, 'animal'), # Sable Island Horse
-        (17, 30227, 44547, 243814268, 'water_slide'), # Fun Mountain Water Park
-        (17, 37341, 50633, 235398095, 'roller_coaster'), # Intimidator 305
-        (17, 37339, 50633, 235037260, 'carousel'), # Carousel
-        (17, 37337, 50632, 235398104, 'amusement_ride'), # White Water Canyon
-        (17, 37363, 49814, 374883740, 'maze') # Lawyers Farm Corn Maze
+        (16, 21228, 23551, 342984911, 'animal'), # Sable Island Horse
+        (16, 15113, 22273, 243814268, 'water_slide'), # Fun Mountain Water Park
+        (16, 18670, 25316, 235398095, 'roller_coaster'), # Intimidator 305
+        (16, 18669, 25316, 235037260, 'carousel'), # Carousel
+        (16, 18668, 25316, 235398104, 'amusement_ride'), # White Water Canyon
+        (16, 18681, 24907, 374883740, 'maze') # Lawyers Farm Corn Maze
     ]
 
     for z, x, y, osm_id, attraction in attraction_values:
@@ -35,6 +35,6 @@ for layer in ['pois', 'landuse']:
 # This is a carousel, but also a building, which keeps it out of the landuse
 # layer. See https://github.com/mapzen/vector-datasource/issues/201
 assert_has_feature(
-    17, 34766, 50047, 'pois',
+    16, 17383, 25023, 'pois',
     { 'id': 325824281,
       'kind': 'carousel' })

--- a/integration-test/440-zoos-and-other-attractions-barrier.py
+++ b/integration-test/440-zoos-and-other-attractions-barrier.py
@@ -1,5 +1,5 @@
 # barrier=fence around enclosures
 # https://www.openstreetmap.org/way/316623706
 assert_has_feature(
-    18, 45834, 87422, 'landuse',
+    16, 11458, 21855, 'landuse',
     { 'kind': 'fence' })

--- a/integration-test/440-zoos-and-other-attractions-tourism.py
+++ b/integration-test/440-zoos-and-other-attractions-tourism.py
@@ -19,7 +19,7 @@ for layer in ['pois', 'landuse']:
 
     # tourism whitelist
     tourism_values = [
-        (17, 35291, 48485, 358445798, 'artwork'), # City Sculpture, Detroit
+        (16, 17645, 24242, 358445798, 'artwork'), # City Sculpture, Detroit
         (13, 2240, 3421, -1228099, 'theme_park'), # Walt Disney World Resort
         (13, 2351, 3181, 362327591, 'theme_park'), # Busch Gardens Williamsburg
         (14, 2825, 6555, -4795362, 'resort'), # Disneyland Resort
@@ -49,6 +49,6 @@ assert_has_feature(
 # in the landuse layer.
 # unnamed, CO
 assert_has_feature(
-    17, 27372, 49802, 'pois',
+    16, 13686, 24901, 'pois',
     { 'id': 1589837084,
       'kind': 'trail_riding_station' })

--- a/integration-test/440-zoos-and-other-attractions-zoo.py
+++ b/integration-test/440-zoos-and-other-attractions-zoo.py
@@ -14,10 +14,10 @@ for layer in ['pois', 'landuse']:
 
     # whitelist zoo values
     zoo_values = [
-        (17, 22916, 43711, 316623706, 'enclosure'), # Bear Enclosure (presumably + woods=yes?)
-        (17, 41926, 47147, 343269426, 'petting_zoo'), # Oaklawn Farm Zoo
-        (17, 20927, 45938, 370123970, 'aviary'), # Budgie Buddies
-        (17, 42457, 47102, 84422829, 'wildlife_park') # Shubenacadie Provincial Wildlife Park
+        (16, 11458, 21855, 316623706, 'enclosure'), # Bear Enclosure (presumably + woods=yes?)
+        (16, 20963, 23573, 343269426, 'petting_zoo'), # Oaklawn Farm Zoo
+        (16, 10463, 22969, 370123970, 'aviary'), # Budgie Buddies
+        (16, 21228, 23551, 84422829, 'wildlife_park') # Shubenacadie Provincial Wildlife Park
     ]
 
     for z, x, y, osm_id, zoo in zoo_values:
@@ -29,6 +29,6 @@ for layer in ['pois', 'landuse']:
 # this is a building, so won't show up in landuse. still should be a POI.
 # Wings of Asia
 assert_has_feature(
-    17, 36263, 55884, 'pois',
+    16, 18131, 27942, 'pois',
     { 'id': 103256220,
       'kind': 'aviary' })

--- a/integration-test/440-zoos-and-other-attractions.py
+++ b/integration-test/440-zoos-and-other-attractions.py
@@ -32,7 +32,7 @@ for layer in ['pois', 'landuse']:
     # NOTE: updated to a feature in North America: MarineLand, Niagara Falls,
     # ON.
     assert_has_feature(
-        17, 36746, 48133, layer,
+        16, 18373, 24066, layer,
         { 'id': 177402901,
           'kind': 'attraction' })
 
@@ -54,7 +54,7 @@ for layer in ['pois', 'landuse']:
 # TAGS: attraction=carousel, building=yes, name=King Arthur Carrousel,
 # tourism=attraction
 assert_has_feature(
-    19, 90412, 209764, 'pois',
+    16, 11301, 26220, 'pois',
     { 'id': 129691054,
       'kind': 'carousel' })
 
@@ -63,6 +63,6 @@ assert_has_feature(
 # tourism=attraction
 ## way 107280556 http://c.tile.openstreetmap.org/17/22603/52441.png
 assert_has_feature(
-    17, 22603, 52441, 'pois',
+    16, 11301, 26220, 'pois',
     { 'id': 107280556,
       'kind': 'roller_coaster' })

--- a/integration-test/447-ice-cream-shops.py
+++ b/integration-test/447-ice-cream-shops.py
@@ -1,11 +1,11 @@
 # New York, NY (amenity=ice_cream)
 #https://www.openstreetmap.org/node/2782000317
 assert_has_feature(
-    18, 77196, 98518, 'pois',
+    16, 19299, 24629, 'pois',
     { 'kind': 'ice_cream' })
 
 # Oakland, CA (shop=ice_cream)
 #https://www.openstreetmap.org/node/661742947
 assert_has_feature(
-    18, 42050, 101257, 'pois',
+    16, 10512, 25314, 'pois',
     { 'kind': 'ice_cream' })

--- a/integration-test/448-wine-and-alcohol-shops.py
+++ b/integration-test/448-wine-and-alcohol-shops.py
@@ -1,11 +1,11 @@
 # Wine, New York, NY
 #https://www.openstreetmap.org/node/2549960970
 assert_has_feature(
-    18, 77193, 98529, 'pois',
+    16, 19298, 24632, 'pois',
     { 'kind': 'wine' })
 
 # Alcohol, San Francisco, CA
 #https://www.openstreetmap.org/node/1713269631
 assert_has_feature(
-    18, 41922, 101345, 'pois',
+    16, 10480, 25336, 'pois',
     { 'kind': 'alcohol' })

--- a/integration-test/465-fitness-pois.py
+++ b/integration-test/465-fitness-pois.py
@@ -4,10 +4,10 @@ tiles = [
     (16, 10484, 25332),
     # Sunset gym, leisure=sports_centre + sport=fitness
     #https://www.openstreetmap.org/node/3674255652
-    (17, 20947, 50666),
+    (16, 10473, 25333),
     # Alameda Athletic Club, amenity=gym
     #https://www.openstreetmap.org/node/310972983
-    (17, 21028, 50668)
+    (16, 10514, 25334)
 ]
 
 for z, x, y in tiles:
@@ -18,5 +18,5 @@ for z, x, y in tiles:
 # Pushup, fitness_station
 #https://www.openstreetmap.org/node/3658323774
 assert_has_feature(
-    17, 26332, 50542, 'pois',
+    16, 13166, 25271, 'pois',
     { 'kind': 'fitness_station' })

--- a/integration-test/484-include-state-pois.py
+++ b/integration-test/484-include-state-pois.py
@@ -1,11 +1,11 @@
 # Antioch Station
 #https://www.openstreetmap.org/node/3353451464
 assert_has_feature(
-    18, 42390, 101119, 'pois',
+    16, 10597, 25279, 'pois',
     {'id': 3353451464, 'state': 'proposed'})
 
 # Pittsburg Center
 #https://www.openstreetmap.org/node/3354463416
 assert_has_feature(
-    19, 84630, 202201, 'pois',
+    16, 10578, 25275, 'pois',
     {'id': 3354463416, 'state': 'proposed'})

--- a/integration-test/510-funicular.py
+++ b/integration-test/510-funicular.py
@@ -1,4 +1,4 @@
 #https://www.openstreetmap.org/way/393550019
 assert_has_feature(
-    18, 41924, 101383, 'roads',
+    16, 10481, 25345, 'roads',
     { 'kind': 'rail', 'kind_detail': 'funicular' })

--- a/integration-test/526-inclusive-pois.py
+++ b/integration-test/526-inclusive-pois.py
@@ -1,21 +1,21 @@
 tiles = [
     # healthcare=midwife
     #https://www.openstreetmap.org/node/3761053357
-    ['17/21000/44983', {'kind': 'midwife'}],
+    ['16/10500/22491', {'kind': 'midwife'}],
 
     # amenity={kindergarten, childcare}
     #https://www.openstreetmap.org/node/1460537343
     #https://www.openstreetmap.org/way/378041773
     ['16/10470/25342', {'kind': 'kindergarten'}],
-    ['17/20956/50676', {'kind': 'childcare'}],
+    ['16/10478/25338', {'kind': 'childcare'}],
 
     # emergency=phone
     #https://www.openstreetmap.org/node/2456072777
-    ['18/41978/101284', {'kind': 'phone'}],
+    ['16/10494/25321', {'kind': 'phone'}],
 
     # amenity=toilets
     #https://www.openstreetmap.org/node/3931486668
-    ['18/41923/101323', {'kind': 'toilets'}],
+    ['16/10480/25330', {'kind': 'toilets'}],
 
     # amenity=social_facility + social_facility=*
     # also with social_facility:for -> for and turned into a list to make it
@@ -25,11 +25,11 @@ tiles = [
     #https://www.openstreetmap.org/way/243357053
     #https://www.openstreetmap.org/way/377082896
     #https://www.openstreetmap.org/node/358816623
-    ['18/41920/101328', {'kind': 'social_facility', 'for': ['senior', 'disabled']}],
-    ['18/41928/101328', {'kind': 'shelter', 'for': ['homeless']}],
-    ['17/20967/50661', {'kind': 'shelter', 'for': ['homeless']}],
-    ['17/20960/50808', {'kind': 'group_home', 'for': ['senior']}],
-    ['18/42119/101622', {'kind': 'assisted_living'}],
+    ['16/10480/25332', {'kind': 'social_facility', 'for': ['senior', 'disabled']}],
+    ['16/10482/25332', {'kind': 'shelter', 'for': ['homeless']}],
+    ['16/10483/25330', {'kind': 'shelter', 'for': ['homeless']}],
+    ['16/10480/25404', {'kind': 'group_home', 'for': ['senior']}],
+    ['16/10529/25405', {'kind': 'assisted_living'}],
 
     # amenity={clinic, doctors, dentist}
     # also with healthcare:speciality -> speciality and turned into a list to make
@@ -39,11 +39,11 @@ tiles = [
     #https://www.openstreetmap.org/node/3133693825
     #https://www.openstreetmap.org/node/3163318863
     #https://www.openstreetmap.org/node/3879177193
-    ['18/41936/101301', {'kind': 'clinic'}],
-    ['17/20965/50666', {'kind': 'clinic'}],
-    ['18/41923/101349', {'kind': 'doctors'}],
-    ['18/41923/101350', {'kind': 'dentist'}],
-    ['17/21066/45789', {'kind': 'doctors', 'speciality': ['general']}],
+    ['16/10484/25325', {'kind': 'clinic'}],
+    ['16/10482/25333', {'kind': 'clinic'}],
+    ['16/10480/25337', {'kind': 'doctors'}],
+    ['16/10480/25337', {'kind': 'dentist'}],
+    ['16/10533/22894', {'kind': 'doctors', 'speciality': ['general']}],
 ]
 
 for loc, props in tiles:

--- a/integration-test/546-road-sort-keys-aerialway.py
+++ b/integration-test/546-road-sort-keys-aerialway.py
@@ -1,23 +1,23 @@
 #https://www.openstreetmap.org/way/32051122
 assert_has_feature(
-    18, 77287, 94962, "roads",
+    16, 19321, 23740, "roads",
     {"kind": "aerialway", "kind_detail": "gondola", "id": 32051122,
      "sort_rank": 442})
 
 #https://www.openstreetmap.org/way/384371038
 assert_has_feature(
-    18, 59578, 116931, "roads",
+    16, 14894, 29232, "roads",
     {"kind": "aerialway", "kind_detail": "cable_car", "id": 384371038,
      "sort_rank": 442})
 
 #https://www.openstreetmap.org/way/113791306
 assert_has_feature(
-    18, 42213, 101971, "roads",
+    16, 10553, 25492, "roads",
     {"kind": "aerialway", "kind_detail": "chair_lift", "id": 113791306,
      "sort_rank": 441})
 
 #https://www.openstreetmap.org/way/209129274
 assert_has_feature(
-    18, 42877, 100050, "roads",
+    16, 10719, 25012, "roads",
     {"kind": "aerialway", "kind_detail": "rope_tow", "id": 209129274,
      "sort_rank": 440})

--- a/integration-test/546-road-sort-keys-aeroway.py
+++ b/integration-test/546-road-sort-keys-aeroway.py
@@ -1,11 +1,11 @@
 #https://www.openstreetmap.org/way/214484985
 assert_has_feature(
-    18, 75831, 98152, "roads",
+    16, 18957, 24538, "roads",
     {"kind": "aeroway", "kind_detail": "runway", "id": 214484985,
      "sort_rank": 62})
 
 #https://www.openstreetmap.org/way/115434129
 assert_has_feature(
-    18, 75927, 97961, "roads",
+    16, 18981, 24490, "roads",
     {"kind": "aeroway", "kind_detail": "taxiway", "id": 115434129,
      "sort_rank": 61})

--- a/integration-test/546-road-sort-keys-bridges.py
+++ b/integration-test/546-road-sort-keys-bridges.py
@@ -1,37 +1,37 @@
 # bridges
 #https://www.openstreetmap.org/way/28412298
 assert_has_feature(
-    18, 41888, 101295, "roads",
+    16, 10472, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "id": 28412298,
      "name": "Presidio Pkwy.", "is_bridge": True, "sort_rank": 443})
 
 #https://www.openstreetmap.org/way/59801274
 assert_has_feature(
-    18, 41885, 101327, "roads",
+    16, 10471, 25331, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 59801274,
      "name": "Crossover Dr.", "is_bridge": True, "sort_rank": 443})
 
 #http://www.openstreetmap.org/way/399640204
 assert_has_feature(
-    18, 45061, 104884, "roads",
+    16, 11265, 26221, "roads",
     {"kind": "major_road", "kind_detail": "primary", "id": 399640204,
      "name": "North Los Coyotes Diagonal", "is_bridge": True, "sort_rank": 430})
 
 #https://www.openstreetmap.org/way/27613581
 assert_has_feature(
-    18, 41946, 101358, "roads",
+    16, 10486, 25339, "roads",
     {"kind": "major_road", "kind_detail": "secondary", "id": 27613581,
      "name": "Oakdale Ave.", "is_bridge": True, "sort_rank": 429})
 
 #https://www.openstreetmap.org/way/242940297
 assert_has_feature(
-    18, 41946, 101309, "roads",
+    16, 10486, 25327, "roads",
     {"kind": "major_road", "kind_detail": "tertiary", "id": 242940297,
      "name": "Beale St.", "is_bridge": True, "sort_rank": 427})
 
 #https://www.openstreetmap.org/way/162038104
 assert_has_feature(
-    18, 42955, 99957, "roads",
+    16, 10738, 24989, "roads",
     {"kind": "minor_road", "kind_detail": "residential", "id": 162038104,
      "name": "Woodwardia Pl.", "sort_rank": 410})
 

--- a/integration-test/546-road-sort-keys-layers.py
+++ b/integration-test/546-road-sort-keys-layers.py
@@ -1,48 +1,48 @@
 # layer 5
 #https://www.openstreetmap.org/way/8918870
 assert_has_feature(
-    18, 41934, 101362, "roads",
+    16, 10483, 25340, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 8918870, "sort_rank": 447})
 
 # layer 4
 #https://www.openstreetmap.org/way/27614705
 assert_has_feature(
-    18, 41938, 101360, "roads",
+    16, 10484, 25340, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 27614705, "sort_rank": 446})
 
 # layer 3
 #https://www.openstreetmap.org/way/29394019
 assert_has_feature(
-    18, 41916, 101364, "roads",
+    16, 10479, 25341, "roads",
     {"kind": "highway", "kind_detail": "motorway_link", "is_bridge": True,
      "id": 29394019, "sort_rank": 445})
 
 # layer 2
 #https://www.openstreetmap.org/way/48037053
 assert_has_feature(
-    18, 41937, 101358, "roads",
+    16, 10484, 25339, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 48037053, "sort_rank": 444})
 
 # layer 1
 #https://www.openstreetmap.org/way/28412298
 assert_has_feature(
-    18, 41888, 101295, "roads",
+    16, 10472, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 28412298, "sort_rank": 443})
 
 # layer -1
 #https://www.openstreetmap.org/way/43685501
 assert_has_feature(
-    18, 41888, 101294, "roads",
+    16, 10472, 25323, "roads",
     {"kind": "minor_road", "kind_detail": "service", "is_tunnel": True,
      "id": 43685501, "sort_rank": 304})
 
 # layer -2
 #https://www.openstreetmap.org/way/50691047
 assert_has_feature(
-    18, 41967, 101293, "roads",
+    16, 10491, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_tunnel": True,
      "id": 50691047, "sort_rank": 303})

--- a/integration-test/546-road-sort-keys-railways.py
+++ b/integration-test/546-road-sort-keys-railways.py
@@ -1,53 +1,53 @@
 # Railways
 #https://www.openstreetmap.org/way/8920472
 assert_has_feature(
-    18, 41948, 101333, "roads",
+    16, 10487, 25333, "roads",
     {"kind": "rail", "kind_detail": "rail", "id": 8920472, "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/95623728
 assert_has_feature(
-    18, 41947, 101306, "roads",
+    16, 10486, 25326, "roads",
     {"kind": "rail", "kind_detail": "tram", "id": 95623728, "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/160279679
 assert_has_feature(
-    18, 41914, 101365, "roads",
+    16, 10478, 25341, "roads",
     {"kind": "rail", "kind_detail": "light_rail", "id": 160279679,
      "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/105574666
 assert_has_feature(
-    18, 76864, 99113, "roads",
+    16, 19216, 24778, "roads",
     {"kind": "rail", "kind_detail": "narrow_gauge", "id": 105574666,
      "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/296530703
 assert_has_feature(
-    18, 70859, 97816, "roads",
+    16, 17714, 24454, "roads",
     {"kind": "rail", "kind_detail": "monorail", "id": 296530703,
      "sort_rank": 382})
 
 # spurs, sidings, etc...
 #https://www.openstreetmap.org/way/106087318
 assert_has_feature(
-    18, 41967, 101369, "roads",
+    16, 10491, 25342, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "spur", "id": 106087318,
      "sort_rank": 361})
 
 #https://www.openstreetmap.org/way/148018328
 assert_has_feature(
-    18, 41943, 101326, "roads",
+    16, 10485, 25331, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "siding", "id": 148018328,
      "sort_rank": 361})
 
 #https://www.openstreetmap.org/way/119709585
 assert_has_feature(
-    18, 41943, 101326, "roads",
+    16, 10485, 25331, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "yard", "id": 119709585,
      "sort_rank": 359})
 
 #https://www.openstreetmap.org/way/119695339
 assert_has_feature(
-    18, 41941, 101390, "roads",
+    16, 10485, 25347, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "crossover",
      "id": 119695339, "sort_rank": 357})

--- a/integration-test/546-road-sort-keys-roads.py
+++ b/integration-test/546-road-sort-keys-roads.py
@@ -1,61 +1,61 @@
 # regular roads
 #https://www.openstreetmap.org/way/26765956
 assert_has_feature(
-    18, 41888, 101295, "roads",
+    16, 10472, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "id": 26765956,
      "name": "Presidio Pkwy.", "sort_rank": 383})
 
 #https://www.openstreetmap.org/way/89802409
 assert_has_feature(
-    18, 41887, 101348, "roads",
+    16, 10471, 25337, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 89802409,
      "name": "19th Ave.", "sort_rank": 381})
 
 #https://www.openstreetmap.org/way/160842753
 assert_has_feature(
-    18, 41952, 101346, "roads",
+    16, 10488, 25336, "roads",
     {"kind": "major_road", "kind_detail": "primary", "id": 160842753,
      "name": "3rd St.", "sort_rank": 380})
 
 #https://www.openstreetmap.org/way/25337673
 assert_has_feature(
-    18, 41928, 101328, "roads",
+    16, 10482, 25332, "roads",
     {"kind": "major_road", "kind_detail": "secondary", "id": 25337673,
      "name": "Mission St.", "sort_rank": 379})
 
 #https://www.openstreetmap.org/way/255330035
 assert_has_feature(
-    18, 41941, 101298, "roads",
+    16, 10485, 25324, "roads",
     {"kind": "major_road", "kind_detail": "tertiary", "id": 255330035,
      "name": "Battery St.", "sort_rank": 377})
 
 #https://www.openstreetmap.org/way/123456285
 assert_has_feature(
-    18, 41890, 101390, "roads",
+    16, 10472, 25347, "roads",
     {"kind": "highway", "kind_detail": "motorway_link", "id": 123456285,
      "name": "Junipero Serra Blvd.", "is_link": True, "sort_rank": 374})
 
 #https://www.openstreetmap.org/way/8919312
 assert_has_feature(
-    18, 41942, 101379, "roads",
+    16, 10485, 25344, "roads",
     {"kind": "minor_road", "kind_detail": "residential", "id": 8919312,
      "name": "Racine Ln.", "sort_rank": 360})
 
 #https://www.openstreetmap.org/way/59161514
 assert_has_feature(
-    18, 41908, 101294, "roads",
+    16, 10477, 25323, "roads",
     {"kind": "minor_road", "kind_detail": "service", "id": 59161514,
      "name": "Yacht Rd.", "sort_rank": 358})
 
 # service roads
 #https://www.openstreetmap.org/way/147002738
 assert_has_feature(
-    18, 41885, 101367, "roads",
+    16, 10471, 25341, "roads",
     {"kind": "minor_road", "kind_detail": "service", "service": "parking_aisle",
      "id": 147002738, "sort_rank": 356})
 
 #https://www.openstreetmap.org/way/242769687
 assert_has_feature(
-    18, 41949, 101316, "roads",
+    16, 10487, 25329, "roads",
     {"kind": "minor_road", "kind_detail": "service", "service": "driveway",
      "id": 242769687, "sort_rank": 356})

--- a/integration-test/546-road-sort-keys-tunnel.py
+++ b/integration-test/546-road-sort-keys-tunnel.py
@@ -1,7 +1,7 @@
 # tunnels at level = 0
 #https://www.openstreetmap.org/way/167952621
 assert_has_feature(
-    18, 41903, 101298, "roads",
+    16, 10475, 25324, "roads",
     {"kind": "highway", "kind_detail": "motorway", "id": 167952621,
      "name": "Presidio Pkwy.", "is_tunnel": True, "sort_rank": 333})
 
@@ -19,30 +19,30 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/way/117837633
 assert_has_feature(
-    18, 67234, 97737, "roads",
+    16, 16808, 24434, "roads",
     {"kind": "major_road", "kind_detail": "primary", "id": 117837633,
      "name": "Dixie Hwy.", "is_tunnel": True, "sort_rank": 330})
 
 #https://www.openstreetmap.org/way/57782075
 assert_has_feature(
-    18, 67251, 97566, "roads",
+    16, 16812, 24391, "roads",
     {"kind": "major_road", "kind_detail": "secondary", "id": 57782075,
      "name": "S Halsted St.", "is_tunnel": True, "sort_rank": 329})
 
 #https://www.openstreetmap.org/way/57708079
 assert_has_feature(
-    18, 67255, 97547, "roads",
+    16, 16813, 24386, "roads",
     {"kind": "major_road", "kind_detail": "tertiary", "id": 57708079,
      "name": "W 74th St.", "is_tunnel": True, "sort_rank": 327})
 
 #https://www.openstreetmap.org/way/56393654
 assert_has_feature(
-    18, 67233, 97449, "roads",
+    16, 16808, 24362, "roads",
     {"kind": "minor_road", "kind_detail": "residential", "id": 56393654,
      "name": "S Paulina St.", "is_tunnel": True, "sort_rank": 310})
 
 #https://www.openstreetmap.org/way/190835369
 assert_has_feature(
-    18, 67258, 97452, "roads",
+    16, 16814, 24363, "roads",
     {"kind": "minor_road", "kind_detail": "service", "id": 190835369,
      "name": "S Wong Pkwy.", "is_tunnel": True, "sort_rank": 308})

--- a/integration-test/549-subways.py
+++ b/integration-test/549-subways.py
@@ -1,3 +1,3 @@
 assert_has_feature(
-    18, 41891, 101394, 'roads',
+    16, 10472, 25348, 'roads',
     {'kind': 'rail', 'kind_detail': 'subway', 'id': 101647480, 'sort_rank': 382})

--- a/integration-test/558-default-brunnel-sort-keys.py
+++ b/integration-test/558-default-brunnel-sort-keys.py
@@ -1,53 +1,53 @@
 #https://www.openstreetmap.org/way/70656344
 assert_has_feature(
-    18, 41903, 101302, "roads",
+    16, 10475, 25325, "roads",
     {"kind": "path", "kind_detail": "footway", "id": 70656344,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/275618623
 assert_has_feature(
-    18, 41916, 101392, "roads",
+    16, 10479, 25348, "roads",
     {"kind": "path", "kind_detail": "path", "id": 275618623,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/8915047
 assert_has_feature(
-    18, 41878, 101381, "roads",
+    16, 10469, 25345, "roads",
     {"kind": "path", "kind_detail": "cycleway", "id": 8915047,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/109938341
 assert_has_feature(
-    18, 45204, 104883, "roads",
+    16, 11301, 26220, "roads",
     {"kind": "path", "kind_detail": "steps", "id": 109938341,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/66418490
 assert_has_feature(
-    18, 45513, 104896, "roads",
+    16, 11378, 26224, "roads",
     {"kind": "path", "kind_detail": "track", "id": 66418490,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/97639585
 assert_has_feature(
-    18, 41875, 101329, "roads",
+    16, 10468, 25332, "roads",
     {"kind": "path", "kind_detail": "footway", "id": 97639585,
      "sort_rank": 304})
 
 #https://www.openstreetmap.org/way/356449810
 assert_has_feature(
-    18, 41894, 101326, "roads",
+    16, 10473, 25331, "roads",
     {"kind": "path", "kind_detail": "path", "id": 356449810,
      "sort_rank": 304})
 
 #https://www.openstreetmap.org/way/338682183
 assert_has_feature(
-    18, 41883, 101370, "roads",
+    16, 10470, 25342, "roads",
     {"kind": "path", "kind_detail": "track", "id": 338682183,
      "sort_rank": 304})
 
 #https://www.openstreetmap.org/way/99231479
 assert_has_feature(
-    18, 41949, 101312, "roads",
+    16, 10487, 25328, "roads",
     {"kind": "path", "kind_detail": "steps", "id": 99231479,
      "sort_rank": 304})

--- a/integration-test/580-kind-csv.py
+++ b/integration-test/580-kind-csv.py
@@ -1,23 +1,23 @@
 #https://www.openstreetmap.org/node/1223019595
 assert_has_feature(
-    18, 41944, 101306, 'pois',
+    16, 10486, 25326, 'pois',
     { 'kind': 'post_office' })
 
 #https://www.openstreetmap.org/node/317081601
 assert_has_feature(
-    18, 41942, 101317, 'pois',
+    16, 10485, 25329, 'pois',
     { 'kind': 'museum' })
 
 #https://www.openstreetmap.org/node/3910307149
 #https://www.openstreetmap.org/way/387798241
 assert_has_feature(
-    18, 41951, 101317, 'pois',
+    16, 10487, 25329, 'pois',
     { 'kind': 'gate' })
 
 #https://www.openstreetmap.org/way/382798029
 #https://www.openstreetmap.org/way/382798035
 assert_has_feature(
-    18, 41867, 101362, 'pois',
+    16, 10466, 25340, 'pois',
     { 'kind': 'enclosure' })
 
 #http://www.openstreetmap.org/way/422270533
@@ -28,5 +28,5 @@ assert_has_feature(
 #https://www.openstreetmap.org/way/274459406
 #https://www.openstreetmap.org/way/274459420
 assert_has_feature(
-    18, 41913, 101317, 'landuse',
+    16, 10478, 25329, 'landuse',
     { 'kind': 'substation' })

--- a/integration-test/602-add-boat-rental.py
+++ b/integration-test/602-add-boat-rental.py
@@ -1,8 +1,8 @@
 tiles = [
-    [18, 66716, 99052], # node 2420432693 shop=boat_rental
-    [18, 53293, 86717], # node 2911709060 amenity=boat_rental
-    [18, 77832, 98089], # node 3466463119 shop=boat, rental=yes
-    [18, 42014, 101241] # node 3509468126 rental=boat
+    [16, 16679, 24763], # node 2420432693 shop=boat_rental
+    [16, 13323, 21679], # node 2911709060 amenity=boat_rental
+    [16, 19458, 24522], # node 3466463119 shop=boat, rental=yes
+    [16, 10503, 25310], # node 3509468126 rental=boat
 ]
 
 for z, x, y in tiles:

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -1,7 +1,7 @@
 # Node:358830410 Grave_yard in POIs
 # http://www.openstreetmap.org/node/358830410
 assert_has_feature(
-    17, 20950, 50704, 'pois',
+    16, 10475, 25352, 'pois',
     {'id': 358830410, 'kind': 'grave_yard'})
 
 # Way:79457493 Grave_yard in POIS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-AppDirs==1.4.0
+AppDirs==1.4.2
 argparse==1.2.1
 boto==2.33.0
 future==0.15.2


### PR DESCRIPTION
This updates all the coordinates used in the tests to use the equivalent at z16. I left the water boundaries and highline building high zoom coordinates because they seemed to be more sensitive to the zoom used.
