### PR TITLE
Drop small inners

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -603,7 +603,7 @@ post_process:
     params:
       end_zoom: 13
       source_layers: [landuse, water]
-      pixel_area: 0.001
+      pixel_area: 0.1
 
   - fn: vectordatasource.transform.simplify_and_clip
     params: {simplify_before: 16}

--- a/queries.yaml
+++ b/queries.yaml
@@ -599,6 +599,12 @@ post_process:
         - addr_street
       max_merged_features: 1000
 
+  - fn: vectordatasource.transform.drop_small_inners
+    params:
+      end_zoom: 13
+      source_layers: [landuse, water]
+      pixel_area: 0.001
+
   - fn: vectordatasource.transform.simplify_and_clip
     params: {simplify_before: 16}
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3663,7 +3663,6 @@ def _drop_small_inners(poly, area_tolerance):
     inners = []
     for inner in poly.interiors:
         area = Polygon(inner).area
-        import sys; print>>sys.stderr, "area: %f, area_tolerance: %f" % (area, area_tolerance)
         if area >= area_tolerance:
             inners.append(inner)
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3692,7 +3692,7 @@ def drop_small_inners(ctx):
         return None
 
     meters_per_pixel_area = calc_meters_per_pixel_area(zoom)
-    area_tolerance = meters_per_pixel_area**2 * pixel_area
+    area_tolerance = meters_per_pixel_area * pixel_area
 
     for layer in ctx.feature_layers:
         layer_datum = layer['layer_datum']
@@ -3709,14 +3709,14 @@ def drop_small_inners(ctx):
 
             if geom_type == 'Polygon':
                 new_shape = _drop_small_inners(shape, area_tolerance)
-                if new_shape:
+                if not new_shape.is_empty:
                     new_features.append((new_shape, props, fid))
 
             elif geom_type == 'MultiPolygon':
                 polys = []
                 for g in shape.geoms:
                     new_g = _drop_small_inners(g, area_tolerance)
-                    if new_g:
+                    if not new_g.is_empty:
                         polys.append(new_g)
                 if polys:
                     new_features.append((MultiPolygon(polys), props, fid))


### PR DESCRIPTION
At mid and low zooms, polygons with lots of small inners cause problems for simplification, validation, intercut and MVT generation. Dropping these small holes means that some operations are slightly faster, and many are more robust.