### PR TITLE
Fix road network transforms when network tag is null.

### DIFF
--- a/integration-test/1211-fix-null-network.py
+++ b/integration-test/1211-fix-null-network.py
@@ -1,0 +1,6 @@
+# http://www.openstreetmap.org/relation/2307408
+# ref="N 4", route=road, but no network=*
+# so we should get something that has no network, but a shield text of '4'
+assert_has_feature(
+    11, 1038, 705, 'roads',
+    { 'kind': 'major_road', 'shield_text': '4', 'network': type(None) })

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3954,7 +3954,9 @@ def _road_network_importance(network, ref):
     network.
     """
 
-    if network == 'US:I' or ':national' in network:
+    if network is None:
+        network_code = 9999
+    elif network == 'US:I' or ':national' in network:
         network_code = 1
     elif network == 'US:US' or ':regional' in network:
         network_code = 2
@@ -4035,18 +4037,18 @@ def _road_shield_text(network, ref):
 
     # These "belt" roads have names in the ref which should be in the shield,
     # there's no number.
-    if network == 'US:PA:Belt':
+    if network and network == 'US:PA:Belt':
         return ref
 
     # Ukranian roads sometimes have internal dashes which should be removed.
-    if network.startswith('ua:'):
+    if network and network.startswith('ua:'):
         m = _UA_TERRITORIAL_RE.match(ref)
         if m:
             return m.group(1) + m.group(2) + m.group(3)
 
     # Greek roads sometimes have alphabetic prefixes which we should _keep_,
     # unlike for other roads.
-    if network.startswith('GR:') or network.startswith('gr:'):
+    if network and (network.startswith('GR:') or network.startswith('gr:')):
         return ref
 
     # If there's a number at the front (optionally with letters following),


### PR DESCRIPTION
#1193 allowed the inclusion of routes with no `network` tag, but this broke some processing functions.

Connects to #1211.