### PR TITLE
Fix dev tests again.

### DIFF
--- a/integration-test/1191-improve-road-line-merging.py
+++ b/integration-test/1191-improve-road-line-merging.py
@@ -98,7 +98,7 @@ assert_is_linestring(11, 603, 770, 'roads', 'Pitkin Ave.', 23, 10)
 # http://www.openstreetmap.org/way/421092484
 # http://www.openstreetmap.org/way/421092485
 # http://www.openstreetmap.org/way/421092487
-assert_is_linestring(13, 2413, 3081, 'roads', 'Linden Blvd.', 22, 8)
+assert_is_linestring(13, 2413, 3081, 'roads', 'Linden Blvd.', 23, 8)
 
 # check that we don't merge across linestrings with different properties. in
 # this case, the central section of this road is a bridge. we currently drop

--- a/integration-test/661-historic-transit-stops.py
+++ b/integration-test/661-historic-transit-stops.py
@@ -39,8 +39,8 @@ assert_no_matching_feature(
 # Current railway stop
 # http://www.openstreetmap.org/node/2986320002
 assert_has_feature(
-    13, 2413, 3081, 'pois',
-    {'id': 2986320002})
+    16, 19306, 24648, 'pois',
+    {'id': 2986320002, 'min_zoom': 13})
 
 # Current tram stop
 # http://www.openstreetmap.org/node/257074010


### PR DESCRIPTION
Two fixes:

1. The tolerance for the number of points in the simplification of lines was too low, it seems, to deal with some variation. It was only one off, so I just bumped the value. But if this keeps happening, then we might want to change how that test is written to be less sensitive to these details.
2. It seems like more important nearby stations were crowding out the stop used in the test at z13. Instead, I've tested at z16 and checked the `min_zoom` is 13.
