### PR TITLE
Add walking route refs

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -106,7 +106,9 @@ FROM (
     WHERE
       parts && ARRAY[way_id] AND
       parts[way_off+1:rel_off] && ARRAY[way_id] AND
-      hstore(tags) ?& ARRAY['route','network']
+      hstore(tags) ? 'route' AND
+      (hstore(tags) ? 'network' OR
+       hstore(tags) ? 'ref')
     ) inner1
   ) inner2;
 $$ LANGUAGE sql STABLE;

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1063,12 +1063,9 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `all_bicycle_networks` and `all_bicycle_shield_texts`: All of the bicycle networks of which this road is a part, and each corresponding shield text. See `bicycle_network` and `bicycle_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
 * `bicycle_network`: Present if the feature is part of a cycling network. If so, the value will be one of `icn` for International Cycling Network, `ncn` for National Cycling Network, `rcn` for Regional Cycling Network, `lcn` for Local Cycling Network.
 * `bicycle_shield_text`: Contains text intended to be displayed on a shield related to the bicycle network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
-* `all_bus_networks` and `all_bus_shield_texts`: All of the bus routes of which this road is a part, and each corresponding shield text. See `bus_network` and `bus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
+* `all_bus_networks` and `all_bus_shield_texts`: All of the bus and trolley-bus routes of which this road is a part, and each corresponding shield text. See `bus_network` and `bus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
 * `bus_network`: Note that this is often not present for bus routes / networks. This may be replaced with `operator` in the future, see [issue 1194](https://github.com/tilezen/vector-datasource/issues/1194).
-* `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
-* `all_trolleybus_networks` and `all_trolleybus_shield_texts`: All of the trolleybus routes of which this road is a part, and each corresponding shield text. See `trolleybus_network` and `trolleybus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
-* `trolleybus_network`: Note that this is often not present for trolley-bus networks / routes.
-* `trolleybus_shield_text`: Contains text intended to be displayed on a shield related to the trolleybus route. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
+* `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus or trolley-bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
 * `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`.
 
 #### Road properties (optional):

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1035,13 +1035,9 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `all_networks` and `all_shield_texts`: All the networks of which this road is a part, and all of the shield texts. See `network` and `shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
 * `network`: eg: `US:I` for the United States Interstate network, useful for shields and road selections. This only contains _road_ network types. Please see `bicycle_network` and `walking_network` for bicycle and walking networks, respectively.
 * `shield_text`: Contains text to display on a shield. For example, I 90 would have a `network` of `US:I` and a `shield_text` of `90`. The `ref`, `I 90`, is less useful for shield display without further processing. _See planned bug fix in [#1062](https://github.com/tilezen/vector-datasource/issues/1062)._
-* `all_walking_networks` and `all_walking_shield_texts`: All of the walking networks of which this road is a part, and each corresponding shield text. See `walking_network` and `walking_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
-* `walking_network`: e.g: `nwn` for a "National Walking Network". Other common values include `iwn` for international, `rwn` for regional and `lwn` for local walking networks.
-* `walking_shield_text`: Contains text intended to be displayed on a shield related to the walking network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
 
 #### Road properties (common optional):
 
-* `bicycle_network`: Present if the feature is part of a cycling network. If so, the value will be one of `icn` for International Cycling Network, `ncn` for National Cycling Network, `rcn` for Regional Cycling Network, `lcn` for Local Cycling Network.
 * `cycleway`: `cycleway` tag from feature. If no `cycleway` tag is present but `cycleway:both` exists, we source from that tag instead.
 * `cycleway_left`: `cycleway_left` tag from feature
 * `cycleway_right`: `cycleway_right` tag from feature
@@ -1061,7 +1057,18 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `oneway`: `yes` or `no`. _See bug fix planned in [#1028](https://github.com/tilezen/vector-datasource/issues/1028)._
 * `segregated`: Set to `true` when a path allows both pedestrian and bicycle traffic, but when pedestrian traffic is segregated from bicycle traffic.
 * `service`: See value list below, provided for `railway` and `kind_detail=service` roads.
-* `walking_network`: Present if the feature is part of a hiking network. If so, the value will be one of `iwn` for International Walking Network, `nwn` for National Walking Network, `rwn` for Regional Walking Network, `lwn` for Local Walking Network.
+* `all_walking_networks` and `all_walking_shield_texts`: All of the walking networks of which this road is a part, and each corresponding shield text. See `walking_network` and `walking_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
+* `walking_network`: e.g: `nwn` for a "National Walking Network". Other common values include `iwn` for international, `rwn` for regional and `lwn` for local walking networks.
+* `walking_shield_text`: Contains text intended to be displayed on a shield related to the walking network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
+* `all_bicycle_networks` and `all_bicycle_shield_texts`: All of the bicycle networks of which this road is a part, and each corresponding shield text. See `bicycle_network` and `bicycle_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
+* `bicycle_network`: Present if the feature is part of a cycling network. If so, the value will be one of `icn` for International Cycling Network, `ncn` for National Cycling Network, `rcn` for Regional Cycling Network, `lcn` for Local Cycling Network.
+* `bicycle_shield_text`: Contains text intended to be displayed on a shield related to the bicycle network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
+* `all_bus_networks` and `all_bus_shield_texts`: All of the bus routes of which this road is a part, and each corresponding shield text. See `bus_network` and `bus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
+* `bus_network`: Note that this is often not present for bus routes / networks. This may be replaced with `operator` in the future, see [issue 1194](https://github.com/tilezen/vector-datasource/issues/1194).
+* `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
+* `all_trolleybus_networks` and `all_trolleybus_shield_texts`: All of the trolleybus routes of which this road is a part, and each corresponding shield text. See `trolleybus_network` and `trolleybus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
+* `trolleybus_network`: Note that this is often not present for trolley-bus networks / routes.
+* `trolleybus_shield_text`: Contains text intended to be displayed on a shield related to the trolleybus route. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
 
 #### Road properties (optional):
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1035,6 +1035,9 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `all_networks` and `all_shield_texts`: All the networks of which this road is a part, and all of the shield texts. See `network` and `shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
 * `network`: eg: `US:I` for the United States Interstate network, useful for shields and road selections. This only contains _road_ network types. Please see `bicycle_network` and `walking_network` for bicycle and walking networks, respectively.
 * `shield_text`: Contains text to display on a shield. For example, I 90 would have a `network` of `US:I` and a `shield_text` of `90`. The `ref`, `I 90`, is less useful for shield display without further processing. _See planned bug fix in [#1062](https://github.com/tilezen/vector-datasource/issues/1062)._
+* `all_walking_networks` and `all_walking_shield_texts`: All of the walking networks of which this road is a part, and each corresponding shield text. See `walking_network` and `walking_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
+* `walking_network`: e.g: `nwn` for a "National Walking Network". Other common values include `iwn` for international, `rwn` for regional and `lwn` for local walking networks.
+* `walking_shield_text`: Contains text intended to be displayed on a shield related to the walking network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
 
 #### Road properties (common optional):
 

--- a/integration-test/1175-bicycle-route-refs.py
+++ b/integration-test/1175-bicycle-route-refs.py
@@ -9,3 +9,16 @@ assert_has_feature(
       'bicycle_shield_text': '45',
       'all_bicycle_networks': ['lcn'],
       'all_bicycle_shield_texts': ['45'] })
+
+# make sure the all_* lists are gone by zoom 12 on major roads, but the "most
+# important" network & shield text remain until.
+assert_has_feature(
+    10, 163, 395, 'roads',
+    { 'bicycle_network': 'lcn',
+      'bicycle_shield_text': '45' })
+assert_no_matching_feature(
+    10, 163, 395, 'roads',
+    { 'all_bicycle_networks': None })
+assert_no_matching_feature(
+    10, 163, 395, 'roads',
+    { 'all_bicycle_shield_texts': None })

--- a/integration-test/1175-bicycle-route-refs.py
+++ b/integration-test/1175-bicycle-route-refs.py
@@ -1,0 +1,11 @@
+# https://www.openstreetmap.org/way/417389551
+#   lcn_ref=45
+# https://www.openstreetmap.org/relation/32310
+#   type=route, route=bicycle, network=lcn, ref=45
+assert_has_feature(
+    16, 10481, 25336, 'roads',
+    { 'id': 417389551,
+      'bicycle_network': 'lcn',
+      'bicycle_shield_text': '45',
+      'all_bicycle_networks': ['lcn'],
+      'all_bicycle_shield_texts': ['45'] })

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -1,0 +1,30 @@
+# https://www.openstreetmap.org/way/417097119
+# https://www.openstreetmap.org/relation/3002741
+#   type=route, route=bus, network="", ref=23
+# https://www.openstreetmap.org/relation/32312
+#   type=route, route=bicycle, network=lcn, ref=50
+# https://www.openstreetmap.org/relation/1976278
+#   type=route, route=road, network=US:CA, ref=35
+assert_has_feature(
+    16, 10469, 25340, 'roads',
+    { 'id': 417097119,
+      'network': 'US:CA',
+      'shield_text': '35',
+      'bicycle_network': 'lcn',
+      'bicycle_shield_text': '50',
+      'bus_network': type(None),
+      'bus_shield_text': '23' })
+
+# Jackson St. SF, part of trolley-bus route 3
+# http://www.openstreetmap.org/way/225516711
+# http://www.openstreetmap.org/relation/2980505
+#   outbound
+# http://www.openstreetmap.org/relation/2980504
+#   inbound
+assert_has_feature(
+    16, 10477, 25327, 'roads',
+    { 'id': 225516711,
+      'trolleybus_network': type(None),
+      'trolleybus_shield_text': '3',
+      'all_trolleybus_networks': [None, None],
+      'all_trolleybus_shield_texts': ['3', '3'] })

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -28,3 +28,16 @@ assert_has_feature(
       'trolleybus_shield_text': '3',
       'all_trolleybus_networks': [None, None],
       'all_trolleybus_shield_texts': ['3', '3'] })
+
+# make sure the all_* lists are gone by zoom 12 on major roads, but the "most
+# important" network & shield text remain until.
+assert_has_feature(
+    10, 163, 395, 'roads',
+    { 'trolleybus_network': type(None),
+      'trolleybus_shield_text': '3' })
+assert_no_matching_feature(
+    10, 163, 395, 'roads',
+    { 'all_trolleybus_networks': None })
+assert_no_matching_feature(
+    10, 163, 395, 'roads',
+    { 'all_trolleybus_shield_texts': None })

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -24,20 +24,20 @@ assert_has_feature(
 assert_has_feature(
     16, 10477, 25327, 'roads',
     { 'id': 225516711,
-      'trolleybus_network': type(None),
-      'trolleybus_shield_text': '3',
-      'all_trolleybus_networks': [None, None],
-      'all_trolleybus_shield_texts': ['3', '3'] })
+      'bus_network': type(None),
+      'bus_shield_text': '3',
+      'all_bus_networks': [None, None],
+      'all_bus_shield_texts': ['3', '3'] })
 
 # make sure the all_* lists are gone by zoom 12 on major roads, but the "most
 # important" network & shield text remain until.
 assert_has_feature(
     10, 163, 395, 'roads',
-    { 'trolleybus_network': type(None),
-      'trolleybus_shield_text': '3' })
+    { 'bus_network': type(None),
+      'bus_shield_text': '3' })
 assert_no_matching_feature(
     10, 163, 395, 'roads',
-    { 'all_trolleybus_networks': None })
+    { 'all_bus_networks': None })
 assert_no_matching_feature(
     10, 163, 395, 'roads',
-    { 'all_trolleybus_shield_texts': None })
+    { 'all_bus_shield_texts': None })

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -1,0 +1,15 @@
+# walking route constituent ways should have the walking route properties
+# projected onto them.
+#
+# https://www.openstreetmap.org/way/127908481
+# https://www.openstreetmap.org/relation/103942
+#   type=route, route=hiking, network=rwn, ref=416
+#
+# NOTE: it's part of two other relations, but these are not walking/hiking
+# routes.
+assert_has_feature(
+    15, 17571, 11449, 'roads',
+    { 'id': 127908481, 'kind': 'path', 'bicyle': type(None),
+      'walking_network': 'rwn', 'walking_shield_text': '416',
+      'all_walking_networks': [ 'rwn' ],
+      'all_walking_shield_texts': [ '416' ]})

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -13,3 +13,34 @@ assert_has_feature(
       'walking_network': 'rwn', 'walking_shield_text': '416',
       'all_walking_networks': [ 'rwn' ],
       'all_walking_shield_texts': [ '416' ]})
+
+# https://www.openstreetmap.org/way/373532611
+#   network=nwn, ref="PCT Section H"
+# https://www.openstreetmap.org/relation/1225378
+#   type=route, route=hiking, network=nwn, ref=PCT
+# https://www.openstreetmap.org/relation/1244828
+#   type=route, route=foot, network=rwn, ref=JMT
+# https://www.openstreetmap.org/relation/1244686
+#   type=route, route=foot, network=rwn, ref="", name="PCT - California Section H"
+assert_has_feature(
+    16, 11044, 25309, 'roads',
+    { 'id': 373532611,
+      'all_walking_networks': ['nwn', 'nwn', 'rwn', 'rwn'],
+      'all_walking_shield_texts' : [ 'PCT', 'PCT Section H', 'JMT', None] })
+
+# https://www.openstreetmap.org/way/417097119
+# https://www.openstreetmap.org/relation/3002741
+#   type=route, route=bus, network="", ref=23
+# https://www.openstreetmap.org/relation/32312
+#   type=route, route=bicycle, network=lcn, ref=50
+# https://www.openstreetmap.org/relation/1976278
+#   type=route, route=road, network=US:CA, ref=35
+assert_has_feature(
+    16, 10469, 25340, 'roads',
+    { 'id': 417097119,
+      'network': 'US:CA',
+      'shield_text': '35',
+      'bicycle_network': 'lcn',
+      'bicycle_shield_text': '50',
+      'bus_network': type(None),
+      'bus_shield_text': '23' })

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -28,20 +28,3 @@ assert_has_feature(
       'walking_network': 'nwn', 'walking_shield_text': 'PCT',
       'all_walking_networks': ['nwn', 'nwn', 'rwn', 'rwn'],
       'all_walking_shield_texts' : [ 'PCT', 'PCT Section H', 'JMT', None] })
-
-# https://www.openstreetmap.org/way/417097119
-# https://www.openstreetmap.org/relation/3002741
-#   type=route, route=bus, network="", ref=23
-# https://www.openstreetmap.org/relation/32312
-#   type=route, route=bicycle, network=lcn, ref=50
-# https://www.openstreetmap.org/relation/1976278
-#   type=route, route=road, network=US:CA, ref=35
-assert_has_feature(
-    16, 10469, 25340, 'roads',
-    { 'id': 417097119,
-      'network': 'US:CA',
-      'shield_text': '35',
-      'bicycle_network': 'lcn',
-      'bicycle_shield_text': '50',
-      'bus_network': type(None),
-      'bus_shield_text': '23' })

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -25,6 +25,7 @@ assert_has_feature(
 assert_has_feature(
     16, 11044, 25309, 'roads',
     { 'id': 373532611,
+      'walking_network': 'nwn', 'walking_shield_text': 'PCT',
       'all_walking_networks': ['nwn', 'nwn', 'rwn', 'rwn'],
       'all_walking_shield_texts' : [ 'PCT', 'PCT Section H', 'JMT', None] })
 

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -28,3 +28,20 @@ assert_has_feature(
       'walking_network': 'nwn', 'walking_shield_text': 'PCT',
       'all_walking_networks': ['nwn', 'nwn', 'rwn', 'rwn'],
       'all_walking_shield_texts' : [ 'PCT', 'PCT Section H', 'JMT', None] })
+
+# https://www.openstreetmap.org/way/417097119
+# https://www.openstreetmap.org/relation/3002741
+#   type=route, route=bus, network="", ref=23
+# https://www.openstreetmap.org/relation/32312
+#   type=route, route=bicycle, network=lcn, ref=50
+# https://www.openstreetmap.org/relation/1976278
+#   type=route, route=road, network=US:CA, ref=35
+assert_has_feature(
+    16, 10469, 25340, 'roads',
+    { 'id': 417097119,
+      'network': 'US:CA',
+      'shield_text': '35',
+      'bicycle_network': 'lcn',
+      'bicycle_shield_text': '50',
+      'bus_network': type(None),
+      'bus_shield_text': '23' })

--- a/queries.yaml
+++ b/queries.yaml
@@ -509,7 +509,29 @@ post_process:
       source_layer: roads
       start_zoom: 0
       end_zoom: 14
-      properties: [name, ref, network, shield_text, all_networks, all_shield_texts]
+      properties:
+        - name
+        - ref
+        - network
+        - shield_text
+        - all_networks
+        - all_shield_texts
+        - bicycle_network
+        - bicycle_shield_text
+        - all_bicycle_networks
+        - all_bicycle_shield_texts
+        - walking_network
+        - walking_shield_text
+        - all_walking_networks
+        - all_walking_shield_texts
+        - trolleybus_network
+        - trolleybus_shield_text
+        - all_trolleybus_networks
+        - all_trolleybus_shield_texts
+        - bus_network
+        - bus_shield_text
+        - all_bus_networks
+        - all_bus_shield_texts
       where: >-
         (kind == 'rail' and zoom < 15) or
         (kind == 'minor_road' and zoom < 14) or
@@ -521,7 +543,18 @@ post_process:
       source_layer: roads
       start_zoom: 7
       end_zoom: 10
-      properties: [name, all_networks, all_shield_texts]
+      properties:
+        - name
+        - all_networks
+        - all_shield_texts
+        - all_bicycle_networks
+        - all_bicycle_shield_texts
+        - all_walking_networks
+        - all_walking_shield_texts
+        - all_trolleybus_networks
+        - all_trolleybus_shield_texts
+        - all_bus_networks
+        - all_bus_shield_texts
       where: >-
         kind == 'major_road'
   # this is a patch to get rid of name, but keep ref & network, for highways

--- a/queries.yaml
+++ b/queries.yaml
@@ -522,10 +522,6 @@ post_process:
         - all_bicycle_shield_texts
         - all_walking_networks
         - all_walking_shield_texts
-        - trolleybus_network
-        - trolleybus_shield_text
-        - all_trolleybus_networks
-        - all_trolleybus_shield_texts
         - bus_network
         - bus_shield_text
         - all_bus_networks
@@ -561,8 +557,6 @@ post_process:
         - all_bicycle_shield_texts
         - all_walking_networks
         - all_walking_shield_texts
-        - all_trolleybus_networks
-        - all_trolleybus_shield_texts
         - all_bus_networks
         - all_bus_shield_texts
       where: >-
@@ -584,7 +578,32 @@ post_process:
       source_layer: roads
       start_zoom: 0
       end_zoom: 6
-      properties: [name, ref, all_networks, all_shield_texts]
+      properties:
+        - name
+        - ref
+        - all_networks
+        - all_shield_texts
+        - walking_network
+        - walking_shield_text
+      where: >-
+        kind == 'highway'
+  # drop non-road shield stuff a good deal earlier.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 10
+      properties:
+        - bicycle_network
+        - bicycle_shield_text
+        - all_bicycle_networks
+        - all_bicycle_shield_texts
+        - all_walking_networks
+        - all_walking_shield_texts
+        - bus_network
+        - bus_shield_text
+        - all_bus_networks
+        - all_bus_shield_texts
       where: >-
         kind == 'highway'
   - fn: vectordatasource.transform.update_parenthetical_properties

--- a/queries.yaml
+++ b/queries.yaml
@@ -520,8 +520,6 @@ post_process:
         - bicycle_shield_text
         - all_bicycle_networks
         - all_bicycle_shield_texts
-        - walking_network
-        - walking_shield_text
         - all_walking_networks
         - all_walking_shield_texts
         - trolleybus_network
@@ -535,6 +533,18 @@ post_process:
       where: >-
         (kind == 'rail' and zoom < 15) or
         (kind == 'minor_road' and zoom < 14) or
+        (kind == 'major_road' and zoom <  7)
+  # previous tests assume we keep walking network information until zoom 11
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 10
+      properties:
+        - walking_network
+        - walking_shield_text
+      where: >-
+        (kind == 'rail') or (kind == 'minor_road') or
         (kind == 'major_road' and zoom <  7)
   # this is a patch because we still want to drop name, network from major_road
   # features between zoom 7 and 10

--- a/queries.yaml
+++ b/queries.yaml
@@ -93,6 +93,7 @@ layers:
       - vectordatasource.transform.normalize_aerialways
       - vectordatasource.transform.normalize_cycleway
       - vectordatasource.transform.add_is_bicycle_related
+      - vectordatasource.transform.merge_networks_from_tags
       - vectordatasource.transform.extract_network_information
       - vectordatasource.transform.choose_most_important_network
       - vectordatasource.transform.road_trim_properties

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3943,6 +3943,14 @@ _WALKING_NETWORK_CODES = {
 }
 
 
+_BICYCLE_NETWORK_CODES = {
+    'icn': 1,
+    'ncn': 2,
+    'rcn': 3,
+    'lcn': 4,
+}
+
+
 def _generic_network_importance(network, ref, codes):
     # get a code based on the "largeness" of the network
     code = codes.get(network, len(codes))
@@ -3961,6 +3969,14 @@ def _generic_network_importance(network, ref, codes):
 
 def _walking_network_importance(network, ref):
     return _generic_network_importance(network, ref, _WALKING_NETWORK_CODES)
+
+
+def _bicycle_network_importance(network, ref):
+    return _generic_network_importance(network, ref, _BICYCLE_NETWORK_CODES)
+
+
+def _bus_network_importance(network, ref):
+    return _generic_network_importance(network, ref, {})
 
 
 _NUMBER_AT_FRONT = re.compile('^(\d+\w*)', re.UNICODE)
@@ -4040,11 +4056,21 @@ _FOOT_NETWORK = _Network(
     'walking_',
     _default_shield_text,
     _walking_network_importance)
+_BIKE_NETWORK = _Network(
+    'bicycle_',
+    _default_shield_text,
+    _bicycle_network_importance)
+_BUS_NETWORK = _Network(
+    'bus_',
+    _default_shield_text,
+    _bus_network_importance)
 
 _NETWORKS = {
     'road': _ROAD_NETWORK,
     'foot': _FOOT_NETWORK,
     'hiking': _FOOT_NETWORK,
+    'bicycle': _BIKE_NETWORK,
+    'bus': _BUS_NETWORK,
 }
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4064,6 +4064,10 @@ _BUS_NETWORK = _Network(
     'bus_',
     _default_shield_text,
     _bus_network_importance)
+_TROLLEYBUS_NETWORK = _Network(
+    'trolleybus_',
+    _default_shield_text,
+    _bus_network_importance)
 
 _NETWORKS = {
     'road': _ROAD_NETWORK,
@@ -4071,6 +4075,7 @@ _NETWORKS = {
     'hiking': _FOOT_NETWORK,
     'bicycle': _BIKE_NETWORK,
     'bus': _BUS_NETWORK,
+    'trolleybus': _TROLLEYBUS_NETWORK,
 }
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4065,10 +4065,6 @@ _BUS_NETWORK = _Network(
     'bus_',
     _default_shield_text,
     _bus_network_importance)
-_TROLLEYBUS_NETWORK = _Network(
-    'trolleybus_',
-    _default_shield_text,
-    _bus_network_importance)
 
 _NETWORKS = {
     'road': _ROAD_NETWORK,
@@ -4076,7 +4072,7 @@ _NETWORKS = {
     'hiking': _FOOT_NETWORK,
     'bicycle': _BIKE_NETWORK,
     'bus': _BUS_NETWORK,
-    'trolleybus': _TROLLEYBUS_NETWORK,
+    'trolleybus': _BUS_NETWORK,
 }
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3943,14 +3943,6 @@ _WALKING_NETWORK_CODES = {
 }
 
 
-_BICYCLE_NETWORK_CODES = {
-    'icn': 1,
-    'ncn': 2,
-    'rcn': 3,
-    'lcn': 4,
-}
-
-
 def _generic_network_importance(network, ref, codes):
     # get a code based on the "largeness" of the network
     code = codes.get(network, len(codes))
@@ -3969,14 +3961,6 @@ def _generic_network_importance(network, ref, codes):
 
 def _walking_network_importance(network, ref):
     return _generic_network_importance(network, ref, _WALKING_NETWORK_CODES)
-
-
-def _bicycle_network_importance(network, ref):
-    return _generic_network_importance(network, ref, _BICYCLE_NETWORK_CODES)
-
-
-def _bus_network_importance(network, ref):
-    return _generic_network_importance(network, ref, {})
 
 
 _NUMBER_AT_FRONT = re.compile('^(\d+\w*)', re.UNICODE)
@@ -4056,21 +4040,11 @@ _FOOT_NETWORK = _Network(
     'walking_',
     _default_shield_text,
     _walking_network_importance)
-_BIKE_NETWORK = _Network(
-    'bicycle_',
-    _default_shield_text,
-    _bicycle_network_importance)
-_BUS_NETWORK = _Network(
-    'bus_',
-    _default_shield_text,
-    _bus_network_importance)
 
 _NETWORKS = {
     'road': _ROAD_NETWORK,
     'foot': _FOOT_NETWORK,
     'hiking': _FOOT_NETWORK,
-    'bicycle': _BIKE_NETWORK,
-    'bus': _BUS_NETWORK,
 }
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4081,8 +4081,6 @@ def extract_network_information(shape, properties, fid, zoom):
     """
 
     mz_networks = properties.pop('mz_networks', None)
-    if fid == 417097119:
-        import sys; print>>sys.stderr, repr(mz_networks)
 
     if mz_networks is not None:
         # take the list and make triples out of it

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -20,7 +20,6 @@ global:
       motor_vehicle: {col: tags->motor_vehicle}
       service: {col: service}
       sport: {col: sport}
-      walking_network: {expr: "mz_hiking_network(osm_id)"}
       bicycle_network: {expr: "mz_cycling_network(tags, osm_id)"}
       oneway: {col: oneway}
       oneway_bicycle: {col: "tags->oneway:bicycle"}

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -45,10 +45,9 @@ global:
       sidewalk: {col: sidewalk}
       sidewalk_left: {col: 'sidewalk:left'}
       sidewalk_right: {col: 'sidewalk:right'}
-  - &osm_network_from_relation
+  - &osm_network
       mz_networks: {expr: "mz_get_rel_networks(osm_id)"}
-  - &osm_network_from_tags
-      network: {col: tags->network}
+      network: {col: network}
   - &osm_piste_properties
       kind: piste
       layer: {col: layer}
@@ -188,7 +187,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: highway
       kind_detail: motorway
   - filter:
@@ -197,7 +196,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: major_road
       kind_detail: {col: highway}
   - filter:
@@ -206,7 +205,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: major_road
       kind_detail: secondary
   - filter:
@@ -215,7 +214,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: highway
       kind_detail: motorway_link
   - filter:
@@ -224,7 +223,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: major_road
       kind_detail: tertiary
   - filter:
@@ -233,7 +232,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: major_road
       kind_detail: trunk_link
   - filter:
@@ -242,7 +241,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: major_road
       kind_detail: {col: highway}
   - filter:
@@ -251,7 +250,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_relation
+      <<: *osm_network
       kind: major_road
       kind_detail: tertiary_link
   #############################################################
@@ -268,7 +267,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: portage_way
   #############################################################
   #
@@ -281,7 +280,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: minor_road
       kind_detail: {col: highway}
   - filter:
@@ -290,7 +289,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: minor_road
       kind_detail: living_street
   - filter:
@@ -299,7 +298,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: pedestrian
@@ -309,7 +308,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: {col: highway}
@@ -326,7 +325,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: footway
@@ -345,7 +344,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: steps
@@ -357,7 +356,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: footway
@@ -368,7 +367,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: {col: highway}
@@ -378,7 +377,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: corridor
@@ -389,7 +388,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: minor_road
       kind_detail: service
       service: alley
@@ -400,7 +399,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: minor_road
       kind_detail: service
       service:
@@ -412,7 +411,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: minor_road
       kind_detail: service
   - filter: {highway: raceway}
@@ -433,7 +432,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: aeroway
       kind_detail: runway
   - filter:
@@ -442,7 +441,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: aeroway
       kind_detail: taxiway
   #############################################################
@@ -457,7 +456,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: rail
       kind_detail: rail
       service: {col: service}
@@ -468,7 +467,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: rail
       kind_detail: rail
       service: {col: service}
@@ -479,7 +478,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: rail
       kind_detail: rail
       service: {col: service}
@@ -500,7 +499,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: rail
       kind_detail: rail
       railway: {col: railway}
@@ -511,7 +510,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: rail
       kind_detail: rail
   - filter:
@@ -520,7 +519,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: rail
       kind_detail: {col: railway}
   #############################################################
@@ -534,7 +533,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: ferry
   #############################################################
   #
@@ -547,7 +546,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: aerialway
       kind_detail: {col: aerialway}
   - filter:
@@ -556,7 +555,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: aerialway
       kind_detail: {col: aerialway}
   - filter:
@@ -578,7 +577,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       kind: aerialway
       kind_detail:
         expr:
@@ -615,7 +614,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       # note: racetrack rather than track, as track might be confusing
       # between a track for racing and a track as in a faint trail.
       kind: racetrack
@@ -632,7 +631,7 @@ filters:
     table: osm
     output:
       <<: *osm_highway_properties
-      <<: *osm_network_from_tags
+      <<: *osm_network
       <<: *osm_footway_properties
       kind: path
       kind_detail: pier


### PR DESCRIPTION
Networks and refs are taken both from the tags on the way (if they look like `*wn` networks) and from relations that the way might be part of. The logic for road shields is re-used and extended to provide all the networks and `shield_text`s, and select the most important to be `walking_network` and `walking_shield_text`.

This now means that route information is requested for almost all road types, which might make the queries slower. They haven't been noticeably so on my local system, but we'll have to wait and see what they look like on dev.

Connects to #775.
