### PR TITLE
Attempt to speed up migration.

### DIFF
--- a/data/migrations/v1.3.0-line.sql
+++ b/data/migrations/v1.3.0-line.sql
@@ -6,4 +6,6 @@ UPDATE planet_osm_line
                    'path', 'track', 'cycleway', 'bridleway', 'footway', 'steps',
                    'service' ) OR
        tags -> 'whitewater' = 'portage_way')
-      AND mz_calculate_min_zoom_roads(planet_osm_line.*) IS NOT NULL;
+      AND mz_calculate_min_zoom_roads(planet_osm_line.*) IS NOT NULL
+      AND mz_road_level IS NOT NULL
+      AND mz_road_level <> mz_calculate_min_zoom_roads(planet_osm_line.*);


### PR DESCRIPTION
By updating only those rows which are different from what's already on disk, and skipping any rows for which the road level is null. The changes to the zooms only change existing values, so we can assume that both the old and new `mz_road_level` values are non-NULL.
