### PR TITLE
Move merging of landuse polygons after roads intercut.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -405,12 +405,6 @@ post_process:
       where: >-
         pixel_area > area
       geom_types: [Polygon, MultiPolygon]
-  # merge any remaining polygons by their properties.
-  - fn: vectordatasource.transform.merge_polygon_features
-    params:
-      source_layer: landuse
-      start_zoom: 4
-      end_zoom: 12
 
   - fn: vectordatasource.transform.drop_features_where
     params:
@@ -615,6 +609,12 @@ post_process:
       attribute: kind
       target_attribute: landuse_kind
       cutting_attrs: { sort_key: 'sort_rank', reverse: True }
+  # merge any remaining polygons by their properties.
+  - fn: vectordatasource.transform.merge_polygon_features
+    params:
+      source_layer: landuse
+      start_zoom: 4
+      end_zoom: 12
 
   - fn: vectordatasource.transform.merge_line_features
     params:


### PR DESCRIPTION
Doing intercut against lare multipolygons can take a very significant amount of time (1400s for one tile!) because there are many components of the polygon to compare against. Moving it until after intercut means that they are mostly still single polygons, which compare more quickly.

There may be other side-effects with this. For example, it also moves the merging until after `simply_and_clip` which might change how the polygons appear, or how well they merge together.
