### PR TITLE
Control number of polygons in merge

### DIFF
--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -49,6 +49,11 @@ with features_in_mvt_layer(5, 17, 9, 'water') as features:
             assert 'Polygon' in geom_type
             ocean_area += area_of(geom['coordinates'])
 
-    expected = 7936264
-    if abs(abs(ocean_area) - expected) / expected > 0.05:
-        raise Exception("Ocean area %f, expected %f." % (abs(ocean_area), expected))
+    ocean_area = abs(ocean_area)
+    expected = 7326600
+    if ocean_area < expected:
+        raise Exception("Ocean area %f, expected at least %f."
+                        % (ocean_area, expected))
+    if ocean_area > 1.5 * expected:
+        raise Exception("Ocean area %f > 1.5 * expected %f"
+                        % (ocean_area, expected))

--- a/integration-test/502-water-boundaries-slow.py
+++ b/integration-test/502-water-boundaries-slow.py
@@ -2,7 +2,7 @@
 # boundaries. since we remove these, then we should have more than one water
 # polygon, but zero water boundaries actually in the tile.
 no_boundary_tiles = [
-    #https://www.openstreetmap.org/way/51858784
+    #https://www.openstreetmap.org/relation/2214015
     #https://www.openstreetmap.org/way/440165276
     [18, 74987, 100321], # Near Washington DC. USA
     #https://www.openstreetmap.org/relation/6333922

--- a/integration-test/546-road-sort-keys-railways.py
+++ b/integration-test/546-road-sort-keys-railways.py
@@ -28,10 +28,10 @@ assert_has_feature(
      "sort_rank": 382})
 
 # spurs, sidings, etc...
-#https://www.openstreetmap.org/way/106087318
+#https://www.openstreetmap.org/way/135403703
 assert_has_feature(
-    16, 10491, 25342, "roads",
-    {"kind": "rail", "kind_detail": "rail", "service": "spur", "id": 106087318,
+    16, 13353, 25941, "roads",
+    {"kind": "rail", "kind_detail": "rail", "service": "spur", "id": 135403703,
      "sort_rank": 361})
 
 #https://www.openstreetmap.org/way/148018328

--- a/integration-test/844-normalize-poi-kind.py
+++ b/integration-test/844-normalize-poi-kind.py
@@ -48,7 +48,7 @@ assert_has_feature(
     16, 10294, 25113, 'landuse',
     { 'id': 393312618, 'kind': 'park' })
 
-# http://www.openstreetmap.org/way/29191880
+# http://www.openstreetmap.org/way/469494860
 assert_has_feature(
-    16, 12393, 26315, 'landuse',
-    { 'id': 29191880, 'kind': 'natural_park' })
+    16, 17612, 24209, 'landuse',
+    { 'id': 469494860, 'kind': 'natural_park' })

--- a/queries.yaml
+++ b/queries.yaml
@@ -603,6 +603,7 @@ post_process:
         - name
         - addr_housenumber
         - addr_street
+      max_merged_features: 1000
 
   - fn: vectordatasource.transform.simplify_and_clip
     params: {simplify_before: 16}


### PR DESCRIPTION
Add configuration option to limit the number of shapes that can all be merged into one MultiPolygon.

This brings the time taken to call `geom.is_valid` down from 228s to 3s. The former means checking a 15,000 element MultiPolygon, the latter is checking 15 1,000 element MultiPolygons.

This cuts 80% of the time when generating tile `13/1314/3165`, near Oakland, which is particularly building-heavy.