### PR TITLE
Update data for the High Line, NYC

### DIFF
--- a/integration-test/197-clip-buildings.py
+++ b/integration-test/197-clip-buildings.py
@@ -3,7 +3,7 @@ from shapely.geometry import shape
 # this is mid way along the High Line in NYC, which is a huge long
 # "building". we should be clipping it to a buffer of 3x the tile
 # dimensions.
-# http://www.openstreetmap.org/way/37054313
+# http://www.openstreetmap.org/relation/7141751
 with features_in_tile_layer(16, 19295, 24631, 'buildings') as buildings:
     # max width and height in degress as 3x the size of the above tile
     max_w = 0.0164794921875
@@ -17,7 +17,7 @@ with features_in_tile_layer(16, 19295, 24631, 'buildings') as buildings:
         w = bounds[2] - bounds[0]
         h = bounds[3] - bounds[1]
 
-        if building['properties']['id'] == 37054313:
+        if building['properties']['id'] == -7141751:
             saw_the_high_line = True
 
         if w > max_w or h > max_h:


### PR DESCRIPTION
Looks like it was turned into a multipolygon relation in [this changeset](http://www.openstreetmap.org/changeset/47542769).
