### PR TITLE
Fix min zoom for garden POIs.

### DIFF
--- a/integration-test/1185-garden-min-zoom.py
+++ b/integration-test/1185-garden-min-zoom.py
@@ -1,0 +1,10 @@
+# this garden previously had a min_zoom of 12, but based on its size should be
+# z16 instead.
+#
+# http://www.openstreetmap.org/way/273274870
+assert_has_feature(
+    16, 32182, 20422, 'landuse',
+    { 'kind': 'garden', 'id': 273274870, 'min_zoom': 16, 'tier': 6 })
+assert_has_feature(
+    16, 32182, 20422, 'pois',
+    { 'kind': 'garden', 'id': 273274870, 'min_zoom': 16, 'tier': 6 })

--- a/integration-test/829-garden-pois.py
+++ b/integration-test/829-garden-pois.py
@@ -3,7 +3,7 @@
 # garden with area in pois
 # https://www.openstreetmap.org/way/120480164
 assert_has_feature(
-    12, 654, 1583, 'pois',
+    13, 1309, 3166, 'pois',
     {'id': 120480164, 'kind': 'garden'})
 
 # garden with area in landuse

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -440,7 +440,7 @@ filters:
   # common - no POI
   # garden
   - filter: {leisure: garden}
-    min_zoom: { min: [ 12, { max: [ { lit: zoom }, { lit: *tier6_min_zoom } ] }, 16 ] }
+    min_zoom: { min: [ { max: [ 12, { lit: zoom }, { lit: *tier6_min_zoom } ] }, 16 ] }
     output: {kind: garden, tier: 6}
   # hedge - no POI
   # pedestrian - no POI


### PR DESCRIPTION
Added a test that small gardens mapped in Edinburgh are only visible at z16, not z12. Used the zoom spec from #1085, which seems to fit the general pattern better than just dropping the `12`.

Fixed up a test for which the garden was too small (according to `tier6_min_zoom`) to be visible at z12, bumped down to z13.

Note that tests will fail until #1187 is merged.

Connects to #1185.