### PR TITLE
Fix migrations and tests for dev

### DIFF
--- a/data/migrations/v1.3.0-point.sql
+++ b/data/migrations/v1.3.0-point.sql
@@ -4,5 +4,6 @@ UPDATE
   WHERE
     (tags -> 'leisure' = 'garden' OR
      tags -> 'landuse' = 'village_green' OR
-     tags -> 'natural' IN ('wood', 'forest'))
+     tags -> 'natural' IN ('wood', 'forest') OR
+     (NOT tags ? 'name' AND mz_poi_min_zoom IS NOT NULL))
     AND COALESCE(mz_poi_min_zoom, 999) <> COALESCE(mz_calculate_min_zoom_pois(p.*), 999);

--- a/data/migrations/v1.3.0-polygon.sql
+++ b/data/migrations/v1.3.0-polygon.sql
@@ -1,8 +1,13 @@
 UPDATE
   planet_osm_polygon p
-  SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(p.*)
+  SET mz_poi_min_zoom = mz_calculate_min_zoom_pois(p.*),
+      mz_landuse_min_zoom = mz_calculate_min_zoom_landuse(p.*)
   WHERE
     (tags -> 'leisure' = 'garden' OR
      tags -> 'landuse' = 'village_green' OR
-     tags -> 'natural' IN ('wood', 'forest'))
-    AND COALESCE(mz_poi_min_zoom, 999) <> COALESCE(mz_calculate_min_zoom_pois(p.*), 999);
+     tags -> 'natural' IN ('wood', 'forest') OR
+     (NOT tags ? 'name' AND mz_poi_min_zoom IS NOT NULL))
+    AND (
+      COALESCE(mz_poi_min_zoom, 999) <> COALESCE(mz_calculate_min_zoom_pois(p.*), 999) OR
+      COALESCE(mz_landuse_min_zoom, 999) <> COALESCE(mz_calculate_min_zoom_landuse(p.*), 999)
+    );

--- a/integration-test.py
+++ b/integration-test.py
@@ -160,8 +160,7 @@ def match_distance(actual, expected):
 
 
 class GatewayTimeout(Exception):
-    def __init__(self, message):
-        self.message = message
+    pass
 
 
 def tile_url(z, x, y, layer):

--- a/integration-test.py
+++ b/integration-test.py
@@ -159,21 +159,57 @@ def match_distance(actual, expected):
     return (distance, misses)
 
 
-@contextmanager
-def features_in_tile_layer(z, x, y, layer):
+class GatewayTimeout(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+def tile_url(z, x, y, layer):
     assert config_url, "Tile URL is not configured, is your config file set up?"
     request_layer = 'all' if config_all_layers else layer
     url = config_url % {'layer': request_layer, 'z': z, 'x': x, 'y': y}
+    return url
+
+
+def fetch_tile_http(url):
     r = requests.get(url)
 
-    if r.status_code != 200:
+    if r.status_code == 504:
+        raise GatewayTimeout("Timeout for tile %r" % url)
+    elif r.status_code != 200:
         raise Exception("Tile %r: error while fetching, status=%d"
                         % (url, r.status_code))
+
+    return r
+
+
+def fetch_tile_http_json(z, x, y, layer):
+    url = tile_url(z, x, y, layer)
+    r = fetch_tile_http(url)
 
     if r.headers['content-type'] != 'application/json':
         raise Exception("Tile %r: expected JSON, but content-type is %r"
                         % (url, r.headers['content-type']))
 
+    return r
+
+
+def fetch_tile_http_mvt(z, x, y, layer):
+    url = tile_url(z, x, y, layer)
+    url = url.replace(".json", ".mvt")
+    r = fetch_tile_http(url)
+
+    if r.headers['content-type'] != 'application/x-protobuf':
+        raise Exception("Tile %r: expected application/x-protobuf, but "
+                        "content-type is %r"
+                        % (url, r.headers['content-type']))
+
+    return r
+
+
+@contextmanager
+def features_in_tile_layer(z, x, y, layer):
+    r = fetch_tile_http_json(z, x, y, layer)
     data = json.loads(r.text)
 
     if config_all_layers:
@@ -189,23 +225,12 @@ def features_in_tile_layer(z, x, y, layer):
         yield features
 
     except Exception as e:
-        raise Exception, "Tile %r: %s" % (url, e.message), sys.exc_info()[2]
+        raise Exception, "Tile %r: %s" % (r.url, e.message), sys.exc_info()[2]
 
 
 @contextmanager
 def layers_in_tile(z, x, y):
-    assert config_url, "Tile URL is not configured, is your config file set up?"
-    url = config_url % {'layer': 'all', 'z': z, 'x': x, 'y': y}
-    r = requests.get(url)
-
-    if r.status_code != 200:
-        raise Exception("Tile %r: error while fetching, status=%d"
-                        % (url, r.status_code))
-
-    if r.headers['content-type'] != 'application/json':
-        raise Exception("Tile %r: expected JSON, but content-type is %r"
-                        % (url, r.headers['content-type']))
-
+    r = fetch_tile_http_json(z, x, y, 'all')
     data = json.loads(r.text)
     layers = data.keys()
     yield layers
@@ -213,20 +238,7 @@ def layers_in_tile(z, x, y):
 
 @contextmanager
 def features_in_mvt_layer(z, x, y, layer):
-    assert config_url, "Tile URL is not configured, is your config file set up?"
-    request_layer = 'all' if config_all_layers else layer
-    url = config_url % {'layer': request_layer, 'z': z, 'x': x, 'y': y}
-    url = url.replace(".json", ".mvt")
-    r = requests.get(url)
-
-    if r.status_code != 200:
-        raise Exception("Tile %r: error while fetching, status=%d"
-                        % (url, r.status_code))
-
-    if r.headers['content-type'] != 'application/x-protobuf':
-        raise Exception("Tile %r: expected application/x-protobuf, but "
-                        "content-type is %r"
-                        % (url, r.headers['content-type']))
+    r = fetch_tile_http_mvt(z, x, y, layer)
 
     from mapbox_vector_tile import decode as mvt_decode
     msg = mvt_decode(r.content)
@@ -237,7 +249,7 @@ def features_in_mvt_layer(z, x, y, layer):
         yield features
 
     except Exception as e:
-        raise Exception, "Tile %r: %s" % (url, e.message), sys.exc_info()[2]
+        raise Exception, "Tile %r: %s" % (r.url, e.message), sys.exc_info()[2]
 
 
 def count_matching(features, properties):
@@ -519,6 +531,12 @@ def run_test(f, log, idx, num_tests):
             'features_in_mvt_layer': features_in_mvt_layer,
         })
         print "[%4d/%d] PASS: %r" % (idx, num_tests, f)
+    except GatewayTimeout, e:
+        print "[%4d/%d] SLOW: %r" % (idx, num_tests, f)
+        fails = 1
+        print>>log, "[%4d/%d] SLOW: %r" % (idx, num_tests, f)
+        print>>log, "Gateway timeout: %s" % e.message
+        print>>log, ""
     except:
         print "[%4d/%d] FAIL: %r" % (idx, num_tests, f)
         fails = 1

--- a/integration-test/1147-bicycle-ramps.py
+++ b/integration-test/1147-bicycle-ramps.py
@@ -9,5 +9,5 @@ assert_has_feature(
 # Footway with ramp=yes in San Francisco
 # https://www.openstreetmap.org/way/346088008
 assert_has_feature(
-    15, 5235, 12671, 'roads',
+    16, 10470, 25342, 'roads',
     { 'id': 346088008, 'kind': 'path', 'kind_detail': 'footway', 'ramp': 'yes'})

--- a/integration-test/1171-bicycle-yes-designated-roads.py
+++ b/integration-test/1171-bicycle-yes-designated-roads.py
@@ -3,11 +3,11 @@
 # Road with bicycle=yes in Washington, DC
 # http://www.openstreetmap.org/way/281677984
 assert_has_feature(
-    15, 9379, 12539, 'roads',
+    16, 18758, 25078, 'roads',
     { 'id': 281677984, 'kind': 'major_road', 'is_bicycle_related': True, 'bicycle': 'yes'})
 
 # Road with bicycle=designated in Eureka, California
 # http://www.openstreetmap.org/way/10273013
 assert_has_feature(
-    15, 5081, 12311, 'roads',
+    16, 10163, 24621, 'roads',
     { 'id': 10273013, 'kind': 'major_road', 'is_bicycle_related': True, 'bicycle': 'designated'})

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -31,10 +31,13 @@ assert_has_feature(
 
 # make sure the all_* lists are gone by zoom 12 on major roads, but the "most
 # important" network & shield text remain until.
+#
+# note that it doesn't matter what the bus shield is - that's data-dependent.
+# for the purposes of the test, we only care that there _is_ one.
 assert_has_feature(
     10, 163, 395, 'roads',
     { 'bus_network': type(None),
-      'bus_shield_text': '3' })
+      'bus_shield_text': None })
 assert_no_matching_feature(
     10, 163, 395, 'roads',
     { 'all_bus_networks': None })


### PR DESCRIPTION
The migrations didn't include changes for things with no names. Those have been added to the migration now.

Other changes:
* Lots of tests were using z15 coordinates and IDs to find the relevant features. In a full database, these are often merged, and so lose their IDs. These were replaced with z16 coordinates instead.
* Because more roads are available in the full database, some tests needed to be adjusted to have higher tolerances.
* Because more relations are available in the full database, some choices of which relation was most important and used as `shield_text` changed. It wasn't important to the test exactly which shield was used, so I made the test insensitive to that.

Once this is merged, I'll deploy again, run the migration and re-seed to a new bucket.