### PR TITLE
Remove `natural_wood` and `natural_forest` POIs.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -870,8 +870,6 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `museum`
 * `music`
 * `national_park`
-* `natural_forest` - _See planned bug fixes in [#1103](https://github.com/tilezen/vector-datasource/issues/1103)._
-* `natural_wood` - _See planned bug fixes in [#1103](https://github.com/tilezen/vector-datasource/issues/1103)._
 * `nature_reserve`
 * `newspaper`
 * `ngo`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -979,7 +979,6 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `university`
 * `veterinary`
 * `viewpoint`
-* `village_green`
 * `volcano` The peak of a volcano. See above for properties available on peaks and volcanos.
 * `walking_junction` - Common in Europe for signed walking routes with named junctions. The walking network reference point's `ref` value is derived from one of `iwn_ref`, `nwn_ref`, `rwn_ref` or `lwn_ref`, in descending order and is suitable for naming or use in a shield.
 * `waste_basket`

--- a/integration-test/1103-no-natural-pois.py
+++ b/integration-test/1103-no-natural-pois.py
@@ -1,0 +1,31 @@
+# example from ticket: an unnamed natural=wood in Hyde Park, London
+# http://www.openstreetmap.org/relation/1756198
+# since this is unnamed, it might already get dropped as a POI, and won't have
+# a landuse label, so this checks for the polygon.
+assert_has_feature(
+    16, 32737, 21792, 'landuse',
+    { 'id': -1756198, 'kind': 'natural_wood' })
+assert_no_matching_feature(
+    16, 32737, 21792, 'pois',
+    { 'id': -1756198, 'kind': 'natural_wood' })
+
+# named area, should get a label placement. note that we currently only add
+# landuse label placements at zoom 15+.
+# Mt. Cydonia Ponds Natural Area
+# http://www.openstreetmap.org/relation/6366946
+assert_has_feature(
+    15, 9327, 12418, 'landuse',
+    { 'id': -6366946, 'kind': 'natural_wood', 'label_placement': True })
+assert_no_matching_feature(
+    15, 9327, 12418, 'pois',
+    { 'id': -6366946, 'kind': 'natural_wood' })
+
+# same, but for a forest
+# Liebesinsel, nr. Berlin, Germany
+# http://www.openstreetmap.org/way/316516905
+assert_has_feature(
+    16, 35199, 21454, 'landuse',
+    { 'id': 316516905, 'kind': 'natural_forest', 'label_placement': True })
+assert_no_matching_feature(
+    16, 35199, 21454, 'pois',
+    { 'id': 316516905, 'kind': 'natural_forest' })

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -71,18 +71,22 @@ assert_has_feature(
 
 # Way: natural: Forest in POIS
 # http://www.openstreetmap.org/way/202680509
-assert_has_feature(
+# note: since #1103, there should be no POIs for natural_forest, only label
+# placements in the landuse layer.
+assert_no_matching_feature(
     14, 4877, 6109, 'pois',
     {'id': 202680509, 'kind': 'natural_forest'})
 
 # Label placement forest in landuse
-assert_no_matching_feature(
+assert_has_feature(
     15, 9755, 12218, 'landuse',
     {'id': 202680509, 'kind': 'natural_forest', 'label_placement': True})
 
 # natural: Forest in POIS
 # http://www.openstreetmap.org/node/4633280957
-assert_has_feature(
+# note: since #1103, there should be no POIs for natural_forest, only label
+# placements in the landuse layer.
+assert_no_matching_feature(
     14, 11852, 7770, 'pois',
     {'id': 4633280957, 'kind': 'natural_forest', 'min_zoom': 14})
 
@@ -332,20 +336,24 @@ assert_no_matching_feature(
 
 # natural: wood in POIS
 # http://www.openstreetmap.org/way/249171216
-assert_has_feature(
+# note: since #1103, there should be no POIs for natural_wood, only label
+# placements in the landuse layer.
+assert_no_matching_feature(
     14, 8107, 5426, 'pois',
     {'id': 249171216, 'kind': 'natural_wood'})
 
 # Label placement natural: wood in landuse
-assert_no_matching_feature(
+assert_has_feature(
     15, 16214, 10852, 'landuse',
     {'id': 249171216, 'kind': 'natural_wood', 'label_placement': True})
 
 # Node:369162231 natural: wood in POIS
 # http://www.openstreetmap.org/node/369162231
-assert_has_feature(
+# note: since #1103, there should be no POIs for natural_wood, only label
+# placements in the landuse layer.
+assert_no_matching_feature(
     14, 2612, 6298, 'pois',
-    {'id': 369162231, 'kind': 'natural_wood', 'min_zoom': 14})
+    {'id': 369162231, 'kind': 'natural_wood'})
 
 # works in POIS
 # http://www.openstreetmap.org/way/161371157

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -257,18 +257,20 @@ assert_has_feature(
 
 # village_green in POIS
 # http://www.openstreetmap.org/way/128479579
-assert_has_feature(
+# note: since #1103, there should be no POIs for village_green, only label
+# placements in the landuse layer.
+assert_no_matching_feature(
     14, 6000, 9246, 'pois',
     {'id': 128479579, 'kind': 'village_green', 'min_zoom': 13.23})
 
 # Label placement village_green in landuse
-assert_no_matching_feature(
+assert_has_feature(
     16, 24002, 36987, 'landuse',
     {'id': 128479579, 'kind': 'village_green', 'label_placement': True})
 
 # Node:3199567035 village_green in POIS
 # http://www.openstreetmap.org/node/3199567035
-assert_has_feature(
+assert_no_matching_feature(
     14, 4186, 6018, 'pois',
     {'id': 3199567035, 'kind': 'village_green', 'min_zoom': 14})
 

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1120,10 +1120,6 @@ filters:
     min_zoom: GREATEST( LEAST(zoom + 3, 14), 12)
     output:
       kind: quarry
-  - filter: {landuse: village_green}
-    min_zoom: GREATEST( LEAST(zoom + 3, 14), 12)
-    output:
-      kind: village_green
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -288,16 +288,6 @@ filters:
     min_zoom: { min: [ { max: [ 10, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
     output: { kind: wood, tier: 2 }
 
-  # natural forests - note already clamped to z12
-  - filter: {natural: forest}
-    min_zoom: { min: [ { max: [ 12, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
-    output: { kind: natural_forest, tier: 2 }
-
-  # natural woods - note already clampted to 12
-  - filter: {natural: wood}
-    min_zoom: { min: [ { max: [ 12, { lit: zoom + 2 }, { lit: *tier2_min_zoom } ] }, 14 ] }
-    output: { kind: natural_wood, tier: 2 }
-
   # farm
   - filter: {landuse: farm}
     min_zoom: { max: [ 15, { lit: *tier2_min_zoom } ] }


### PR DESCRIPTION
These are no longer present in the POIs layer, but will be present in the landuse layer as label placements.

Connects to #1103.

@nvkelso: One side-effect of this is that `natural=wood` or `natural=forest` nodes will disappear, as we do not select point features for the landuse layer. We only create points from polygons as label placements. Is that the desired behaviour, or should we also include landuse nodes as label placement points?