### PR TITLE
Specify id in test to fix failure

### DIFF
--- a/integration-test/593-early-footway.py
+++ b/integration-test/593-early-footway.py
@@ -47,7 +47,7 @@ assert_has_feature(
 #SF in the Avenues, way/344205837
 assert_no_matching_feature(
     14, 2617, 6333, 'roads',
-    {'kind': 'path', 'footway': 'sidewalk'})
+    {'id': 344205837, 'kind': 'path', 'footway': 'sidewalk'})
 
 #SF in the Avenues, way/344205837
 assert_has_feature(


### PR DESCRIPTION
There was no id in the `assert_no_matching_feature` call, and it started picking up a different osm way.