### PR TITLE
add bicyle tag to roads

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1047,7 +1047,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `sidewalk_right`: `sidewalk:right` tag from feature
 * `ferry`: See kind list below.
 * `footway`: sidewalk or crossing
-* `is_bicycle_related`: Present and `true` when road features is a dedicated cycleway, part of an OSM bicycle network route relation, or includes cycleway infrastructure like bike lanes or designed for shared use.
+* `is_bicycle_related`: Present and `true` when road features is a dedicated cycleway, part of an OSM bicycle network route relation, or includes cycleway infrastructure like bike lanes, or tagged bicycle=yes or bicycle=designated for shared use.
 * `is_bridge`: `true` if the road is part of a bridge. The property will not be present if the road is not part of a bridge.
 * `is_bus_route`: If present and `true`, then buses or trolley-buses travel down this road. This property is determined based on whether the road is part of an OSM bus route relation, and is only present on roads at zoom 12 and higher.
 * `is_link`: `true` if the road is part of a highway link or ramp. The property will not be present if the road is not part of a highway link or ramp.
@@ -1063,6 +1063,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 #### Road properties (optional):
 
 * `ascent`: ski pistes from OpenStreetMap
+* `bicycle`: `yes`, `no`, `designated`, `dismount`, and other values from OpenStreetMap
 * `colour`: ski pistes from OpenStreetMap
 * `descent`: ski pistes from OpenStreetMap
 * `description`: OpenStreetMap features

--- a/integration-test/1171-bicycle-yes-designated-roads.py
+++ b/integration-test/1171-bicycle-yes-designated-roads.py
@@ -1,0 +1,13 @@
+# Add bicycle properties to roads
+
+# Road with bicycle=yes in Washington, DC
+# http://www.openstreetmap.org/way/281677984
+assert_has_feature(
+    15, 9379, 12539, 'roads',
+    { 'id': 281677984, 'kind': 'major_road', 'is_bicycle_related': True, 'bicycle': 'yes'})
+
+# Road with bicycle=designated in Eureka, California
+# http://www.openstreetmap.org/way/10273013
+assert_has_feature(
+    15, 5081, 12311, 'roads',
+    { 'id': 10273013, 'kind': 'major_road', 'is_bicycle_related': True, 'bicycle': 'designated'})

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -77,7 +77,6 @@ global:
       snowshoe: {col: tags->snowshoe}
       symbol: {col: tags->symbol}
   - &osm_footway_properties
-      bicycle: {col: bicycle}
       foot: {col: foot}
       horse: {col: horse}
       tracktype: {col: tracktype}

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -18,6 +18,7 @@ global:
       roundtrip: {col: tags->roundtrip}
       route_name: {col: tags->route_name}
       motor_vehicle: {col: tags->motor_vehicle}
+      bicycle: {col: bicycle}
       service: {col: service}
       sport: {col: sport}
       walking_network: {expr: "mz_hiking_network(osm_id)"}


### PR DESCRIPTION
Connects with #1171 to add bicyle tag to roads

- [x] Update tests
- [x] Updated docs

No change to [transform logic](https://github.com/tilezen/vector-datasource/blob/150b660946fed6f1328450fd9a20eeb88a7d3518/vectordatasource/transform.py#L3590) fir `is_bicycle_related` as it's already working for paths but the required bicycle tag just wasn't present on roads (fixed in this PR).

I don't think this needs a data migration (it's an optional extra tag at select time).