### PR TITLE
Capture all test coordinates with -printcoords

### DIFF
--- a/integration-test.py
+++ b/integration-test.py
@@ -374,6 +374,13 @@ def fail(msg):
     raise Exception(msg)
 
 
+def assertTrue(condition, msg=None):
+    if msg is None:
+        assert condition
+    else:
+        assert condition, msg
+
+
 def noop(*args, **kwargs):
     pass
 
@@ -400,6 +407,7 @@ def print_coords(f, log, idx, num_tests):
             'layers_in_tile': print_coord_with_context,
             'features_in_mvt_layer': print_coord_with_context,
             'fail': noop,
+            'assertTrue': noop,
         })
     except:
         pass
@@ -539,6 +547,7 @@ def run_test(f, log, idx, num_tests):
             'layers_in_tile': layers_in_tile,
             'features_in_mvt_layer': features_in_mvt_layer,
             'fail': fail,
+            'assertTrue': assertTrue,
         })
         print "[%4d/%d] PASS: %r" % (idx, num_tests, f)
     except GatewayTimeout, e:

--- a/integration-test.py
+++ b/integration-test.py
@@ -370,6 +370,14 @@ def print_coord(z, x, y, *ignored):
     print '%d/%d/%d' % (z, x, y)
 
 
+def fail(msg):
+    raise Exception(msg)
+
+
+def noop(*args, **kwargs):
+    pass
+
+
 @contextmanager
 def print_coord_with_context(z, x, y, *ignored):
     """
@@ -391,6 +399,7 @@ def print_coords(f, log, idx, num_tests):
             'assert_feature_geom_type': print_coord,
             'layers_in_tile': print_coord_with_context,
             'features_in_mvt_layer': print_coord_with_context,
+            'fail': noop,
         })
     except:
         pass
@@ -529,6 +538,7 @@ def run_test(f, log, idx, num_tests):
             'assert_feature_geom_type': assert_feature_geom_type,
             'layers_in_tile': layers_in_tile,
             'features_in_mvt_layer': features_in_mvt_layer,
+            'fail': fail,
         })
         print "[%4d/%d] PASS: %r" % (idx, num_tests, f)
     except GatewayTimeout, e:

--- a/integration-test.py
+++ b/integration-test.py
@@ -395,23 +395,66 @@ def print_coord_with_context(z, x, y, *ignored):
     yield []
 
 
-def print_coords(f, log, idx, num_tests):
-    try:
-        runpy.run_path(f, init_globals={
-            'assert_has_feature': print_coord,
-            'assert_no_matching_feature': print_coord,
-            'assert_at_least_n_features': print_coord,
-            'assert_less_than_n_features': print_coord,
-            'features_in_tile_layer': print_coord_with_context,
-            'assert_feature_geom_type': print_coord,
-            'layers_in_tile': print_coord_with_context,
-            'features_in_mvt_layer': print_coord_with_context,
-            'fail': noop,
-            'assertTrue': noop,
-        })
-    except:
-        pass
-    return 0
+class TestRunner(object):
+
+    def __init__(self, mode):
+        if mode == 'print':
+            self.test_api = {
+                'assert_has_feature': print_coord,
+                'assert_no_matching_feature': print_coord,
+                'assert_at_least_n_features': print_coord,
+                'assert_less_than_n_features': print_coord,
+                'features_in_tile_layer': print_coord_with_context,
+                'assert_feature_geom_type': print_coord,
+                'layers_in_tile': print_coord_with_context,
+                'features_in_mvt_layer': print_coord_with_context,
+                'fail': noop,
+                'assertTrue': noop,
+            }
+
+        else:
+            assert mode == 'test'
+            self.test_api = {
+                'assert_has_feature': assert_has_feature,
+                'assert_no_matching_feature': assert_no_matching_feature,
+                'assert_at_least_n_features': assert_at_least_n_features,
+                'assert_less_than_n_features': assert_less_than_n_features,
+                'features_in_tile_layer': features_in_tile_layer,
+                'assert_feature_geom_type': assert_feature_geom_type,
+                'layers_in_tile': layers_in_tile,
+                'features_in_mvt_layer': features_in_mvt_layer,
+                'fail': fail,
+                'assertTrue': assertTrue,
+            }
+        self.mode = mode
+
+    def __call__(self, f, log, idx, num_tests):
+        fails = 0
+
+        try:
+            runpy.run_path(f, init_globals=self.test_api)
+            if self.mode == 'test':
+                print "[%4d/%d] PASS: %r" % (idx, num_tests, f)
+        except GatewayTimeout, e:
+            if self.mode == 'test':
+                fails = 1
+                print "[%4d/%d] SLOW: %r" % (idx, num_tests, f)
+                print>>log, "[%4d/%d] SLOW: %r" % (idx, num_tests, f)
+                print>>log, "Gateway timeout: %s" % e.message
+                print>>log, ""
+        except:
+            if self.mode == 'test':
+                fails = 1
+                print "[%4d/%d] FAIL: %r" % (idx, num_tests, f)
+                print>>log, "[%4d/%d] FAIL: %r" % (idx, num_tests, f)
+                print>>log, traceback.format_exc()
+                print>>log, ""
+
+        return fails
+
+
+def make_runner(mode):
+    return TestRunner(mode)
 
 
 def chunks(length, iterable):
@@ -533,45 +576,12 @@ class DataDumper(object):
         return dump_data
 
 
-def run_test(f, log, idx, num_tests):
-    fails = 0
-
-    try:
-        runpy.run_path(f, init_globals={
-            'assert_has_feature': assert_has_feature,
-            'assert_no_matching_feature': assert_no_matching_feature,
-            'assert_at_least_n_features': assert_at_least_n_features,
-            'assert_less_than_n_features': assert_less_than_n_features,
-            'features_in_tile_layer': features_in_tile_layer,
-            'assert_feature_geom_type': assert_feature_geom_type,
-            'layers_in_tile': layers_in_tile,
-            'features_in_mvt_layer': features_in_mvt_layer,
-            'fail': fail,
-            'assertTrue': assertTrue,
-        })
-        print "[%4d/%d] PASS: %r" % (idx, num_tests, f)
-    except GatewayTimeout, e:
-        print "[%4d/%d] SLOW: %r" % (idx, num_tests, f)
-        fails = 1
-        print>>log, "[%4d/%d] SLOW: %r" % (idx, num_tests, f)
-        print>>log, "Gateway timeout: %s" % e.message
-        print>>log, ""
-    except:
-        print "[%4d/%d] FAIL: %r" % (idx, num_tests, f)
-        fails = 1
-        print>>log, "[%4d/%d] FAIL: %r" % (idx, num_tests, f)
-        print>>log, traceback.format_exc()
-        print>>log, ""
-
-    return fails
-
-
 data_dumper = None
 
 if len(sys.argv) > 1 and sys.argv[1] == '-printcoords':
     tests = sys.argv[2:]
     mode = 'print'
-    runner = print_coords
+    runner = make_runner(mode)
 elif len(sys.argv) > 1 and sys.argv[1] == '-dumpdata':
     tests = sys.argv[2:]
     mode = 'dump'
@@ -583,7 +593,7 @@ else:
         "running the tests. Please check your configuration file."
     tests = sys.argv[2:]
     mode = 'test'
-    runner = run_test
+    runner = make_runner(mode)
 
 fail_count = 0
 with open('test.log', 'w') as log:

--- a/integration-test/1012-sort_key-boundary.py
+++ b/integration-test/1012-sort_key-boundary.py
@@ -2,27 +2,27 @@
 
 # country boundary of USA
 #https://www.openstreetmap.org/relation/148838
-assert_has_feature(
+test.assert_has_feature(
     8, 39, 95, "boundaries",
     {"kind": "country", "sort_rank": 262})
 
 # region boundary between Nevada - California
 #https://www.openstreetmap.org/relation/165473
 #https://www.openstreetmap.org/relation/165475
-assert_has_feature(
+test.assert_has_feature(
     8, 42, 96, "boundaries",
     {"kind": "region", "sort_rank": 256})
 
 # county boundary between Mendocino County - Humboldt County
 #https://www.openstreetmap.org/relation/396458
 #https://www.openstreetmap.org/relation/396489
-assert_has_feature(
+test.assert_has_feature(
     10, 159, 387, "boundaries",
     {"kind": "county", "sort_rank": 254})
 
 # locality boundary between San Francisco - Daly City
 #https://www.openstreetmap.org/relation/111968
 #https://www.openstreetmap.org/relation/112271
-assert_has_feature(
+test.assert_has_feature(
     10, 163, 396, "boundaries",
     {"kind": "locality", "sort_rank": 252})

--- a/integration-test/1016-missing-localized-names.py
+++ b/integration-test/1016-missing-localized-names.py
@@ -3,7 +3,7 @@
 # New Jersey - New York state boundary
 # http://www.openstreetmap.org/relation/224951 (New Jersey)
 # http://www.openstreetmap.org/relation/61320 (New York state)
-assert_has_feature(
+test.assert_has_feature(
     15, 9643, 12327, "boundaries",
     {"kind": "region", "name": "New Jersey - New York",
     "name:right": "New York",      "name:left": "New Jersey",

--- a/integration-test/1020-roads-surface.py
+++ b/integration-test/1020-roads-surface.py
@@ -2,11 +2,11 @@
 
 # Prince St with cobblestones in Alexandria, VA
 # https://www.openstreetmap.org/way/190536019
-assert_has_feature(
+test.assert_has_feature(
     15, 9371, 12546, 'roads',
     { 'id': 190536019, 'kind': 'minor_road', 'surface': 'cobblestone'})
 
 # But strip that surface property off at earlier zooms
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 2342, 3136, 'roads',
     { 'surface': 'cobblestone'})

--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -52,8 +52,6 @@ with features_in_mvt_layer(5, 17, 9, 'water') as features:
     ocean_area = abs(ocean_area)
     expected = 7326600
     if ocean_area < expected:
-        raise Exception("Ocean area %f, expected at least %f."
-                        % (ocean_area, expected))
+        fail('Ocean area %f, expected at least %f.' % (ocean_area, expected))
     if ocean_area > 1.5 * expected:
-        raise Exception("Ocean area %f > 1.5 * expected %f"
-                        % (ocean_area, expected))
+        fail('Ocean area %f > 1.5 * expected %f' % (ocean_area, expected))

--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -1,12 +1,12 @@
 from mapbox_vector_tile.decoder import POLYGON
 
 # Caspian Sea
-assert_has_feature(
+test.assert_has_feature(
     5, 20, 12, 'water',
     { 'kind': 'ocean' })
 
 # Baltic Sea - JSON format
-assert_has_feature(
+test.assert_has_feature(
     5, 17, 9, 'water',
     { 'kind': 'ocean' })
 
@@ -35,7 +35,7 @@ def area_of(polygons):
 
 
 # Check MVT format
-with features_in_mvt_layer(5, 17, 9, 'water') as features:
+with test.features_in_mvt_layer(5, 17, 9, 'water') as features:
     ocean_area = 0
 
     for feature in features:
@@ -46,12 +46,12 @@ with features_in_mvt_layer(5, 17, 9, 'water') as features:
         if props.get('kind') == 'ocean':
             geom = feature['geometry']
             geom_type = geom['type']
-            assertTrue('Polygon' in geom_type)
+            test.assertTrue('Polygon' in geom_type)
             ocean_area += area_of(geom['coordinates'])
 
     ocean_area = abs(ocean_area)
     expected = 7326600
     if ocean_area < expected:
-        fail('Ocean area %f, expected at least %f.' % (ocean_area, expected))
+        test.fail('Ocean area %f, expected at least %f.' % (ocean_area, expected))
     if ocean_area > 1.5 * expected:
-        fail('Ocean area %f > 1.5 * expected %f' % (ocean_area, expected))
+        test.fail('Ocean area %f > 1.5 * expected %f' % (ocean_area, expected))

--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -46,7 +46,7 @@ with features_in_mvt_layer(5, 17, 9, 'water') as features:
         if props.get('kind') == 'ocean':
             geom = feature['geometry']
             geom_type = geom['type']
-            assert 'Polygon' in geom_type
+            assertTrue('Polygon' in geom_type)
             ocean_area += area_of(geom['coordinates'])
 
     ocean_area = abs(ocean_area)

--- a/integration-test/1091-missing-name-short.py
+++ b/integration-test/1091-missing-name-short.py
@@ -1,5 +1,5 @@
 # Node: Missouri (473849775)
 # http://www.openstreetmap.org/node/473849775
-assert_has_feature(
+test.assert_has_feature(
     16, 15917, 25102, 'places',
     { 'id': 473849775, 'name:short': 'MO' })

--- a/integration-test/1103-no-natural-pois.py
+++ b/integration-test/1103-no-natural-pois.py
@@ -2,10 +2,10 @@
 # http://www.openstreetmap.org/relation/1756198
 # since this is unnamed, it might already get dropped as a POI, and won't have
 # a landuse label, so this checks for the polygon.
-assert_has_feature(
+test.assert_has_feature(
     16, 32737, 21792, 'landuse',
     { 'id': -1756198, 'kind': 'natural_wood' })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 32737, 21792, 'pois',
     { 'id': -1756198, 'kind': 'natural_wood' })
 
@@ -13,19 +13,19 @@ assert_no_matching_feature(
 # landuse label placements at zoom 15+.
 # Mt. Cydonia Ponds Natural Area
 # http://www.openstreetmap.org/relation/6366946
-assert_has_feature(
+test.assert_has_feature(
     15, 9327, 12418, 'landuse',
     { 'id': -6366946, 'kind': 'natural_wood', 'label_placement': True })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 9327, 12418, 'pois',
     { 'id': -6366946, 'kind': 'natural_wood' })
 
 # same, but for a forest
 # Liebesinsel, nr. Berlin, Germany
 # http://www.openstreetmap.org/way/316516905
-assert_has_feature(
+test.assert_has_feature(
     16, 35199, 21454, 'landuse',
     { 'id': 316516905, 'kind': 'natural_forest', 'label_placement': True })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 35199, 21454, 'pois',
     { 'id': 316516905, 'kind': 'natural_forest' })

--- a/integration-test/1106-merge-ocean-earth.py
+++ b/integration-test/1106-merge-ocean-earth.py
@@ -1,9 +1,9 @@
 # There should be a single, merged feature in each of these tiles
 
 # Natural Earth
-assert_less_than_n_features(5, 12, 11, 'water', {'kind': 'ocean'}, 2)
-assert_less_than_n_features(5, 8, 11, 'earth', {'kind': 'earth'}, 2)
+test.assert_less_than_n_features(5, 12, 11, 'water', {'kind': 'ocean'}, 2)
+test.assert_less_than_n_features(5, 8, 11, 'earth', {'kind': 'earth'}, 2)
 
 # OpenStreetMap
-assert_less_than_n_features(9, 167, 186, 'water', {'kind': 'ocean'}, 2)
-assert_less_than_n_features(9, 170, 186, 'earth', {'kind': 'earth'}, 2)
+test.assert_less_than_n_features(9, 167, 186, 'water', {'kind': 'ocean'}, 2)
+test.assert_less_than_n_features(9, 170, 186, 'earth', {'kind': 'earth'}, 2)

--- a/integration-test/1140-fix-city-names.py
+++ b/integration-test/1140-fix-city-names.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
 # data is in the fixture ne_10m_populated_places/1140-fix-city-names.shp
-assert_has_feature(
+test.assert_has_feature(
     7, 38, 45, 'places',
     { 'name': 'Québec', 'source': 'naturalearthdata.com' })
 
 # this one has an interesting character outside of the extended latin
 # charset, so hopefully will test an extra path from just acute characters
 # and umlauts.
-assert_has_feature(
+test.assert_has_feature(
     7, 57, 32, 'places',
     { 'name': 'Sauðárkrókur', 'source': 'naturalearthdata.com' })
 
 # ditto interesting character
-assert_has_feature(
+test.assert_has_feature(
     7, 8, 27, 'places',
     { 'name': 'Utqiaġvik', 'source': 'naturalearthdata.com' })

--- a/integration-test/1147-bicycle-ramps.py
+++ b/integration-test/1147-bicycle-ramps.py
@@ -2,12 +2,12 @@
 
 # Steps with ramp:bicycle=yes in Copenhagen
 # https://www.openstreetmap.org/way/91275149
-assert_has_feature(
+test.assert_has_feature(
     15, 17527, 10257, 'roads',
     { 'id': 91275149, 'kind': 'path', 'kind_detail': 'steps', 'is_bicycle_related': True, 'ramp_bicycle': 'yes'})
 
 # Footway with ramp=yes in San Francisco
 # https://www.openstreetmap.org/way/346088008
-assert_has_feature(
+test.assert_has_feature(
     16, 10470, 25342, 'roads',
     { 'id': 346088008, 'kind': 'path', 'kind_detail': 'footway', 'ramp': 'yes'})

--- a/integration-test/1170-very-early-paths-and-bike-routes.py
+++ b/integration-test/1170-very-early-paths-and-bike-routes.py
@@ -2,21 +2,21 @@
 # GR5-Grand Traverse de Jura between France and Switzerland
 # https://www.openstreetmap.org/way/285975282
 # https://www.openstreetmap.org/relation/6009161
-assert_has_feature(
+test.assert_has_feature(
     9, 265, 179, 'roads',
     { 'kind': 'path', 'walking_network': 'iwn' } )
 
 # highway=path, with route national (Pacific Crest Trail) at zoom 9
 # https://www.openstreetmap.org/way/236361475
 # https://www.openstreetmap.org/relation/1225378
-assert_has_feature(
+test.assert_has_feature(
     9, 86, 197, 'roads',
     { 'kind': 'path', 'walking_network': 'nwn' } )
 
 # highway=path, with route regional (Merced Pass Trail) at zoom 11
 # https://www.openstreetmap.org/way/373491941
 # https://www.openstreetmap.org/relation/5549623
-assert_has_feature(
+test.assert_has_feature(
    11, 343, 792, 'roads',
    { 'kind': 'path', 'walking_network': 'rwn'  } )
 
@@ -24,7 +24,7 @@ assert_has_feature(
 # part of The Barbary Coast Trail in San Francisco
 # https://www.openstreetmap.org/way/91181758
 # https://www.openstreetmap.org/relation/6322028
-assert_has_feature(
+test.assert_has_feature(
    12, 655, 1582, 'roads',
    { 'kind': 'minor_road', 'walking_network': 'lwn' } )
 
@@ -37,7 +37,7 @@ assert_has_feature(
 # https://www.openstreetmap.org/relation/2749837
 # https://www.openstreetmap.org/relation/36778
 # https://www.openstreetmap.org/relation/721738
-assert_has_feature(
+test.assert_has_feature(
     8, 136, 80, 'roads',
     { 'kind': 'major_road', 'kind_detail': 'secondary',
       'is_bicycle_related': True, 'bicycle_network': 'icn' })
@@ -45,7 +45,7 @@ assert_has_feature(
 # Sundbylillevej tertiary road part of national cycle network
 # https://www.openstreetmap.org/way/28273516
 # https://www.openstreetmap.org/relation/26863
-assert_has_feature(
+test.assert_has_feature(
     8, 136, 79, 'roads',
     { 'kind': 'major_road', 'kind_detail': 'tertiary',
       'is_bicycle_related': True, 'bicycle_network': 'ncn' })
@@ -57,21 +57,21 @@ assert_has_feature(
 # https://www.openstreetmap.org/relation/1975739
 # https://www.openstreetmap.org/relation/5294
 # https://www.openstreetmap.org/relation/537418
-assert_has_feature(
+test.assert_has_feature(
     8, 131, 83, 'roads',
     { 'kind': 'path', 'is_bicycle_related': True, 'bicycle_network': 'icn' })
 
 # Ferry between Denmark and Germany, icn
 # https://www.openstreetmap.org/way/128631318
 # https://www.openstreetmap.org/relation/721738
-assert_has_feature(
+test.assert_has_feature(
     8, 136, 81, 'roads',
     { 'kind': 'ferry', 'is_bicycle_related': True, 'bicycle_network': 'icn' })
 
 # Søndervangsvej minor road in Denmark as national cycle route
 # https://www.openstreetmap.org/way/149701891
 # https://www.openstreetmap.org/relation/349521
-assert_has_feature(
+test.assert_has_feature(
     8, 136, 79, 'roads',
     { 'kind': 'minor_road', 'is_bicycle_related': True, 'bicycle_network': 'ncn' })
 
@@ -79,34 +79,34 @@ assert_has_feature(
 # way is marked rcn=yes, and part of a proper bike relation
 # http://www.openstreetmap.org/way/44422697
 # http://www.openstreetmap.org/relation/325779
-assert_has_feature(
+test.assert_has_feature(
     10, 164, 396, 'roads',
     { 'kind': 'path', 'is_bicycle_related': True, 'bicycle_network': 'rcn' })
 
 # Hyltebjerg Allé residential road with rcn in Copenhagen
 # https://www.openstreetmap.org/way/2860759
 # https://www.openstreetmap.org/relation/2087590
-assert_has_feature(
+test.assert_has_feature(
     10, 547, 320, 'roads',
     { 'kind': 'minor_road', 'is_bicycle_related': True, 'bicycle_network': 'rcn' })
 
 # lcn in Seattle (living street that would only be visible at zoom 13 otherwise) at zoom 11
 # https://www.openstreetmap.org/way/6477775
 # https://www.openstreetmap.org/relation/3541926
-assert_has_feature(
+test.assert_has_feature(
     11, 327, 715, 'roads',
     { 'kind': 'minor_road', 'bicycle_network': 'lcn' })
 
 # Kirkham Street lcn in San Francisco at zoom 11
 # https://www.openstreetmap.org/way/89802424
 # https://www.openstreetmap.org/relation/32313
-assert_has_feature(
+test.assert_has_feature(
     11, 327, 791, 'roads',
     { 'kind': 'minor_road', 'bicycle_network': 'lcn' })
 
 # Asiatisk Plads service road with lcn in Copenhagen
 # https://www.openstreetmap.org/way/164049387
 # https://www.openstreetmap.org/relation/6199242
-assert_has_feature(
+test.assert_has_feature(
     11, 1095, 641, 'roads',
     { 'kind': 'minor_road', 'bicycle_network': 'lcn' })

--- a/integration-test/1171-bicycle-yes-designated-roads.py
+++ b/integration-test/1171-bicycle-yes-designated-roads.py
@@ -2,12 +2,12 @@
 
 # Road with bicycle=yes in Washington, DC
 # http://www.openstreetmap.org/way/281677984
-assert_has_feature(
+test.assert_has_feature(
     16, 18758, 25078, 'roads',
     { 'id': 281677984, 'kind': 'major_road', 'is_bicycle_related': True, 'bicycle': 'yes'})
 
 # Road with bicycle=designated in Eureka, California
 # http://www.openstreetmap.org/way/10273013
-assert_has_feature(
+test.assert_has_feature(
     16, 10163, 24621, 'roads',
     { 'id': 10273013, 'kind': 'major_road', 'is_bicycle_related': True, 'bicycle': 'designated'})

--- a/integration-test/1175-bicycle-route-refs.py
+++ b/integration-test/1175-bicycle-route-refs.py
@@ -2,7 +2,7 @@
 #   lcn_ref=45
 # https://www.openstreetmap.org/relation/32310
 #   type=route, route=bicycle, network=lcn, ref=45
-assert_has_feature(
+test.assert_has_feature(
     16, 10481, 25336, 'roads',
     { 'id': 417389551,
       'bicycle_network': None,
@@ -12,14 +12,14 @@ assert_has_feature(
 
 # make sure the all_* lists are gone by zoom 12 on major roads, but the "most
 # important", singular network & shield text remain at earlier zooms
-assert_has_feature(
+test.assert_has_feature(
     10, 163, 395, 'roads',
     { 'bicycle_network': None,
       'bicycle_shield_text': '45' })
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 655, 1583, 'roads',
     { 'all_bicycle_networks': None })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 655, 1583, 'roads',
     { 'all_bicycle_shield_texts': None })

--- a/integration-test/1178-earlier-piers.py
+++ b/integration-test/1178-earlier-piers.py
@@ -2,24 +2,24 @@
 # be kept until z11.
 #
 # http://www.openstreetmap.org/way/377915546
-assert_has_feature(
+test.assert_has_feature(
     11, 1714, 876, 'landuse',
     { 'id': 377915546, 'kind': 'pier', 'min_zoom': 11})
 
 # zoom 11 for Cruise Terminal with area 53,276
 # http://www.openstreetmap.org/way/275609726
-assert_has_feature(
+test.assert_has_feature(
     11, 357, 826, 'landuse',
     { 'id': 275609726, 'kind': 'pier', 'min_zoom': 11.22})
 
 # zoom 12 for Broadway Pier with area 17,856
 # http://www.openstreetmap.org/way/275609725
-assert_has_feature(
+test.assert_has_feature(
     12, 714, 1653, 'landuse',
     { 'id': 275609725, 'kind': 'pier', 'min_zoom': 12})
 
 # zoom 12 for unnamed pier with area 4,734
 # http://www.openstreetmap.org/way/275609722
-assert_has_feature(
+test.assert_has_feature(
     12, 714, 1653, 'landuse',
     { 'id': 275609722, 'kind': 'pier', 'min_zoom': 12.96})

--- a/integration-test/1185-garden-min-zoom.py
+++ b/integration-test/1185-garden-min-zoom.py
@@ -2,16 +2,16 @@
 # z16 instead.
 #
 # http://www.openstreetmap.org/way/273274870
-assert_has_feature(
+test.assert_has_feature(
     16, 32182, 20422, 'landuse',
     { 'kind': 'garden', 'id': 273274870, 'min_zoom': 16, 'tier': 6 })
 # shouldn't be a POI now as it has no name.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 32182, 20422, 'pois',
     { 'kind': 'garden' })
 
 # instead, here's a small, named garden
 # http://www.openstreetmap.org/way/162235630
-assert_has_feature(
+test.assert_has_feature(
     16, 19303, 24647, 'pois',
     { 'kind': 'garden', 'id': 162235630, 'min_zoom': 16, 'tier': 6 })

--- a/integration-test/1186-the-pois-with-no-name.py
+++ b/integration-test/1186-the-pois-with-no-name.py
@@ -4,18 +4,18 @@
 # originally from 440-zoos-and-other-attractions-tourism.py
 #https://www.openstreetmap.org/node/1589837084
 # unnamed, CO
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 13686, 24901, 'pois',
     { 'id': 1589837084 })
 
 # originally from 526-inclusive-pois.py
 #https://www.openstreetmap.org/node/1460537343
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10470, 25342, 'pois',
     { 'id': 1460537343 })
 
 #https://www.openstreetmap.org/node/3879177193
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10533, 22894, 'pois',
     { 'id': 3879177193 })
 
@@ -27,73 +27,73 @@ assert_no_matching_feature(
 # originally from 663-combo-outdoor-landuse-pois.py
 #https://www.openstreetmap.org/relation/6328943
 # Cox Stadium recreation track
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10471, 25342, 'pois',
     { 'id': -6328943 })
 #https://www.openstreetmap.org/node/3643451363
 # unnamed running track
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10962, 25007, 'pois',
     { 'id': 3643451363 })
 
 # originally from 742-predictable-layers-pois.py
 # Way:79457493 Grave_yard in POIS
 # http://www.openstreetmap.org/way/79457493
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5240, 12666, 'pois',
     {'id': 79457493})
 # Way:64296322 landuse: Forest in POIS
 # http://www.openstreetmap.org/way/64296322
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     10, 163, 392, 'pois',
     {'id': 64296322})
 # Node:2148541212 natural: Forest in POIS
 # http://www.openstreetmap.org/node/2148541212
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 3942, 5901, 'pois',
     {'id': 2148541212})
 # Node:4206408136 park in POIS
 # http://www.openstreetmap.org/node/4206408136
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2619, 6333, 'pois',
     {'id': 4206408136})
 # Node:4076680383 protected_area in POIS
 # http://www.openstreetmap.org/node/4076680383
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2809, 6074, 'pois',
     {'id': 4076680383})
 # Way:86285084 recreation_ground in POIS
 # http://www.openstreetmap.org/way/86285084
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2619, 6334, 'pois',
     {'id': 86285084})
 # Node:582131344 recreation_ground in POIS
 # http://www.openstreetmap.org/node/582131344
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2621, 6331, 'pois',
     {'id': 582131344})
 # Way:28694608 village_green in POIS
 # http://www.openstreetmap.org/way/28694608
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2618, 6334, 'pois',
     {'id': 28694608})
 # Node:3367407023 water_works in POIS
 # http://www.openstreetmap.org/node/3367407023
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2627, 6346, 'pois',
     {'id': 3367407023})
 # Way:207859675 landuse: wood in POIS
 # http://www.openstreetmap.org/way/207859675
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2826, 6549, 'pois',
     {'id': 207859675})
 # Way:372445925 natural: wood in POIS
 # http://www.openstreetmap.org/way/372445925
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2618, 6330, 'pois',
     {'id': 372445925})
 # Way:164878781 works in POIS
 # http://www.openstreetmap.org/way/164878781
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 1429, 3247, 'pois',
     {'id': 164878781 })

--- a/integration-test/1190-mz-colours.py
+++ b/integration-test/1190-mz-colours.py
@@ -1,5 +1,5 @@
 # http://www.openstreetmap.org/relation/366773
-assert_has_feature(
+test.assert_has_feature(
     16, 19310, 24645, 'transit',
     { 'kind': 'subway', 'ref': 'Z',
       'colour': '#996633', 'colour_name': 'peru' })

--- a/integration-test/1191-improve-road-line-merging.py
+++ b/integration-test/1191-improve-road-line-merging.py
@@ -9,29 +9,25 @@ def assert_is_linestring(z, x, y, layer, name, max_coords, max_count):
                 geom_type = feature['geometry']['type']
                 if geom_type != 'LineString' and \
                    geom_type != 'MultiLineString':
-                    raise Exception('Expected linestring, got %r' % geom_type)
+                    fail('Expected linestring, got %r' % geom_type)
                 count += 1
                 coords = feature['geometry']['coordinates']
                 if geom_type == 'LineString':
                     if len(coords) > max_coords:
-                        raise Exception(
-                            'Single feature exceeded max coords: %d > %d' %
-                            (len(coords), max_coords))
+                        fail('Single feature exceeded max coords: %d > %d' %
+                             (len(coords), max_coords))
                     total_coords += len(coords)
                 else:
                     for line in coords:
                         if len(line) > max_coords:
-                            raise Exception('Single part of multi-feature' +
-                                            'exceeded max coords: %d > %d' %
-                                            (len(line), max_coords))
+                            fail('Single part of multi-feature exceeded max '
+                                 'coords: %d > %d' % (len(line), max_coords))
                         total_coords += len(line)
         if count > max_count:
-            raise Exception('Expected at most %d features, found %d' %
-                            (max_count, count))
+            fail('Expected at most %d features, found %d' % (max_count, count))
         if total_coords > max_coords:
-            raise Exception(
-                'Expected at most %d coordinates, found %d in total' %
-                (max_coords, total_coords))
+            fail('Expected at most %d coordinates, found %d in total' %
+                 (max_coords, total_coords))
 
 
 # Pitkin Ave, NYC
@@ -128,6 +124,6 @@ with features_in_tile_layer(13, 1865, 2866, 'roads') as features:
                 count_bridge += 1
 
     if count_nd_200 != 3:
-        raise Exception('Expecting 3 US:ND 200 roads, got %d' % count_nd_200)
+        fail('Expecting 3 US:ND 200 roads, got %d' % count_nd_200)
     if count_bridge != 1:
-        raise Exception('Expecting one bridge, but got %d' % count_bridge)
+        fail('Expecting one bridge, but got %d' % count_bridge)

--- a/integration-test/1191-improve-road-line-merging.py
+++ b/integration-test/1191-improve-road-line-merging.py
@@ -1,5 +1,5 @@
 def assert_is_linestring(z, x, y, layer, name, max_coords, max_count):
-    with features_in_tile_layer(z, x, y, layer) as features:
+    with test.features_in_tile_layer(z, x, y, layer) as features:
         count = 0
         total_coords = 0
         for feature in features:
@@ -9,24 +9,24 @@ def assert_is_linestring(z, x, y, layer, name, max_coords, max_count):
                 geom_type = feature['geometry']['type']
                 if geom_type != 'LineString' and \
                    geom_type != 'MultiLineString':
-                    fail('Expected linestring, got %r' % geom_type)
+                    test.fail('Expected linestring, got %r' % geom_type)
                 count += 1
                 coords = feature['geometry']['coordinates']
                 if geom_type == 'LineString':
                     if len(coords) > max_coords:
-                        fail('Single feature exceeded max coords: %d > %d' %
+                        test.fail('Single feature exceeded max coords: %d > %d' %
                              (len(coords), max_coords))
                     total_coords += len(coords)
                 else:
                     for line in coords:
                         if len(line) > max_coords:
-                            fail('Single part of multi-feature exceeded max '
+                            test.fail('Single part of multi-feature exceeded max '
                                  'coords: %d > %d' % (len(line), max_coords))
                         total_coords += len(line)
         if count > max_count:
-            fail('Expected at most %d features, found %d' % (max_count, count))
+            test.fail('Expected at most %d features, found %d' % (max_count, count))
         if total_coords > max_coords:
-            fail('Expected at most %d coordinates, found %d in total' %
+            test.fail('Expected at most %d coordinates, found %d in total' %
                  (max_coords, total_coords))
 
 
@@ -105,7 +105,7 @@ assert_is_linestring(13, 2413, 3081, 'roads', 'Linden Blvd.', 23, 8)
 # http://www.openstreetmap.org/way/421314246 <-- bridge
 # http://www.openstreetmap.org/way/9678799
 # http://www.openstreetmap.org/relation/1109565 <-- relation for ND 200
-with features_in_tile_layer(13, 1865, 2866, 'roads') as features:
+with test.features_in_tile_layer(13, 1865, 2866, 'roads') as features:
     # looking for features in US:ND 200 - there should be 3 in this tile,
     # and one should be the bridge.
     count_nd_200 = 0
@@ -124,6 +124,6 @@ with features_in_tile_layer(13, 1865, 2866, 'roads') as features:
                 count_bridge += 1
 
     if count_nd_200 != 3:
-        fail('Expecting 3 US:ND 200 roads, got %d' % count_nd_200)
+        test.fail('Expecting 3 US:ND 200 roads, got %d' % count_nd_200)
     if count_bridge != 1:
-        fail('Expecting one bridge, but got %d' % count_bridge)
+        test.fail('Expecting one bridge, but got %d' % count_bridge)

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -5,7 +5,7 @@
 #   type=route, route=bicycle, network=lcn, ref=50
 # https://www.openstreetmap.org/relation/1976278
 #   type=route, route=road, network=US:CA, ref=35
-assert_has_feature(
+test.assert_has_feature(
     16, 10469, 25340, 'roads',
     { 'id': 417097119,
       'network': 'US:CA',
@@ -21,7 +21,7 @@ assert_has_feature(
 #   outbound
 # http://www.openstreetmap.org/relation/2980504
 #   inbound
-assert_has_feature(
+test.assert_has_feature(
     16, 10477, 25327, 'roads',
     { 'id': 225516711,
       'bus_network': type(None),
@@ -34,14 +34,14 @@ assert_has_feature(
 #
 # note that it doesn't matter what the bus shield is - that's data-dependent.
 # for the purposes of the test, we only care that there _is_ one.
-assert_has_feature(
+test.assert_has_feature(
     10, 163, 395, 'roads',
     { 'bus_network': type(None),
       'bus_shield_text': None })
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 654, 1583, 'roads',
     { 'all_bus_networks': None })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 654, 1583, 'roads',
     { 'all_bus_shield_texts': None })

--- a/integration-test/1211-fix-null-network.py
+++ b/integration-test/1211-fix-null-network.py
@@ -1,6 +1,6 @@
 # http://www.openstreetmap.org/relation/2307408
 # ref="N 4", route=road, but no network=*
 # so we should get something that has no network, but a shield text of '4'
-assert_has_feature(
+test.assert_has_feature(
     11, 1038, 705, 'roads',
     { 'kind': 'major_road', 'shield_text': '4', 'network': type(None) })

--- a/integration-test/1215-fix-bad-unicode-shield-text.py
+++ b/integration-test/1215-fix-bad-unicode-shield-text.py
@@ -1,7 +1,7 @@
 # http://www.openstreetmap.org/relation/3948946
-assert_has_feature(
+test.assert_has_feature(
     16, 63085, 15623, 'roads',
     { 'id': 425415345, 'shield_text': u'77\u041a' })
-assert_has_feature(
+test.assert_has_feature(
     16, 63085, 15623, 'roads',
     { 'id': -3948946, 'osm_relation': type(True), 'shield_text': u'77\u041a' })

--- a/integration-test/1218-poni-whitelist.py
+++ b/integration-test/1218-poni-whitelist.py
@@ -1,10 +1,10 @@
 # aeroway=helipad
 # min_zoom: 16
 # https://www.openstreetmap.org/node/2207370738
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5230, 12657, 'pois',
     {'id': 2207370738})
-assert_has_feature(
+test.assert_has_feature(
     16, 10461, 25315, 'pois',
     {'id': 2207370738})
 
@@ -12,20 +12,20 @@ assert_has_feature(
 # min_zoom: 17
 # it's on the edge, might be 16, 10481, 25338
 # https://www.openstreetmap.org/node/4113423533
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5242, 12668, 'pois',
     {'id': 4113423533})
-assert_has_feature(
+test.assert_has_feature(
     16, 10481, 25337, 'pois',
     {'id': 4113423533})
 
 # amenity=bench
 # min_zoom: 18
 # https://www.openstreetmap.org/node/3951215438
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5239, 12672, 'pois',
     {'id': 3951215438})
-assert_has_feature(
+test.assert_has_feature(
     16, 10479, 25345, 'pois',
     {'id': 3951215438})
 
@@ -33,10 +33,10 @@ assert_has_feature(
 # when operator: false, then min_zoom: 16
 # when operator: true, then min_zoom: 17
 # https://www.openstreetmap.org/node/3509468129
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5251, 12655, 'pois',
     {'id': 3509468129})
-assert_has_feature(
+test.assert_has_feature(
     16, 10503, 25310, 'pois',
     {'id': 3509468129})
 
@@ -46,176 +46,176 @@ assert_has_feature(
 # amenity=car_sharing
 # min_zoom: 16
 # https://www.openstreetmap.org/node/4758733421
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5266, 12706, 'pois',
     {'id': 4758733421})
-assert_has_feature(
+test.assert_has_feature(
     16, 10532, 25412, 'pois',
     {'id': 4758733421})
 
 # amenity=fuel
 # https://www.openstreetmap.org/node/2059530671
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5239, 12671, 'pois',
     {'id': 2059530671})
-assert_has_feature(
+test.assert_has_feature(
     16, 10478, 25342, 'pois',
     {'id': 2059530671})
 
 # amenity=post_box
 # https://www.openstreetmap.org/node/4397690695
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5239, 12672, 'pois',
     {'id': 4397690695})
-assert_has_feature(
+test.assert_has_feature(
     16, 10478, 25344, 'pois',
     {'id': 4397690695})
 
 # amenity=recycling
 # https://www.openstreetmap.org/node/2338524067
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5243, 12666, 'pois',
     {'id': 2338524067})
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25332, 'pois',
     {'id': 2338524067})
 
 # amenity=shelter
 # https://www.openstreetmap.org/node/4177497032
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5250, 12700, 'pois',
     {'id': 4177497032})
-assert_has_feature(
+test.assert_has_feature(
     16, 10501, 25401, 'pois',
     {'id': 4177497032})
 
 # amenity=telephone
 # https://www.openstreetmap.org/node/1241673617
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5241, 12670, 'pois',
     {'id': 1241673617})
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25341, 'pois',
     {'id': 1241673617})
 
 # amenity=waste_basket
 # https://www.openstreetmap.org/node/4265260145
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5240, 12672, 'pois',
     {'id': 4265260145})
-assert_has_feature(
+test.assert_has_feature(
     16, 10480, 25344, 'pois',
     {'id': 4265260145})
 
 # highway=bus_stop
 # https://www.openstreetmap.org/node/1229920715
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5239, 12672, 'pois',
     {'id': 1229920715})
-assert_has_feature(
+test.assert_has_feature(
     16, 10478, 25344, 'pois',
     {'id': 1229920715})
 
 # highway=ford
 # https://www.openstreetmap.org/node/880807552
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5767, 13110, 'pois',
     {'id': 880807552})
-assert_has_feature(
+test.assert_has_feature(
     16, 11534, 26220, 'pois',
     {'id': 880807552})
 
 # highway=mini_roundabout
 # https://www.openstreetmap.org/node/110392851
-assert_has_feature(
+test.assert_has_feature(
     15, 5228, 12650, 'pois',
     {'id': 110392851})
 
 # highway=platform
 # https://www.openstreetmap.org/node/1275126569
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 7539, 11137, 'pois',
     {'id': 1275126569})
-assert_has_feature(
+test.assert_has_feature(
     16, 15079, 22275, 'pois',
     {'id': 1275126569})
 
 # highway=traffic_signals
 # https://www.openstreetmap.org/node/65329980
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5242, 12664, 'pois',
     {'id': 65329980})
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25328, 'pois',
     {'id': 65329980})
 
 # waterway=lock
 # https://www.openstreetmap.org/node/675426915
-assert_has_feature(
+test.assert_has_feature(
     15, 9399, 12418, 'pois',
     {'id': 675426915})
 
 # landuse=quarry
 # https://www.openstreetmap.org/node/3356570361
-assert_has_feature(
+test.assert_has_feature(
     15, 5265, 12615, 'pois',
     {'id': 3356570361})
 
 # Way:184367568 quarry in POIS
 # https://www.openstreetmap.org/way/184367568
-assert_has_feature(
+test.assert_has_feature(
     12, 671, 1583, 'pois',
     {'id': 184367568})
 
 # leisure=dog_park
 # https://www.openstreetmap.org/node/1229112075
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5235, 12669, 'pois',
     {'id': 1229112075})
-assert_has_feature(
+test.assert_has_feature(
     16, 10470, 25339, 'pois',
     {'id': 1229112075})
 
 # leisure=slipway
 # https://www.openstreetmap.org/node/2678961627
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5238, 12652, 'pois',
     {'id': 2678961627})
-assert_has_feature(
+test.assert_has_feature(
     16, 10477, 25304, 'pois',
     {'id': 2678961627})
 
 # lock='yes'
 # https://www.openstreetmap.org/node/365485771
-assert_has_feature(
+test.assert_has_feature(
     15, 9527, 11985, 'pois',
     {'id': 365485771})
 
 # man_made=adit
 # https://www.openstreetmap.org/node/4469596254
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5626, 12731, 'pois',
     {'id': 4469596254})
-assert_has_feature(
+test.assert_has_feature(
     16, 11253, 25463, 'pois',
     {'id': 4469596254})
 
 # man_made=mineshaft
 # https://www.openstreetmap.org/node/1818064871
-assert_has_feature(
+test.assert_has_feature(
     15, 5378, 12607, 'pois',
     {'id': 1818064871})
 
 # man_made=offshore_platform
 # https://www.openstreetmap.org/node/4239915448
-assert_has_feature(
+test.assert_has_feature(
     15, 7549, 13919, 'pois',
     {'id': 4239915448})
 
 # originally from 675-man_made-outdoor-landmarks.py
 # man_made=offshore_platform
 # https://www.openstreetmap.org/way/350328482
-assert_has_feature(
+test.assert_has_feature(
     13, 1942, 3395, 'pois',
     { 'id': 350328482 })
 
@@ -224,49 +224,49 @@ assert_has_feature(
 
 # man_made=telescope
 # https://www.openstreetmap.org/node/3310910810
-assert_has_feature(
+test.assert_has_feature(
     16, 10668, 25021, 'pois',
     {'id': 3310910810})
 
 # natural=cave_entrance
 # https://www.openstreetmap.org/node/1050825518
-assert_has_feature(
+test.assert_has_feature(
     15, 5178, 12346, 'pois',
     {'id': 1050825518})
 
 # natural=waterfall
 # https://www.openstreetmap.org/node/4719786091
-assert_has_feature(
+test.assert_has_feature(
     15, 5491, 12694, 'pois',
     {'id': 4719786091})
 
 # public_transport=platform
 # https://www.openstreetmap.org/node/2073000913
-assert_has_feature(
+test.assert_has_feature(
     15, 5238, 12671, 'pois',
     {'id': 2073000913})
 
 # public_transport=stop_area
 # https://www.openstreetmap.org/node/2991866242
-assert_has_feature(
+test.assert_has_feature(
     15, 5214, 12588, 'pois',
     {'id': 2991866242})
 
 # railway=halt
 # https://www.openstreetmap.org/node/2382580308
-assert_has_feature(
+test.assert_has_feature(
     15, 9545, 12368, 'pois',
     {'id': 2382580308})
 
 # railway=platform
 # https://www.openstreetmap.org/node/3987143106
-assert_has_feature(
+test.assert_has_feature(
     15, 9821, 12242, 'pois',
     {'id': 3987143106})
 
 # railway=stop
 # https://www.openstreetmap.org/node/1130268570
-assert_has_feature(
+test.assert_has_feature(
     15, 9381, 12527, 'pois',
     {'id': 1130268570})
 
@@ -274,31 +274,31 @@ assert_has_feature(
 # public_transport=stop_position
 # railway=stop
 # https://www.openstreetmap.org/node/3721890342
-assert_has_feature(
+test.assert_has_feature(
     13, 1316, 3176, 'pois',
     {'id': 3721890342})
 
 # railway=subway_entrance
 # https://www.openstreetmap.org/node/3833748147
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 9367, 12536, 'pois',
     {'id': 3833748147})
-assert_has_feature(
+test.assert_has_feature(
     16, 18735, 25072, 'pois',
     {'id': 3833748147})
 
 # railway=tram_stop
 # https://www.openstreetmap.org/node/1719012916
-assert_has_feature(
+test.assert_has_feature(
     15, 5239, 12670, 'pois',
     {'id': 1719012916})
 
 # railway=level_crossing (but make min_zoom 18)
 # https://www.openstreetmap.org/node/4665711307
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5235, 12667, 'pois',
     {'id': 4665711307})
-assert_has_feature(
+test.assert_has_feature(
     16, 10470, 25334, 'pois',
     {'id': 4665711307})
 
@@ -307,49 +307,49 @@ assert_has_feature(
 
 # tags->whitewater=egress
 # https://www.openstreetmap.org/node/4696619992
-assert_has_feature(
+test.assert_has_feature(
     15, 5362, 12461, 'pois',
     {'id': 4696619992})
 
 # tags->whitewater=hazard
 # https://www.openstreetmap.org/node/4253919482
-assert_has_feature(
+test.assert_has_feature(
     15, 5387, 12481, 'pois',
     {'id': 4253919482})
 
 # tags->whitewater=put_in
 # https://www.openstreetmap.org/node/3688927027
-assert_has_feature(
+test.assert_has_feature(
     15, 5541, 12666, 'pois',
     {'id': 3688927027})
 
 # tags->whitewater=rapid
 # https://www.openstreetmap.org/node/4253919493
-assert_has_feature(
+test.assert_has_feature(
     15, 5385, 12482, 'pois',
     {'id': 4253919493})
 
 # tourism=alpine_hut
 # https://www.openstreetmap.org/node/1076123765
-assert_has_feature(
+test.assert_has_feature(
     15, 5433, 12607, 'pois',
     {'id': 1076123765})
 
 # tourism=viewpoint
 # https://www.openstreetmap.org/node/3065529317
-assert_has_feature(
+test.assert_has_feature(
     15, 5236, 12667, 'pois',
     {'id': 3065529317})
 
 # tourism=wilderness_hut
 # https://www.openstreetmap.org/node/1837443430
-assert_has_feature(
+test.assert_has_feature(
     15, 17100, 11564, 'pois',
     {'id': 1837443430})
 
 # waterway=waterfall
 # https://www.openstreetmap.org/node/4319935813
-assert_has_feature(
+test.assert_has_feature(
     15, 5449, 12526, 'pois',
     {'id': 4319935813})
 
@@ -358,18 +358,18 @@ assert_has_feature(
 # operator=US Forest Service
 # tourism=information
 # https://www.openstreetmap.org/node/4216584100
-assert_has_feature(
+test.assert_has_feature(
     16, 15995, 25090, 'pois',
     {'id': 4216584100})
 
 # originally from 657-natural-man_made.py
 # unnamed rock
 # node 4013703516
-assert_has_feature(
+test.assert_has_feature(
     16, 10463, 25274, 'pois',
     { 'id': 4013703516 })
 
 # node 3150154140
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25294, 'pois',
     { 'id': 3150154140 })

--- a/integration-test/1224-earlier-bike-properties.py
+++ b/integration-test/1224-earlier-bike-properties.py
@@ -1,5 +1,5 @@
 # Bobcat Trail
 # https://www.openstreetmap.org/way/12188550
-assert_has_feature(
+test.assert_has_feature(
     13, 1308, 3164, 'roads',
     {'motor_vehicle': 'no'})

--- a/integration-test/148-sea-ocean-labels-water-layer.py
+++ b/integration-test/148-sea-ocean-labels-water-layer.py
@@ -2,18 +2,18 @@
 # layer.
 
 ## Gulf of California: http://www.openstreetmap.org/node/305639734
-assert_has_feature(
+test.assert_has_feature(
     9, 97, 215, 'water',
     {'kind': 'sea', 'name': 'Gulf of California', 'label_placement': True})
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     9, 97, 215, 'places',
     {'kind': 'sea', 'name': 'Gulf of California'})
 
 ## Greenland Sea: http://www.openstreetmap.org/node/305639396
-assert_has_feature(
+test.assert_has_feature(
     9, 241, 90, 'water',
     {'kind': 'sea', 'name': 'Greenland Sea', 'label_placement': True})
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     9, 241, 90, 'places',
     {'kind': 'sea', 'name': 'Greenland Sea'})
 

--- a/integration-test/160-motorway-junctions.py
+++ b/integration-test/160-motorway-junctions.py
@@ -1,8 +1,8 @@
 # http://www.openstreetmap.org/node/733619113
-assert_has_feature(
+test.assert_has_feature(
     16, 10483, 25332, 'pois',
     { 'kind': 'motorway_junction' })
 
-assert_has_feature(
+test.assert_has_feature(
     14, 2620, 6333, 'pois',
     { 'kind': 'motorway_junction' })

--- a/integration-test/192-shield-text-ref.py
+++ b/integration-test/192-shield-text-ref.py
@@ -1,7 +1,7 @@
 # US 101, "James Lick Freeway"
 # http://www.openstreetmap.org/way/27183379
 # http://www.openstreetmap.org/relation/108619
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25334, 'roads',
     { 'kind': 'highway', 'network': 'US:US', 'id': 27183379,
       'shield_text': '101' })
@@ -13,7 +13,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/relation/2301037
 # http://www.openstreetmap.org/relation/2297359
 # http://www.openstreetmap.org/relation/1027748
-assert_has_feature(
+test.assert_has_feature(
     16, 18022, 25522, 'roads',
     { 'kind': 'highway', 'network': 'US:I', 'id': 51388984,
       'shield_text': '77',
@@ -23,7 +23,7 @@ assert_has_feature(
 # routes with network but no ref should return a null ref.
 # http://www.openstreetmap.org/relation/4069015
 # http://www.openstreetmap.org/relation/6080335
-assert_has_feature(
+test.assert_has_feature(
     16, 14852, 26071, 'roads',
     { 'kind': 'highway', 'id': 290908536,
       'all_networks': ['US:I', 'US:OK:Turnpike'],

--- a/integration-test/197-clip-buildings.py
+++ b/integration-test/197-clip-buildings.py
@@ -21,11 +21,8 @@ with features_in_tile_layer(16, 19295, 24631, 'buildings') as buildings:
             saw_the_high_line = True
 
         if w > max_w or h > max_h:
-            raise Exception("feature %r is %rx%r, larger than the allowed "
-                            "%rx%r."
-                            % (building['properties']['id'],
-                               w, h, max_w, max_h))
+            fail('feature %r is %rx%r, larger than the allowed %rx%r.' %
+                 (building['properties']['id'], w, h, max_w, max_h))
 
     if not saw_the_high_line:
-        raise Exception("Expected to see the High Line in this tile, "
-                        "but didn't.")
+        fail("Expected to see the High Line in this tile, but didn't.")

--- a/integration-test/197-clip-buildings.py
+++ b/integration-test/197-clip-buildings.py
@@ -4,7 +4,7 @@ from shapely.geometry import shape
 # "building". we should be clipping it to a buffer of 3x the tile
 # dimensions.
 # http://www.openstreetmap.org/relation/7141751
-with features_in_tile_layer(16, 19295, 24631, 'buildings') as buildings:
+with test.features_in_tile_layer(16, 19295, 24631, 'buildings') as buildings:
     # max width and height in degress as 3x the size of the above tile
     max_w = 0.0164794921875
     max_h = 0.012484410579673977
@@ -21,8 +21,8 @@ with features_in_tile_layer(16, 19295, 24631, 'buildings') as buildings:
             saw_the_high_line = True
 
         if w > max_w or h > max_h:
-            fail('feature %r is %rx%r, larger than the allowed %rx%r.' %
+            test.fail('feature %r is %rx%r, larger than the allowed %rx%r.' %
                  (building['properties']['id'], w, h, max_w, max_h))
 
     if not saw_the_high_line:
-        fail("Expected to see the High Line in this tile, but didn't.")
+        test.fail("Expected to see the High Line in this tile, but didn't.")

--- a/integration-test/230-place-population-integer.py
+++ b/integration-test/230-place-population-integer.py
@@ -5,14 +5,14 @@
 # San Carlos   http://www.openstreetmap.org/node/150975918
 # Redwood City http://www.openstreetmap.org/node/150946345
 # Menlo Park   http://www.openstreetmap.org/node/150981209
-assert_has_feature(
+test.assert_has_feature(
     11, 328, 793, 'places',
     { 'kind': 'locality',
       'kind_detail': {'city', 'town'},
       'population': int })
 
 # Sacramento, CA http://www.openstreetmap.org/node/150959789
-assert_has_feature(
+test.assert_has_feature(
     8, 41, 98, 'places',
     { 'kind': 'locality', 'kind_detail': 'city', 'region_capital': True,
       'population': int })

--- a/integration-test/244-railway-plaforms.py
+++ b/integration-test/244-railway-plaforms.py
@@ -1,5 +1,5 @@
 # Hunterspoint Avenue LIRR
 # https://www.openstreetmap.org/way/326365794
-assert_has_feature(
+test.assert_has_feature(
     16, 19306, 24633, 'transit',
     { 'kind': 'platform' })

--- a/integration-test/291-483-suppress-historical-closed.py
+++ b/integration-test/291-483-suppress-historical-closed.py
@@ -2,16 +2,16 @@
 # https://www.openstreetmap.org/way/241643507
 
 # building should be present at z15
-assert_has_feature(
+test.assert_has_feature(
     15, 5232, 12654, 'buildings',
     {'id': 241643507, 'kind': 'building', 'kind_detail': 'retail'})
 
 # but POI shouldn't
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5232, 12654, 'pois',
     {'id': 241643507})
 
 # but POI should be present at z17 and marked as closed
-assert_has_feature(
+test.assert_has_feature(
     16, 10465, 25308, 'pois',
     {'id': 241643507, 'kind': 'closed', 'min_zoom': 17})

--- a/integration-test/333-mz_is_building.py
+++ b/integration-test/333-mz_is_building.py
@@ -9,4 +9,4 @@
 with features_in_tile_layer(16, 10470, 25342, 'landuse') as features:
     for feature in features:
         props = feature['properties']
-        assert 'mz_is_building' not in props, 'mz_is_building detected'
+        assertTrue('mz_is_building' not in props, 'mz_is_building detected')

--- a/integration-test/333-mz_is_building.py
+++ b/integration-test/333-mz_is_building.py
@@ -6,7 +6,7 @@
 # RAW QUERY: way(37.72049,-122.48589,37.72918,-122.47472)[building];>;
 # RAW QUERY: relation(37.72049,-122.48589,37.72918,-122.47472)[building];>;
 #
-with features_in_tile_layer(16, 10470, 25342, 'landuse') as features:
+with test.features_in_tile_layer(16, 10470, 25342, 'landuse') as features:
     for feature in features:
         props = feature['properties']
-        assertTrue('mz_is_building' not in props, 'mz_is_building detected')
+        test.assertTrue('mz_is_building' not in props, 'mz_is_building detected')

--- a/integration-test/342-winter-sports-pistes.py
+++ b/integration-test/342-winter-sports-pistes.py
@@ -1,5 +1,5 @@
 # http://www.openstreetmap.org/way/313466665
-assert_has_feature(
+test.assert_has_feature(
     15, 5467, 12531, 'roads',
     { 'kind': 'piste',
       'kind_detail': 'downhill',
@@ -7,7 +7,7 @@ assert_has_feature(
       'id': 313466665 })
 
 # http://www.openstreetmap.org/way/313466720
-assert_has_feature(
+test.assert_has_feature(
     15, 5467, 12531, 'roads',
     { 'kind': 'piste',
       'kind_detail': 'downhill',
@@ -15,7 +15,7 @@ assert_has_feature(
       'id': 313466720 })
 
 # Way: 49'er (313466490) http://www.openstreetmap.org/way/313466490
-assert_has_feature(
+test.assert_has_feature(
     16, 10939, 25061, 'roads',
     { 'kind': 'piste',
       'kind_detail': 'downhill',

--- a/integration-test/343-winter-sports-resorts.py
+++ b/integration-test/343-winter-sports-resorts.py
@@ -1,6 +1,6 @@
 # Heavenly Mountain Resort NV/CA
 # https://www.openstreetmap.org/way/317721523
-assert_has_feature(
+test.assert_has_feature(
     15, 5467, 12531, 'landuse',
     { 'kind': 'winter_sports',
       'sort_rank': 36 })

--- a/integration-test/344-winter-sports-pois.py
+++ b/integration-test/344-winter-sports-pois.py
@@ -1,6 +1,6 @@
 # ski shop in Big Bear Lake, CA
 # https://www.openstreetmap.org/node/2720341705
-assert_has_feature(
+test.assert_has_feature(
     16, 11488, 26126, 'pois',
     { 'kind': 'ski',
       'name': None })
@@ -9,7 +9,7 @@ assert_has_feature(
 # https://www.openstreetmap.org/way/135968166
 # https://www.openstreetmap.org/way/135968170
 # https://www.openstreetmap.org/way/135968168
-assert_has_feature(
+test.assert_has_feature(
     16, 19302, 23765, 'roads',
     { 'kind': 'racetrack',
       'leisure': 'track',

--- a/integration-test/358-merge-same-roads.py
+++ b/integration-test/358-merge-same-roads.py
@@ -18,12 +18,12 @@ def _freeze(thing):
 
     return thing
 
-with features_in_tile_layer(8, 41, 99, 'roads') as roads:
+with test.features_in_tile_layer(8, 41, 99, 'roads') as roads:
     features = set()
 
     for road in roads:
         props = frozenset(_freeze(road['properties']))
         if props in features:
-            fail('Duplicate properties %r in roads layer, but properties '
+            test.fail('Duplicate properties %r in roads layer, but properties '
                  'should be unique.' % road['properties'])
         features.add(props)

--- a/integration-test/358-merge-same-roads.py
+++ b/integration-test/358-merge-same-roads.py
@@ -24,7 +24,6 @@ with features_in_tile_layer(8, 41, 99, 'roads') as roads:
     for road in roads:
         props = frozenset(_freeze(road['properties']))
         if props in features:
-            raise Exception("Duplicate properties %r in roads layer, but "
-                            "properties should be unique."
-                            % road['properties'])
+            fail('Duplicate properties %r in roads layer, but properties '
+                 'should be unique.' % road['properties'])
         features.add(props)

--- a/integration-test/366-beaches.py
+++ b/integration-test/366-beaches.py
@@ -1,5 +1,5 @@
 # Baker beach, SF
 # https://www.openstreetmap.org/relation/6260732
-assert_has_feature(
+test.assert_has_feature(
     16, 10470, 25327, 'landuse',
     { 'kind': 'beach' })

--- a/integration-test/367-military-landuse.py
+++ b/integration-test/367-military-landuse.py
@@ -1,5 +1,5 @@
 # Naval Weapons Station Concord, CA
 # https://www.openstreetmap.org/way/154836419
-assert_has_feature(
+test.assert_has_feature(
     16, 10553, 25274, 'landuse',
     { 'kind': 'military' })

--- a/integration-test/368-disused-railway-stations.py
+++ b/integration-test/368-disused-railway-stations.py
@@ -1,10 +1,10 @@
 # Old South Ferry (1) (disused=yes)
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 19294, 24643, 'pois',
     {'kind': 'station', 'id': 2086974744})
 
 # Valle, AZ (disused=station)
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 12342, 25813, 'pois',
     {'id': 366220389})
 

--- a/integration-test/369-subway-stations-z12.py
+++ b/integration-test/369-subway-stations-z12.py
@@ -1,4 +1,4 @@
 # New York, NY
-assert_has_feature(
+test.assert_has_feature(
     12, 1206, 1539, 'pois',
     { 'kind': 'station' })

--- a/integration-test/370-prisons.py
+++ b/integration-test/370-prisons.py
@@ -6,12 +6,12 @@ tiles = [
 ]
 
 for z, x, y, name in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'pois',
         { 'kind': 'prison',
           'name': name })
 
 # Rikers Island also should have a landuse polygon
-assert_has_feature(
+test.assert_has_feature(
     10, 301, 384, 'landuse',
     { 'kind': 'prison' })

--- a/integration-test/374-electronics-shops.py
+++ b/integration-test/374-electronics-shops.py
@@ -10,7 +10,7 @@ tiles = [
 ]
 
 for z, x, y, name in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'pois',
         { 'kind': 'electronics',
           'name': name })

--- a/integration-test/382-pier-lines.py
+++ b/integration-test/382-pier-lines.py
@@ -1,5 +1,5 @@
 # http://www.openstreetmap.org/way/23783924
-assert_has_feature(
+test.assert_has_feature(
     16, 10467, 25308, 'roads',
     { 'kind': 'path',
       'kind_detail': 'pier' })

--- a/integration-test/398-airport-iata-codes.py
+++ b/integration-test/398-airport-iata-codes.py
@@ -1,13 +1,13 @@
 # San Francisco International
 # https://www.openstreetmap.org/way/23718192
-assert_has_feature(
+test.assert_has_feature(
     13, 1311, 3170, 'pois',
     { 'kind': 'aerodrome',
       'iata': 'SFO' })
 
 # Oakland airport
 # https://www.openstreetmap.org/way/54363486
-assert_has_feature(
+test.assert_has_feature(
     13, 1314, 3167, 'pois',
     { 'kind': 'aerodrome',
       'iata': 'OAK' })

--- a/integration-test/399-add-island-labels.py
+++ b/integration-test/399-add-island-labels.py
@@ -1,20 +1,20 @@
 # Natural Earth 110m
-assert_has_feature(
+test.assert_has_feature(
     1, 0, 0, 'earth',
     { 'kind': 'earth', 'source': 'naturalearthdata.com' })
 
 # Natural Earth 50m
-assert_has_feature(
+test.assert_has_feature(
     2, 0, 1, 'earth',
     { 'kind': 'earth', 'source': 'naturalearthdata.com' })
 
 # Natural Earth 10m
-assert_has_feature(
+test.assert_has_feature(
     8, 40, 98, 'earth',
     { 'kind': 'earth', 'source': 'naturalearthdata.com' })
 
 # OSM derived data from openstreetmapdata.com
-assert_has_feature(
+test.assert_has_feature(
     9, 81, 197, 'earth',
     { 'kind': 'earth', 'source': 'openstreetmapdata.com' })
 
@@ -22,7 +22,7 @@ assert_has_feature(
 
 # NODE continent labels (from places)
 # http://www.openstreetmap.org/node/36966063
-assert_has_feature(
+test.assert_has_feature(
     1, 0, 0, 'earth',
     { 'kind': 'continent', 'label_placement': True, 'name': 'North America' })
 
@@ -30,7 +30,7 @@ assert_has_feature(
 
 # NODE archipelago labels (from place nodes)
 # http://www.openstreetmap.org/node/3860848374
-assert_has_feature(
+test.assert_has_feature(
     15, 10817, 11412, 'earth',
     { 'kind': 'archipelago', 'label_placement': True, 'min_zoom': 15,
       'name': 'Rochers aux Oiseaux' })
@@ -42,7 +42,7 @@ assert_has_feature(
 # MEDIUM archipelago labels (from place polygons)
 # Really these should be lines, but will initially be points
 # http://www.openstreetmap.org/relation/6722301
-assert_has_feature(
+test.assert_has_feature(
     15, 9367, 12534, 'earth',
     { 'kind': 'archipelago', 'label_placement': True, 'min_zoom': 15, 'name': 'Three Sisters Islands' })
 
@@ -50,7 +50,7 @@ assert_has_feature(
 # Really these should be lines, but will initially be points
 # http://www.openstreetmap.org/way/395338481
 # In Europe, with a name, is exported
-assert_has_feature(
+test.assert_has_feature(
     15, 18647, 9497, 'earth',
     { 'kind': 'archipelago', 'label_placement': True, 'name': 'Louekrinpaadet' })
 
@@ -59,56 +59,56 @@ assert_has_feature(
 # NODE island labels (from place nodes)
 # http://www.openstreetmap.org/node/358796350
 # Yerba Buena Island, near SF
-assert_has_feature(
+test.assert_has_feature(
     15, 5245, 12661, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Yerba Buena Island' })
 
 # NODE island labels (from place nodes)
 # http://www.openstreetmap.org/node/358761955
 # Bird Island, north of SF
-assert_has_feature(
+test.assert_has_feature(
     15, 5230, 12659, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Bird Island' })
 
 # NODE island labels (from place nodes)
 # http://www.openstreetmap.org/node/358768646
 # Kent Island, north of SF
-assert_has_feature(
+test.assert_has_feature(
     15, 5217, 12649, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Kent Island' })
 
 # LARGE island labels (from place polygons)
 # http://www.openstreetmap.org/relation/4227580
 # Manitoulin Island, Canada
-assert_has_feature(
+test.assert_has_feature(
     7, 34, 45, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Manitoulin Island' })
 
 # LARGE island labels (from place polygons)
 # http://www.openstreetmap.org/relation/5176042
 # Trinidad, the island of the nation
-assert_has_feature(
+test.assert_has_feature(
     7, 42, 60, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Trinidad' })
 
 # MEDIUM island labels (from place polygons)
 # http://www.openstreetmap.org/way/124916662
 # Cockburn Island, Canada
-assert_has_feature(
+test.assert_has_feature(
     9, 137, 182, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Cockburn Island' })
 
 # MEDIUM island labels (from place polygons)
 # http://www.openstreetmap.org/relation/7117158
 # San Miguel Island, California
-assert_has_feature(
+test.assert_has_feature(
     10, 169, 408, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'San Miguel Island' })
 
 # MEDIUM island labels (from place polygons)
 # http://www.openstreetmap.org/way/40500922
 # West Anacapa Island, California
-assert_has_feature(
+test.assert_has_feature(
     12, 689, 1636, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'West Anacapa Island' })
 
@@ -116,28 +116,28 @@ assert_has_feature(
 # http://www.openstreetmap.org/way/157429145
 # Angel Island, near SF
 # 12, 654, 1581
-assert_has_feature(
+test.assert_has_feature(
     12, 655, 1581, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Angel Island' })
 
 # SMALL island labels (from place polygons)
 # http://www.openstreetmap.org/way/22693068
 # Great Gull Island, NY state
-assert_has_feature(
+test.assert_has_feature(
     15, 9819, 12261, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Great Gull Island' })
 
 # SMALL island labels (from place polygons)
 # http://www.openstreetmap.org/way/308262375
 # Goose Island, NY state
-assert_has_feature(
+test.assert_has_feature(
     16, 19659, 24507, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Goose Island' })
 
 # SMALL island labels (from place polygons)
 # http://www.openstreetmap.org/way/37248735
 # Rincon Island, California
-assert_has_feature(
+test.assert_has_feature(
     16, 11023, 26103, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Rincon Island' })
 
@@ -146,7 +146,7 @@ assert_has_feature(
 # NODE islet labels (from place nodes)
 # http://www.openstreetmap.org/node/358795646
 # Pyramid Rock, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10466, 25327, 'earth',
     { 'kind': 'islet', 'label_placement': True, 'name': 'Pyramid Rock', 'min_zoom': 17 })
 
@@ -154,49 +154,49 @@ assert_has_feature(
 # http://www.openstreetmap.org/way/40500803
 # Sugarloaf Island, west of SF
 # 15, 5188, 12673
-assert_has_feature(
+test.assert_has_feature(
     15, 5188, 12673, 'earth',
     { 'kind': 'islet', 'label_placement': True, 'name': 'Sugarloaf Island' })
 
 # LARGE islet labels (from place polygons)
 # http://www.openstreetmap.org/way/24433344
 # Alcatraz Island, near SF
-assert_has_feature(
+test.assert_has_feature(
     15, 5240, 12659, 'earth',
     { 'kind': 'islet', 'label_placement': True, 'name': 'Alcatraz Island' })
 
 # MEDIUM islet labels (from place polygons)
 # http://www.openstreetmap.org/way/157449982
 # Bird Island, west of SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10493, 25303, 'earth',
     { 'kind': 'islet', 'label_placement': True, 'name': 'Bird Island' })
 
 # SMALL islet labels (from place polygons)
 # http://www.openstreetmap.org/way/306344403
 # Sail Rock, near SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10467, 25395, 'earth',
     { 'kind': 'islet', 'label_placement': True, 'name': 'Sail Rock', 'min_zoom': 17 })
 
 # SMALL islet labels (from place polygons)
 # http://www.openstreetmap.org/way/32289183
 # Little Mile Rock, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10465, 25326, 'earth',
     { 'kind': 'islet', 'label_placement': True, 'name': 'Little Mile Rock', 'min_zoom': 17 })
 
 # LARGE island labels (from place polygons)
 # http://www.openstreetmap.org/relation/4227580
 # Manitoulin Island, Canada
-assert_has_feature(
+test.assert_has_feature(
     7, 34, 45, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Manitoulin Island' })
 
 # LARGE island labels (from place polygons)
 # http://www.openstreetmap.org/relation/5176042
 # Trinidad, the island of the nation
-assert_has_feature(
+test.assert_has_feature(
     7, 42, 60, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Trinidad' })
 
@@ -204,17 +204,17 @@ assert_has_feature(
 # in each tile, only one.
 # http://www.openstreetmap.org/way/26767313
 # Treasure Island, San Francisco
-assert_has_feature(
+test.assert_has_feature(
     14, 2622, 6329, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Treasure Island' })
 # neighbouring tiles should not have a placement
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2623, 6329, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Treasure Island' })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2622, 6340, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Treasure Island' })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2623, 6340, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Treasure Island' })
 
@@ -222,13 +222,13 @@ assert_no_matching_feature(
 # http://www.openstreetmap.org/relation/5344925
 # Islas Marietas
 # main island should get label
-assert_has_feature(
+test.assert_has_feature(
     15, 6773, 14457, 'earth',
     { 'kind': 'island', 'label_placement': True, 'name': 'Islas Marietas' })
 # FUTURE: smaller island parts should not
-#assert_no_matching_feature(
+#test.assert_no_matching_feature(
 #    15, 6774, 14457, 'earth',
 #    { 'kind': 'island', 'label_placement': True, 'name': 'Islas Marietas' })
-#assert_no_matching_feature(
+#test.assert_no_matching_feature(
 #    15, 6775, 14457, 'earth',
 #    { 'kind': 'island', 'label_placement': True, 'name': 'Islas Marietas' })

--- a/integration-test/400-bay-water.py
+++ b/integration-test/400-bay-water.py
@@ -1,17 +1,17 @@
 # San Pablo Bay
 # https://www.openstreetmap.org/way/43950409
-assert_has_feature(
+test.assert_has_feature(
     14, 2623, 6318, 'water',
     { 'kind': 'bay', 'label_placement': True })
 
 # Sansum Narrows
 # https://www.openstreetmap.org/relation/1019862
-assert_has_feature(
+test.assert_has_feature(
     11, 321, 705, 'water',
     { 'kind': 'strait', 'label_placement': True })
 
 # Horsens Fjord
 # https://www.openstreetmap.org/relation/1451065
-assert_has_feature(
+test.assert_has_feature(
     10, 540, 319, 'water',
     { 'kind': 'fjord', 'label_placement': True })

--- a/integration-test/404-toys-not-found.py
+++ b/integration-test/404-toys-not-found.py
@@ -12,6 +12,6 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'pois',
         { 'kind': 'toys' })

--- a/integration-test/418-wof-l10n_name.py
+++ b/integration-test/418-wof-l10n_name.py
@@ -1,6 +1,6 @@
 # Hollywood (wof neighbourhood)
 # https://whosonfirst.mapzen.com/data/858/260/37/85826037.geojson
-assert_has_feature(
+test.assert_has_feature(
     16, 11225, 26158, 'places',
     { 'id': 85826037, 'kind': 'neighbourhood',
       'source': "whosonfirst.mapzen.com",
@@ -9,7 +9,7 @@ assert_has_feature(
 
 # San Francisco (wof neighbourhood)
 # https://whosonfirst.mapzen.com/data/858/826/41/85882641.geojson
-assert_has_feature(
+test.assert_has_feature(
     16, 14893, 29234, 'places',
     { 'id': 85882641, 'kind': 'neighbourhood',
       'source': "whosonfirst.mapzen.com",
@@ -21,7 +21,7 @@ assert_has_feature(
 #
 # note: presence of Chinese name tested, but not its value, as that can and
 # does change.
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25330, 'places',
     { 'id': 26819236, 'kind': 'locality', 'kind_detail': 'city',
       'source': "openstreetmap.org",
@@ -30,7 +30,7 @@ assert_has_feature(
 
 # Node: Londonderry/Derry (267762522)
 # http://www.openstreetmap.org/node/267762522
-assert_has_feature(
+test.assert_has_feature(
     16, 31436, 20731, 'places',
     { 'id': 267762522, 'name:en_GB': 'Londonderry'})
 
@@ -39,7 +39,7 @@ assert_has_feature(
 #
 # note: presence of Chinese name tested, but not its value, as that can and
 # does change.
-assert_has_feature(
+test.assert_has_feature(
     16, 39180, 26661, 'places',
     { 'id': 29090735,
       'name:zh-min-nan': None,

--- a/integration-test/421-zoos-z13.py
+++ b/integration-test/421-zoos-z13.py
@@ -1,5 +1,5 @@
 # Zoo Montana, Billings, MT
 # https://www.openstreetmap.org/node/2274329294
-assert_has_feature(
+test.assert_has_feature(
     13, 1624, 2923, 'pois',
     { 'kind': 'zoo' })

--- a/integration-test/440-zoos-and-other-attractions-attraction.py
+++ b/integration-test/440-zoos-and-other-attractions-attraction.py
@@ -27,14 +27,14 @@ for layer in ['pois', 'landuse']:
     ]
 
     for z, x, y, osm_id, attraction in attraction_values:
-        assert_has_feature(
+        test.assert_has_feature(
             z, x, y, layer,
             { 'id': osm_id,
               'kind': attraction })
 
 # This is a carousel, but also a building, which keeps it out of the landuse
 # layer. See https://github.com/mapzen/vector-datasource/issues/201
-assert_has_feature(
+test.assert_has_feature(
     16, 17383, 25023, 'pois',
     { 'id': 325824281,
       'kind': 'carousel' })

--- a/integration-test/440-zoos-and-other-attractions-barrier.py
+++ b/integration-test/440-zoos-and-other-attractions-barrier.py
@@ -1,5 +1,5 @@
 # barrier=fence around enclosures
 # https://www.openstreetmap.org/way/316623706
-assert_has_feature(
+test.assert_has_feature(
     16, 11458, 21855, 'landuse',
     { 'kind': 'fence' })

--- a/integration-test/440-zoos-and-other-attractions-tourism.py
+++ b/integration-test/440-zoos-and-other-attractions-tourism.py
@@ -26,7 +26,7 @@ for layer in ['pois', 'landuse']:
     ]
 
     for z, x, y, osm_id, tourism in tourism_values:
-        assert_has_feature(
+        test.assert_has_feature(
             z, x, y, layer,
             { 'id': osm_id,
               'kind': tourism })
@@ -34,12 +34,12 @@ for layer in ['pois', 'landuse']:
 # these are POIs, but also a buildings, so they won't show up in the landuse
 # layer.
 # Wendy Thompson Hut, BC
-assert_has_feature(
+test.assert_has_feature(
     15, 5236, 11051, 'pois',
     { 'id': 220084069,
       'kind': 'wilderness_hut' })
 # Scharffenberger Winery
-assert_has_feature(
+test.assert_has_feature(
     16, 10296, 25030, 'pois',
     { 'id': 242899474,
       'kind': 'winery' })
@@ -47,7 +47,7 @@ assert_has_feature(
 # this is a POI, but also a point, so as it has no area, it won't show up
 # in the landuse layer.
 # http://www.openstreetmap.org/node/3095286850
-assert_has_feature(
+test.assert_has_feature(
     16, 34893, 21123, 'pois',
     { 'id': 3095286850,
       'kind': 'trail_riding_station' })

--- a/integration-test/440-zoos-and-other-attractions-zoo.py
+++ b/integration-test/440-zoos-and-other-attractions-zoo.py
@@ -21,14 +21,14 @@ for layer in ['pois', 'landuse']:
     ]
 
     for z, x, y, osm_id, zoo in zoo_values:
-        assert_has_feature(
+        test.assert_has_feature(
             z, x, y, layer,
             { 'id': osm_id,
               'kind': zoo })
 
 # this is a building, so won't show up in landuse. still should be a POI.
 # Wings of Asia
-assert_has_feature(
+test.assert_has_feature(
     16, 18131, 27942, 'pois',
     { 'id': 103256220,
       'kind': 'aviary' })

--- a/integration-test/440-zoos-and-other-attractions.py
+++ b/integration-test/440-zoos-and-other-attractions.py
@@ -16,7 +16,7 @@ for layer in ['pois', 'landuse']:
     #
     # kind: enclosure, attraction: animal, name: Asian Rhino, natural: sand and
     # tourism: attraction
-    # assert_has_feature(
+    # test.assert_has_feature(
     #     19, 83737, 202725, layer,
     #     { 'id': -5695997,
     #       'osm_relation': True,
@@ -31,14 +31,14 @@ for layer in ['pois', 'landuse']:
     # attraction.
     # NOTE: updated to a feature in North America: MarineLand, Niagara Falls,
     # ON.
-    assert_has_feature(
+    test.assert_has_feature(
         16, 18373, 24066, layer,
         { 'id': 177402901,
           'kind': 'attraction' })
 
     # pipe through religion on resorts
     # La Foret Conference & Retreat Center (way 228716140)
-    assert_has_feature(
+    test.assert_has_feature(
         15, 6852, 12522, layer,
         { 'kind': 'resort',
           'religion': 'christian' })
@@ -53,7 +53,7 @@ for layer in ['pois', 'landuse']:
 #
 # TAGS: attraction=carousel, building=yes, name=King Arthur Carrousel,
 # tourism=attraction
-assert_has_feature(
+test.assert_has_feature(
     16, 11301, 26220, 'pois',
     { 'id': 129691054,
       'kind': 'carousel' })
@@ -62,7 +62,7 @@ assert_has_feature(
 # TAGS: attraction=roller_coaster, building=yes, name=Matterhorn Bobsleds,
 # tourism=attraction
 ## way 107280556 http://c.tile.openstreetmap.org/17/22603/52441.png
-assert_has_feature(
+test.assert_has_feature(
     16, 11301, 26220, 'pois',
     { 'id': 107280556,
       'kind': 'roller_coaster' })

--- a/integration-test/443-swimming-pools.py
+++ b/integration-test/443-swimming-pools.py
@@ -8,6 +8,6 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'water',
         { 'kind': 'swimming_pool' })

--- a/integration-test/447-ice-cream-shops.py
+++ b/integration-test/447-ice-cream-shops.py
@@ -1,11 +1,11 @@
 # New York, NY (amenity=ice_cream)
 #https://www.openstreetmap.org/node/2782000317
-assert_has_feature(
+test.assert_has_feature(
     16, 19299, 24629, 'pois',
     { 'kind': 'ice_cream' })
 
 # Oakland, CA (shop=ice_cream)
 #https://www.openstreetmap.org/node/661742947
-assert_has_feature(
+test.assert_has_feature(
     16, 10512, 25314, 'pois',
     { 'kind': 'ice_cream' })

--- a/integration-test/448-wine-and-alcohol-shops.py
+++ b/integration-test/448-wine-and-alcohol-shops.py
@@ -1,11 +1,11 @@
 # Wine, New York, NY
 #https://www.openstreetmap.org/node/2549960970
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24632, 'pois',
     { 'kind': 'wine' })
 
 # Alcohol, San Francisco, CA
 #https://www.openstreetmap.org/node/1713269631
-assert_has_feature(
+test.assert_has_feature(
     16, 10480, 25336, 'pois',
     { 'kind': 'alcohol' })

--- a/integration-test/454-aeroway-gates.py
+++ b/integration-test/454-aeroway-gates.py
@@ -1,5 +1,5 @@
 # Gate A5, SFO
 #https://www.openstreetmap.org/node/656398641
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25368, 'pois',
     { 'kind': 'aeroway_gate' })

--- a/integration-test/465-fitness-pois.py
+++ b/integration-test/465-fitness-pois.py
@@ -11,12 +11,12 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'pois',
         { 'kind': 'fitness' })
 
 # Pushup, fitness_station
 #https://www.openstreetmap.org/node/3658323774
-assert_has_feature(
+test.assert_has_feature(
     16, 13166, 25271, 'pois',
     { 'kind': 'fitness_station' })

--- a/integration-test/469-transit-features.py
+++ b/integration-test/469-transit-features.py
@@ -1,14 +1,14 @@
 # way 91806504
-assert_has_feature(
+test.assert_has_feature(
     16, 10470, 25316, 'transit',
     { 'kind': 'bus_stop' })
 
 # node 1241518350
-assert_has_feature(
+test.assert_has_feature(
     16, 10480, 25332, 'pois',
     { 'kind': 'bus_stop' })
 
 # way 196670577
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, 'transit',
     { 'kind': 'platform' })

--- a/integration-test/471-categorize-trains.py
+++ b/integration-test/471-categorize-trains.py
@@ -1,14 +1,14 @@
 # relation 2812900
-assert_has_feature(
+test.assert_has_feature(
     5, 5, 12, 'transit',
     { 'kind': 'train', 'service': 'long_distance' })
 
 # relation 4460896
-assert_has_feature(
+test.assert_has_feature(
     5, 9, 12, 'transit',
     { 'kind': 'train', 'service': 'high_speed' })
 
 # relation 4467189
-assert_has_feature(
+test.assert_has_feature(
     5, 9, 12, 'transit',
     { 'kind': 'train', 'service': 'international' })

--- a/integration-test/472-adjust-transit-zoom-ranges.py
+++ b/integration-test/472-adjust-transit-zoom-ranges.py
@@ -1,17 +1,17 @@
 # SFO-Pittsburg/Bay Point BART
 #https://www.openstreetmap.org/relation/2827684
-assert_has_feature(
+test.assert_has_feature(
     8, 40, 98, 'transit',
     { 'kind': 'subway' })
 
 # N-Judah Muni
 #https://www.openstreetmap.org/relation/63223
-assert_has_feature(
+test.assert_has_feature(
     9, 81, 197, 'transit',
     { 'kind': 'light_rail' })
 
 # F-Market & Wharves tram
 #https://www.openstreetmap.org/relation/2007934
-assert_has_feature(
+test.assert_has_feature(
     9, 81, 197, 'transit',
     { 'kind': 'tram' })

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -1,20 +1,20 @@
 # http://www.openstreetmap.org/relation/1453306
 # area 1.75564e+10
-assert_has_feature(
+test.assert_has_feature(
     4, 3, 5, 'landuse',
     { 'kind': 'national_park', 'id': -1453306, 'tier': 1,
       'min_zoom': 3 })
-assert_has_feature(
+test.assert_has_feature(
     6, 12, 23, 'pois',
     { 'kind': 'national_park', 'id': -1453306, 'tier': 1,
       'min_zoom': 3.74 })
 
 # http://www.openstreetmap.org/relation/921675
 # area 30089300
-assert_has_feature(
+test.assert_has_feature(
     8, 56, 115, 'landuse',
     { 'kind': 'national_park', 'tier': 1, 'min_zoom': 8 })
-assert_has_feature(
+test.assert_has_feature(
     8, 56, 115, 'pois',
     { 'kind': 'national_park', 'id': -921675, 'tier': 1,
       'min_zoom': 8.33 })
@@ -22,7 +22,7 @@ assert_has_feature(
 # this is USFS, so demoted to tier 2 :-(
 # http://www.openstreetmap.org/way/34416231
 # area 86685400
-assert_has_feature(
+test.assert_has_feature(
     8, 71, 98, 'landuse',
     { 'kind': 'forest', 'id': 34416231,
       'tier': 2, 'min_zoom': 8 })
@@ -31,7 +31,7 @@ assert_has_feature(
 #
 # note that the feature _is_ present in the zoom 8 tile, but gets merged
 # with a nearby feature of the same name, so instead we test this at z9.
-assert_has_feature(
+test.assert_has_feature(
     9, 142, 196, 'pois',
     { 'kind': 'forest', 'id': 34416231,
       'tier': 2, 'min_zoom': 8 })

--- a/integration-test/479-barrier-toll_booth.py
+++ b/integration-test/479-barrier-toll_booth.py
@@ -1,10 +1,10 @@
 # http://www.openstreetmap.org/way/25814380
-assert_has_feature(
+test.assert_has_feature(
     16, 10471, 25323, 'pois',
     { 'id': 25814380, 'kind': 'toll_booth' })
 
 # Node: Main Gate (392430963)
 # http://www.openstreetmap.org/node/392430963
-assert_has_feature(
+test.assert_has_feature(
     16, 10473, 25332, 'pois',
     { 'id': 392430963, 'kind': 'toll_booth' })

--- a/integration-test/480-rest_area-services.py
+++ b/integration-test/480-rest_area-services.py
@@ -1,22 +1,22 @@
 # node: Tiffin River
 # http://www.openstreetmap.org/node/200412620
-assert_has_feature(
+test.assert_has_feature(
     16, 17401, 24424, 'pois',
     { 'kind': 'service_area', 'id': 200412620, 'min_zoom': 11 })
 
 # http://www.openstreetmap.org/node/159773030
-assert_has_feature(
+test.assert_has_feature(
     16, 18798, 24573, 'pois',
     { 'kind': 'rest_area', 'id': 159773030, 'min_zoom': 11 })
 
 # Way: Crystal Springs Rest Area (97057565)
 # http://www.openstreetmap.org/way/97057565
-assert_has_feature(
+test.assert_has_feature(
     16, 10492, 25385, 'landuse',
     { 'kind': 'rest_area', 'id': 97057565, 'sort_rank': 41 })
 
 # Way: Nicole Driveway (274732386)
 # http://www.openstreetmap.org/way/274732386
-assert_has_feature(
+test.assert_has_feature(
     16, 10900, 25256, 'landuse',
     { 'kind': 'service_area', 'id': 274732386, 'sort_rank': 42 })

--- a/integration-test/484-include-state-pois.py
+++ b/integration-test/484-include-state-pois.py
@@ -1,11 +1,11 @@
 # Antioch Station
 #https://www.openstreetmap.org/node/3353451464
-assert_has_feature(
+test.assert_has_feature(
     16, 10597, 25279, 'pois',
     {'id': 3353451464, 'state': 'proposed'})
 
 # Pittsburg Center
 #https://www.openstreetmap.org/node/3354463416
-assert_has_feature(
+test.assert_has_feature(
     16, 10578, 25275, 'pois',
     {'id': 3354463416, 'state': 'proposed'})

--- a/integration-test/488-motorway_link-z11.py
+++ b/integration-test/488-motorway_link-z11.py
@@ -3,12 +3,12 @@ locations = [
 ]
 
 for z, x, y in locations:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'roads',
         { 'kind': 'highway',
           'is_link': True,
           'kind_detail': 'motorway_link'})
-    assert_no_matching_feature(
+    test.assert_no_matching_feature(
         z-1, x/2, y/2, 'roads',
         { 'kind': 'highway',
           'is_link': True,

--- a/integration-test/489-keep-ref-for-major-roads.py
+++ b/integration-test/489-keep-ref-for-major-roads.py
@@ -2,7 +2,7 @@
 # RAW QUERY: way(40.4553,-73.8391,41.0068,-73.1167)[highway=motorway];>;
 # RAW QUERY: way(40.4553,-73.8391,41.0068,-73.1167)[highway=trunk];>;
 # RAW QUERY: way(40.4553,-73.8391,41.0068,-73.1167)[highway=primary];>;
-assert_has_feature(
+test.assert_has_feature(
     9, 151, 192, 'roads',
     { 'kind': 'major_road',
       'ref': None })

--- a/integration-test/501-drop-physical-railways-from-transit.py
+++ b/integration-test/501-drop-physical-railways-from-transit.py
@@ -12,7 +12,6 @@ with features_in_tile_layer(7, 20, 48, 'transit') as transit:
         if feature['properties'].get('kind') in railway_kinds:
             props = frozenset(feature['properties'].items())
             if props in seen_properties:
-                raise Exception("Duplicate properties %r in transit layer, but "
-                                "properties should be unique."
-                                % feature['properties'])
+                fail('Duplicate properties %r in transit layer, but properties '
+                     'should be unique.' % feature['properties'])
             seen_properties.add(props)

--- a/integration-test/501-drop-physical-railways-from-transit.py
+++ b/integration-test/501-drop-physical-railways-from-transit.py
@@ -1,10 +1,10 @@
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     7, 20, 48, 'transit',
     {'kind': 'railway'})
 
 # count the unique parameters - there should only be one, indicating that the
 # rail routes have been merged.
-with features_in_tile_layer(7, 20, 48, 'transit') as transit:
+with test.features_in_tile_layer(7, 20, 48, 'transit') as transit:
     seen_properties = set()
     railway_kinds = set(['train', 'subway', 'light_rail', 'tram'])
 
@@ -12,6 +12,6 @@ with features_in_tile_layer(7, 20, 48, 'transit') as transit:
         if feature['properties'].get('kind') in railway_kinds:
             props = frozenset(feature['properties'].items())
             if props in seen_properties:
-                fail('Duplicate properties %r in transit layer, but properties '
+                test.fail('Duplicate properties %r in transit layer, but properties '
                      'should be unique.' % feature['properties'])
             seen_properties.add(props)

--- a/integration-test/502-water-boundaries-slow.py
+++ b/integration-test/502-water-boundaries-slow.py
@@ -17,7 +17,7 @@ boundary_tiles = [
 ]
 
 for z, x, y in no_boundary_tiles:
-    with features_in_tile_layer(z, x, y, 'water') as features:
+    with test.features_in_tile_layer(z, x, y, 'water') as features:
         num_polygons = 0
         num_boundaries = 0
 
@@ -32,14 +32,14 @@ for z, x, y in no_boundary_tiles:
                 num_boundaries += 1
 
         if num_polygons < 2:
-            fail('Expected at least 2 polygons in water boundary '
+            test.fail('Expected at least 2 polygons in water boundary '
                  'test tile, but found only %d' % num_polygons)
 
         if num_boundaries > 0:
-            fail('Expected an all-water tile with no land '
+            test.fail('Expected an all-water tile with no land '
                  'boundaries, but found %d boundaries.' % num_boundaries)
 
 for z, x, y in boundary_tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'water',
         {'boundary': True})

--- a/integration-test/502-water-boundaries-slow.py
+++ b/integration-test/502-water-boundaries-slow.py
@@ -32,12 +32,12 @@ for z, x, y in no_boundary_tiles:
                 num_boundaries += 1
 
         if num_polygons < 2:
-            raise Exception, "Expected at least 2 polygons in water boundary " \
-                "test tile, but found only %d" % num_polygons
+            fail('Expected at least 2 polygons in water boundary '
+                 'test tile, but found only %d' % num_polygons)
 
         if num_boundaries > 0:
-            raise Exception, "Expected an all-water tile with no land " \
-                "boundaries, but found %d boundaries." % num_boundaries
+            fail('Expected an all-water tile with no land '
+                 'boundaries, but found %d boundaries.' % num_boundaries)
 
 for z, x, y in boundary_tiles:
     assert_has_feature(

--- a/integration-test/507-routes-via-stop-positions.py
+++ b/integration-test/507-routes-via-stop-positions.py
@@ -115,7 +115,7 @@ stations = [
 ]
 
 for z, x, y, name, osm_id, expected_rank, expected_routes in stations:
-    with features_in_tile_layer(z, x, y, 'pois') as pois:
+    with test.features_in_tile_layer(z, x, y, 'pois') as pois:
         found = False
 
         for poi in pois:
@@ -128,7 +128,7 @@ for z, x, y, name, osm_id, expected_rank, expected_routes in stations:
                 rank = props['kind_tile_rank']
 
                 if rank > expected_rank:
-                    fail('Found %r, and was expecting a rank of %r or less, '
+                    test.fail('Found %r, and was expecting a rank of %r or less, '
                          'but got %r.' % (name, expected_rank, rank))
 
                 for r in expected_routes:
@@ -138,9 +138,9 @@ for z, x, y, name, osm_id, expected_rank, expected_routes in stations:
                             count = count + 1
 
                     if count == 0:
-                        fail('Found %r, and was expecting at least one %r '
+                        test.fail('Found %r, and was expecting at least one %r '
                              'route, but found none. Routes: %r' %
                              (name, r, routes))
 
         if not found:
-            fail('Did not find %r (ID=%r) in tile.' % (name, osm_id))
+            test.fail('Did not find %r (ID=%r) in tile.' % (name, osm_id))

--- a/integration-test/507-routes-via-stop-positions.py
+++ b/integration-test/507-routes-via-stop-positions.py
@@ -128,9 +128,8 @@ for z, x, y, name, osm_id, expected_rank, expected_routes in stations:
                 rank = props['kind_tile_rank']
 
                 if rank > expected_rank:
-                    raise Exception("Found %r, and was expecting a rank "
-                                    "of %r or less, but got %r."
-                                    % (name, expected_rank, rank))
+                    fail('Found %r, and was expecting a rank of %r or less, '
+                         'but got %r.' % (name, expected_rank, rank))
 
                 for r in expected_routes:
                     count = 0
@@ -139,10 +138,9 @@ for z, x, y, name, osm_id, expected_rank, expected_routes in stations:
                             count = count + 1
 
                     if count == 0:
-                        raise Exception("Found %r, and was expecting at "
-                                        "least one %r route, but found "
-                                        "none. Routes: %r"
-                                        % (name, r, routes))
+                        fail('Found %r, and was expecting at least one %r '
+                             'route, but found none. Routes: %r' %
+                             (name, r, routes))
 
         if not found:
-            raise Exception("Did not find %r (ID=%r) in tile." % (name, osm_id))
+            fail('Did not find %r (ID=%r) in tile.' % (name, osm_id))

--- a/integration-test/510-funicular.py
+++ b/integration-test/510-funicular.py
@@ -1,4 +1,4 @@
 #https://www.openstreetmap.org/way/393550019
-assert_has_feature(
+test.assert_has_feature(
     16, 10481, 25345, 'roads',
     { 'kind': 'rail', 'kind_detail': 'funicular' })

--- a/integration-test/520-big-box-stores.py
+++ b/integration-test/520-big-box-stores.py
@@ -17,4 +17,4 @@ tiles = [
 
 for zxy, id, kind in tiles:
     z, x, y = map(int, zxy.split('/'))
-    assert_has_feature(z, x, y, 'pois', {'kind': kind, 'id': id})
+    test.assert_has_feature(z, x, y, 'pois', {'kind': kind, 'id': id})

--- a/integration-test/522-hotels.py
+++ b/integration-test/522-hotels.py
@@ -1,9 +1,9 @@
 #https://www.openstreetmap.org/way/32947245
-assert_has_feature(
+test.assert_has_feature(
     15, 5242, 12663, 'pois',
     { 'kind': 'hotel', 'name': 'Ritz-Carlton' })
 
 #http://www.openstreetmap.org/relation/1358120
-assert_has_feature(
+test.assert_has_feature(
     16, 10483, 25323, 'pois',
     { 'kind': 'hotel', 'name': 'Hotel Zephyr' })

--- a/integration-test/523-add-elevation-to-peaks.py
+++ b/integration-test/523-add-elevation-to-peaks.py
@@ -4,13 +4,13 @@
 
 #http://www.openstreetmap.org/node/358915477
 # Mount Elbert, CO
-assert_has_feature(
+test.assert_has_feature(
     9, 104, 195, 'pois',
     { 'kind': 'peak', 'id': 358915477, 'elevation': 4397 })
 
 # http://www.openstreetmap.org/node/1744903493
 # Mount Rainier, WA (volcano)
-assert_has_feature(
+test.assert_has_feature(
     9, 82, 180, 'pois',
     { 'kind': 'volcano', 'id': 1744903493, 'elevation': 4392 })
 
@@ -19,8 +19,8 @@ assert_has_feature(
 ##
 
 def assert_feature_min_zoom(z, x, y, layer, props):
-    assert_has_feature(z, x, y, layer, props)
-    assert_no_matching_feature(z-1, x/2, y/2, layer, props)
+    test.assert_has_feature(z, x, y, layer, props)
+    test.assert_no_matching_feature(z-1, x/2, y/2, layer, props)
 
 # http://www.openstreetmap.org/node/358792071
 # San Gorgonio Mountain

--- a/integration-test/524-peak-kind-tile-rank.py
+++ b/integration-test/524-peak-kind-tile-rank.py
@@ -57,13 +57,13 @@ def count_matching(features, props):
     return num_matches
 
 
-with features_in_tile_layer(11, 420, 779, 'pois') as features:
+with test.features_in_tile_layer(11, 420, 779, 'pois') as features:
     def assert_peak(rank, elevation, name):
         properties = {'kind': 'peak', 'elevation': elevation, 'name': name,
                       'kind_tile_rank': rank}
         num_matching = count_matching(features, properties)
         if num_matching != 1:
-            fail('Did not find peak matching properties %r.' % properties)
+            test.fail('Did not find peak matching properties %r.' % properties)
 
     assert_peak(1, 4348, 'Quandary Peak')
     assert_peak(2, 4239, 'Fletcher Mountain')
@@ -73,7 +73,7 @@ with features_in_tile_layer(11, 420, 779, 'pois') as features:
 
     num_matching = count_matching(features, {'kind': 'peak'})
     if num_matching > 5:
-        fail('Found %d peaks, but should only have five.' % num_matching)
+        test.fail('Found %d peaks, but should only have five.' % num_matching)
 
 # this tile has 7 peaks in it, and at z16 we should keep all of them
 #https://www.openstreetmap.org/node/767614798
@@ -83,16 +83,16 @@ with features_in_tile_layer(11, 420, 779, 'pois') as features:
 #https://www.openstreetmap.org/node/774446221
 #https://www.openstreetmap.org/node/774446223
 #https://www.openstreetmap.org/node/774446224
-with features_in_tile_layer(16, 12372, 26269, 'pois') as features:
+with test.features_in_tile_layer(16, 12372, 26269, 'pois') as features:
     num = count_matching(features, {'kind': 'peak'})
     if num != 7:
-        fail('Found %d peaks, but expected seven.' % num)
+        test.fail('Found %d peaks, but expected seven.' % num)
 
 # check that volcanos are sorted along with other kinds of peak
 #https://www.openstreetmap.org/node/1744903493
 #https://www.openstreetmap.org/node/356546139
 #https://www.openstreetmap.org/node/348179123
-with features_in_tile_layer(12, 662, 1443, 'pois') as features:
+with test.features_in_tile_layer(12, 662, 1443, 'pois') as features:
     def assert_peak(rank_spec, elevation, kind, name):
         if isinstance(rank_spec, int):
             possible_ranks = [rank_spec]
@@ -107,7 +107,7 @@ with features_in_tile_layer(12, 662, 1443, 'pois') as features:
                 matched_one = True
                 break
         if not matched_one:
-            fail('Did not find %s matching properties %r.' %
+            test.fail('Did not find %s matching properties %r.' %
                  (kind, properties))
 
     assert_peak(1,      4392, 'volcano', 'Mount Rainier')

--- a/integration-test/524-peak-kind-tile-rank.py
+++ b/integration-test/524-peak-kind-tile-rank.py
@@ -63,8 +63,7 @@ with features_in_tile_layer(11, 420, 779, 'pois') as features:
                       'kind_tile_rank': rank}
         num_matching = count_matching(features, properties)
         if num_matching != 1:
-            raise Exception, "Did not find peak matching properties %r." \
-                % properties
+            fail('Did not find peak matching properties %r.' % properties)
 
     assert_peak(1, 4348, 'Quandary Peak')
     assert_peak(2, 4239, 'Fletcher Mountain')
@@ -74,8 +73,7 @@ with features_in_tile_layer(11, 420, 779, 'pois') as features:
 
     num_matching = count_matching(features, {'kind': 'peak'})
     if num_matching > 5:
-        raise Exception, "Found %d peaks, but should only have five." \
-            % num_matching
+        fail('Found %d peaks, but should only have five.' % num_matching)
 
 # this tile has 7 peaks in it, and at z16 we should keep all of them
 #https://www.openstreetmap.org/node/767614798
@@ -88,7 +86,7 @@ with features_in_tile_layer(11, 420, 779, 'pois') as features:
 with features_in_tile_layer(16, 12372, 26269, 'pois') as features:
     num = count_matching(features, {'kind': 'peak'})
     if num != 7:
-        raise Exception, "Found %d peaks, but expected seven." % num
+        fail('Found %d peaks, but expected seven.' % num)
 
 # check that volcanos are sorted along with other kinds of peak
 #https://www.openstreetmap.org/node/1744903493
@@ -109,8 +107,8 @@ with features_in_tile_layer(12, 662, 1443, 'pois') as features:
                 matched_one = True
                 break
         if not matched_one:
-            raise Exception, "Did not find %s matching properties %r." \
-                % (kind, properties)
+            fail('Did not find %s matching properties %r.' %
+                 (kind, properties))
 
     assert_peak(1,      4392, 'volcano', 'Mount Rainier')
     assert_peak(2,      4302, 'peak',    'Point Success')

--- a/integration-test/526-inclusive-pois.py
+++ b/integration-test/526-inclusive-pois.py
@@ -48,4 +48,4 @@ tiles = [
 
 for loc, props in tiles:
     z, x, y = map(int, loc.split('/'))
-    assert_has_feature(z, x, y, 'pois', props)
+    test.assert_has_feature(z, x, y, 'pois', props)

--- a/integration-test/546-road-sort-keys-aerialway.py
+++ b/integration-test/546-road-sort-keys-aerialway.py
@@ -1,23 +1,23 @@
 #https://www.openstreetmap.org/way/32051122
-assert_has_feature(
+test.assert_has_feature(
     16, 19321, 23740, "roads",
     {"kind": "aerialway", "kind_detail": "gondola", "id": 32051122,
      "sort_rank": 442})
 
 #https://www.openstreetmap.org/way/384371038
-assert_has_feature(
+test.assert_has_feature(
     16, 14894, 29232, "roads",
     {"kind": "aerialway", "kind_detail": "cable_car", "id": 384371038,
      "sort_rank": 442})
 
 #https://www.openstreetmap.org/way/113791306
-assert_has_feature(
+test.assert_has_feature(
     16, 10553, 25492, "roads",
     {"kind": "aerialway", "kind_detail": "chair_lift", "id": 113791306,
      "sort_rank": 441})
 
 #https://www.openstreetmap.org/way/209129274
-assert_has_feature(
+test.assert_has_feature(
     16, 10719, 25012, "roads",
     {"kind": "aerialway", "kind_detail": "rope_tow", "id": 209129274,
      "sort_rank": 440})

--- a/integration-test/546-road-sort-keys-aeroway.py
+++ b/integration-test/546-road-sort-keys-aeroway.py
@@ -1,11 +1,11 @@
 #https://www.openstreetmap.org/way/214484985
-assert_has_feature(
+test.assert_has_feature(
     16, 18957, 24538, "roads",
     {"kind": "aeroway", "kind_detail": "runway", "id": 214484985,
      "sort_rank": 62})
 
 #https://www.openstreetmap.org/way/115434129
-assert_has_feature(
+test.assert_has_feature(
     16, 18981, 24490, "roads",
     {"kind": "aeroway", "kind_detail": "taxiway", "id": 115434129,
      "sort_rank": 61})

--- a/integration-test/546-road-sort-keys-bridges.py
+++ b/integration-test/546-road-sort-keys-bridges.py
@@ -1,42 +1,42 @@
 # bridges
 #https://www.openstreetmap.org/way/28412298
-assert_has_feature(
+test.assert_has_feature(
     16, 10472, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "id": 28412298,
      "name": "Presidio Pkwy.", "is_bridge": True, "sort_rank": 443})
 
 #https://www.openstreetmap.org/way/59801274
-assert_has_feature(
+test.assert_has_feature(
     16, 10471, 25331, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 59801274,
      "name": "Crossover Dr.", "is_bridge": True, "sort_rank": 443})
 
 #http://www.openstreetmap.org/way/399640204
-assert_has_feature(
+test.assert_has_feature(
     16, 11265, 26221, "roads",
     {"kind": "major_road", "kind_detail": "primary", "id": 399640204,
      "name": "North Los Coyotes Diagonal", "is_bridge": True, "sort_rank": 430})
 
 #https://www.openstreetmap.org/way/27613581
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25339, "roads",
     {"kind": "major_road", "kind_detail": "secondary", "id": 27613581,
      "name": "Oakdale Ave.", "is_bridge": True, "sort_rank": 429})
 
 #https://www.openstreetmap.org/way/242940297
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25327, "roads",
     {"kind": "major_road", "kind_detail": "tertiary", "id": 242940297,
      "name": "Beale St.", "is_bridge": True, "sort_rank": 427})
 
 #https://www.openstreetmap.org/way/162038104
-assert_has_feature(
+test.assert_has_feature(
     16, 10738, 24989, "roads",
     {"kind": "minor_road", "kind_detail": "residential", "id": 162038104,
      "name": "Woodwardia Pl.", "sort_rank": 410})
 
 #http://www.openstreetmap.org/way/232303398
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25363, "roads",
     {"id": 232303398, "kind": "minor_road", "kind_detail": "service",
      "is_bridge": True, "sort_rank": 408})

--- a/integration-test/546-road-sort-keys-layers.py
+++ b/integration-test/546-road-sort-keys-layers.py
@@ -1,48 +1,48 @@
 # layer 5
 #https://www.openstreetmap.org/way/8918870
-assert_has_feature(
+test.assert_has_feature(
     16, 10483, 25340, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 8918870, "sort_rank": 447})
 
 # layer 4
 #https://www.openstreetmap.org/way/27614705
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25340, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 27614705, "sort_rank": 446})
 
 # layer 3
 #https://www.openstreetmap.org/way/29394019
-assert_has_feature(
+test.assert_has_feature(
     16, 10479, 25341, "roads",
     {"kind": "highway", "kind_detail": "motorway_link", "is_bridge": True,
      "id": 29394019, "sort_rank": 445})
 
 # layer 2
 #https://www.openstreetmap.org/way/48037053
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25339, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 48037053, "sort_rank": 444})
 
 # layer 1
 #https://www.openstreetmap.org/way/28412298
-assert_has_feature(
+test.assert_has_feature(
     16, 10472, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_bridge": True,
      "id": 28412298, "sort_rank": 443})
 
 # layer -1
 #https://www.openstreetmap.org/way/43685501
-assert_has_feature(
+test.assert_has_feature(
     16, 10472, 25323, "roads",
     {"kind": "minor_road", "kind_detail": "service", "is_tunnel": True,
      "id": 43685501, "sort_rank": 304})
 
 # layer -2
 #https://www.openstreetmap.org/way/50691047
-assert_has_feature(
+test.assert_has_feature(
     16, 10491, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "is_tunnel": True,
      "id": 50691047, "sort_rank": 303})

--- a/integration-test/546-road-sort-keys-railways.py
+++ b/integration-test/546-road-sort-keys-railways.py
@@ -1,53 +1,53 @@
 # Railways
 #https://www.openstreetmap.org/way/8920472
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25333, "roads",
     {"kind": "rail", "kind_detail": "rail", "id": 8920472, "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/95623728
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, "roads",
     {"kind": "rail", "kind_detail": "tram", "id": 95623728, "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/160279679
-assert_has_feature(
+test.assert_has_feature(
     16, 10478, 25341, "roads",
     {"kind": "rail", "kind_detail": "light_rail", "id": 160279679,
      "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/105574666
-assert_has_feature(
+test.assert_has_feature(
     16, 19216, 24778, "roads",
     {"kind": "rail", "kind_detail": "narrow_gauge", "id": 105574666,
      "sort_rank": 382})
 
 #https://www.openstreetmap.org/way/296530703
-assert_has_feature(
+test.assert_has_feature(
     16, 17714, 24454, "roads",
     {"kind": "rail", "kind_detail": "monorail", "id": 296530703,
      "sort_rank": 382})
 
 # spurs, sidings, etc...
 #https://www.openstreetmap.org/way/135403703
-assert_has_feature(
+test.assert_has_feature(
     16, 13353, 25941, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "spur", "id": 135403703,
      "sort_rank": 361})
 
 #https://www.openstreetmap.org/way/148018328
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25331, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "siding", "id": 148018328,
      "sort_rank": 361})
 
 #https://www.openstreetmap.org/way/119709585
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25331, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "yard", "id": 119709585,
      "sort_rank": 359})
 
 #https://www.openstreetmap.org/way/119695339
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25347, "roads",
     {"kind": "rail", "kind_detail": "rail", "service": "crossover",
      "id": 119695339, "sort_rank": 357})

--- a/integration-test/546-road-sort-keys-roads.py
+++ b/integration-test/546-road-sort-keys-roads.py
@@ -1,61 +1,61 @@
 # regular roads
 #https://www.openstreetmap.org/way/26765956
-assert_has_feature(
+test.assert_has_feature(
     16, 10472, 25323, "roads",
     {"kind": "highway", "kind_detail": "motorway", "id": 26765956,
      "name": "Presidio Pkwy.", "sort_rank": 383})
 
 #https://www.openstreetmap.org/way/89802409
-assert_has_feature(
+test.assert_has_feature(
     16, 10471, 25337, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 89802409,
      "name": "19th Ave.", "sort_rank": 381})
 
 #https://www.openstreetmap.org/way/160842753
-assert_has_feature(
+test.assert_has_feature(
     16, 10488, 25336, "roads",
     {"kind": "major_road", "kind_detail": "primary", "id": 160842753,
      "name": "3rd St.", "sort_rank": 380})
 
 #https://www.openstreetmap.org/way/25337673
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25332, "roads",
     {"kind": "major_road", "kind_detail": "secondary", "id": 25337673,
      "name": "Mission St.", "sort_rank": 379})
 
 #https://www.openstreetmap.org/way/255330035
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25324, "roads",
     {"kind": "major_road", "kind_detail": "tertiary", "id": 255330035,
      "name": "Battery St.", "sort_rank": 377})
 
 #https://www.openstreetmap.org/way/123456285
-assert_has_feature(
+test.assert_has_feature(
     16, 10472, 25347, "roads",
     {"kind": "highway", "kind_detail": "motorway_link", "id": 123456285,
      "name": "Junipero Serra Blvd.", "is_link": True, "sort_rank": 374})
 
 #https://www.openstreetmap.org/way/8919312
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25344, "roads",
     {"kind": "minor_road", "kind_detail": "residential", "id": 8919312,
      "name": "Racine Ln.", "sort_rank": 360})
 
 #https://www.openstreetmap.org/way/59161514
-assert_has_feature(
+test.assert_has_feature(
     16, 10477, 25323, "roads",
     {"kind": "minor_road", "kind_detail": "service", "id": 59161514,
      "name": "Yacht Rd.", "sort_rank": 358})
 
 # service roads
 #https://www.openstreetmap.org/way/147002738
-assert_has_feature(
+test.assert_has_feature(
     16, 10471, 25341, "roads",
     {"kind": "minor_road", "kind_detail": "service", "service": "parking_aisle",
      "id": 147002738, "sort_rank": 356})
 
 #https://www.openstreetmap.org/way/242769687
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25329, "roads",
     {"kind": "minor_road", "kind_detail": "service", "service": "driveway",
      "id": 242769687, "sort_rank": 356})

--- a/integration-test/546-road-sort-keys-tunnel.py
+++ b/integration-test/546-road-sort-keys-tunnel.py
@@ -1,48 +1,48 @@
 # tunnels at level = 0
 #https://www.openstreetmap.org/way/167952621
-assert_has_feature(
+test.assert_has_feature(
     16, 10475, 25324, "roads",
     {"kind": "highway", "kind_detail": "motorway", "id": 167952621,
      "name": "Presidio Pkwy.", "is_tunnel": True, "sort_rank": 333})
 
 # http://www.openstreetmap.org/way/259492789
-assert_has_feature(
+test.assert_has_feature(
     16, 19266, 24635, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 259492789,
      "name": "McCarter Hwy.", "is_tunnel": True, "sort_rank": 331})
 
 # http://www.openstreetmap.org/way/277441866
-assert_has_feature(
+test.assert_has_feature(
     16, 17563, 25792, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 277441866,
      "name": "Gatlinburg Spur Road (north)", "is_tunnel": True, "sort_rank": 331})
 
 #https://www.openstreetmap.org/way/117837633
-assert_has_feature(
+test.assert_has_feature(
     16, 16808, 24434, "roads",
     {"kind": "major_road", "kind_detail": "primary", "id": 117837633,
      "name": "Dixie Hwy.", "is_tunnel": True, "sort_rank": 330})
 
 #https://www.openstreetmap.org/way/57782075
-assert_has_feature(
+test.assert_has_feature(
     16, 16812, 24391, "roads",
     {"kind": "major_road", "kind_detail": "secondary", "id": 57782075,
      "name": "S Halsted St.", "is_tunnel": True, "sort_rank": 329})
 
 #https://www.openstreetmap.org/way/57708079
-assert_has_feature(
+test.assert_has_feature(
     16, 16813, 24386, "roads",
     {"kind": "major_road", "kind_detail": "tertiary", "id": 57708079,
      "name": "W 74th St.", "is_tunnel": True, "sort_rank": 327})
 
 #https://www.openstreetmap.org/way/56393654
-assert_has_feature(
+test.assert_has_feature(
     16, 16808, 24362, "roads",
     {"kind": "minor_road", "kind_detail": "residential", "id": 56393654,
      "name": "S Paulina St.", "is_tunnel": True, "sort_rank": 310})
 
 #https://www.openstreetmap.org/way/190835369
-assert_has_feature(
+test.assert_has_feature(
     16, 16814, 24363, "roads",
     {"kind": "minor_road", "kind_detail": "service", "id": 190835369,
      "name": "S Wong Pkwy.", "is_tunnel": True, "sort_rank": 308})

--- a/integration-test/549-subways.py
+++ b/integration-test/549-subways.py
@@ -1,3 +1,3 @@
-assert_has_feature(
+test.assert_has_feature(
     16, 10472, 25348, 'roads',
     {'kind': 'rail', 'kind_detail': 'subway', 'id': 101647480, 'sort_rank': 382})

--- a/integration-test/552-water-boundary-sort-key.py
+++ b/integration-test/552-water-boundary-sort-key.py
@@ -1,4 +1,4 @@
 # from https://github.com/mapzen/vector-datasource/issues/552
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25327, "water",
     {"kind": "ocean", "boundary": True, "sort_rank": 205})

--- a/integration-test/557-missing-buildings.py
+++ b/integration-test/557-missing-buildings.py
@@ -1,17 +1,17 @@
 # Best Tile
 #https://www.openstreetmap.org/way/103383621
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25339, 'buildings',
     {'id': 103383621})
 
 # Miraloma School
 #https://www.openstreetmap.org/way/338881092
-assert_has_feature(
+test.assert_has_feature(
     16, 10476, 25339, 'buildings',
     {'id': 338881092})
 
 # Tiny individual building (way_area = 5.4 sq.m.)
 #https://www.openstreetmap.org/way/278410540
-assert_has_feature(
+test.assert_has_feature(
     16, 10474, 25343, 'buildings',
     {'id': 278410540, 'min_zoom': 17})

--- a/integration-test/558-default-brunnel-sort-keys.py
+++ b/integration-test/558-default-brunnel-sort-keys.py
@@ -1,53 +1,53 @@
 #https://www.openstreetmap.org/way/70656344
-assert_has_feature(
+test.assert_has_feature(
     16, 10475, 25325, "roads",
     {"kind": "path", "kind_detail": "footway", "id": 70656344,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/275618623
-assert_has_feature(
+test.assert_has_feature(
     16, 10479, 25348, "roads",
     {"kind": "path", "kind_detail": "path", "id": 275618623,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/8915047
-assert_has_feature(
+test.assert_has_feature(
     16, 10469, 25345, "roads",
     {"kind": "path", "kind_detail": "cycleway", "id": 8915047,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/109938341
-assert_has_feature(
+test.assert_has_feature(
     16, 11301, 26220, "roads",
     {"kind": "path", "kind_detail": "steps", "id": 109938341,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/66418490
-assert_has_feature(
+test.assert_has_feature(
     16, 11378, 26224, "roads",
     {"kind": "path", "kind_detail": "track", "id": 66418490,
      "sort_rank": 404})
 
 #https://www.openstreetmap.org/way/97639585
-assert_has_feature(
+test.assert_has_feature(
     16, 10468, 25332, "roads",
     {"kind": "path", "kind_detail": "footway", "id": 97639585,
      "sort_rank": 304})
 
 #https://www.openstreetmap.org/way/356449810
-assert_has_feature(
+test.assert_has_feature(
     16, 10473, 25331, "roads",
     {"kind": "path", "kind_detail": "path", "id": 356449810,
      "sort_rank": 304})
 
 #https://www.openstreetmap.org/way/338682183
-assert_has_feature(
+test.assert_has_feature(
     16, 10470, 25342, "roads",
     {"kind": "path", "kind_detail": "track", "id": 338682183,
      "sort_rank": 304})
 
 #https://www.openstreetmap.org/way/99231479
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25328, "roads",
     {"kind": "path", "kind_detail": "steps", "id": 99231479,
      "sort_rank": 304})

--- a/integration-test/566-landuse-line.py
+++ b/integration-test/566-landuse-line.py
@@ -1,9 +1,9 @@
 # way 207142223
-assert_has_feature(
+test.assert_has_feature(
     16, 10454, 25310, 'landuse',
     { 'kind': 'tree_row', 'sort_rank': 264 })
 
 # way 205644321
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25332, 'landuse',
     { 'kind': 'hedge', 'sort_rank': 263 })

--- a/integration-test/569-duplicate-points.py
+++ b/integration-test/569-duplicate-points.py
@@ -5,11 +5,11 @@ def assert_no_repeated_points(coords):
     for i in range(1, len(coords)):
         coord = coords[i]
         if coord == last_coord:
-            fail('Coordinate %r (at %d) == %r (at %d), but coordinates should '
+            test.fail('Coordinate %r (at %d) == %r (at %d), but coordinates should '
                  'not be repeated.' % (coord, i, last_coord, i-1))
 
 
-with features_in_tile_layer(16, 17885, 27755, 'roads') as features:
+with test.features_in_tile_layer(16, 17885, 27755, 'roads') as features:
     for feature in features:
         gtype = feature['geometry']['type']
 

--- a/integration-test/569-duplicate-points.py
+++ b/integration-test/569-duplicate-points.py
@@ -5,9 +5,8 @@ def assert_no_repeated_points(coords):
     for i in range(1, len(coords)):
         coord = coords[i]
         if coord == last_coord:
-            raise Exception("Coordinate %r (at %d) == %r (at %d), but "
-                            "coordinates should not be repeated." %
-                            (coord, i, last_coord, i-1))
+            fail('Coordinate %r (at %d) == %r (at %d), but coordinates should '
+                 'not be repeated.' % (coord, i, last_coord, i-1))
 
 
 with features_in_tile_layer(16, 17885, 27755, 'roads') as features:

--- a/integration-test/580-kind-csv.py
+++ b/integration-test/580-kind-csv.py
@@ -1,32 +1,32 @@
 #https://www.openstreetmap.org/node/1223019595
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, 'pois',
     { 'kind': 'post_office' })
 
 #https://www.openstreetmap.org/node/317081601
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25329, 'pois',
     { 'kind': 'museum' })
 
 #https://www.openstreetmap.org/node/3910307149
 #https://www.openstreetmap.org/way/387798241
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25329, 'pois',
     { 'kind': 'gate' })
 
 #https://www.openstreetmap.org/way/382798029
 #https://www.openstreetmap.org/way/382798035
-assert_has_feature(
+test.assert_has_feature(
     16, 10466, 25340, 'pois',
     { 'kind': 'enclosure' })
 
 #http://www.openstreetmap.org/way/422270533
-assert_has_feature(
+test.assert_has_feature(
     16, 10476, 25324, 'landuse',
     { 'id': 422270533, 'kind': 'forest' })
 
 #https://www.openstreetmap.org/way/274459406
 #https://www.openstreetmap.org/way/274459420
-assert_has_feature(
+test.assert_has_feature(
     16, 10478, 25329, 'landuse',
     { 'kind': 'substation' })

--- a/integration-test/583-merge-landuse.py
+++ b/integration-test/583-merge-landuse.py
@@ -644,7 +644,7 @@ def _freeze(thing):
     return thing
 
 # check that there are no duplicates
-with features_in_tile_layer(9, 245, 166, 'landuse') as landuse:
+with test.features_in_tile_layer(9, 245, 166, 'landuse') as landuse:
     feature_props = set()
 
     for feature in landuse:
@@ -660,6 +660,6 @@ with features_in_tile_layer(9, 245, 166, 'landuse') as landuse:
 
         props = frozenset(_freeze(p))
         if props in feature_props:
-            fail('Duplicate properties %r in landuse layer, but properties '
+            test.fail('Duplicate properties %r in landuse layer, but properties '
                  'should be unique (except ID, area).' % feature['properties'])
         feature_props.add(props)

--- a/integration-test/583-merge-landuse.py
+++ b/integration-test/583-merge-landuse.py
@@ -660,7 +660,6 @@ with features_in_tile_layer(9, 245, 166, 'landuse') as landuse:
 
         props = frozenset(_freeze(p))
         if props in feature_props:
-            raise Exception("Duplicate properties %r in landuse layer, but "
-                            "properties should be unique (except ID, area)."
-                            % feature['properties'])
+            fail('Duplicate properties %r in landuse layer, but properties '
+                 'should be unique (except ID, area).' % feature['properties'])
         feature_props.add(props)

--- a/integration-test/588-funicular-monorail.py
+++ b/integration-test/588-funicular-monorail.py
@@ -1,9 +1,9 @@
 # https://www.openstreetmap.org/relation/6043603
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25367, 'transit',
     { 'kind': 'monorail' })
 
 # https://www.openstreetmap.org/relation/6060405
-assert_has_feature(
+test.assert_has_feature(
     16, 18201, 24705, 'transit',
     { 'kind': 'funicular' })

--- a/integration-test/592-add-adjust-bicycle-pois.py
+++ b/integration-test/592-add-adjust-bicycle-pois.py
@@ -1,25 +1,25 @@
 # http://www.openstreetmap.org/node/414269441
 # Valencia Cyclery in SF
-assert_has_feature(
+test.assert_has_feature(
     15, 5240, 12667, 'pois',
     { 'kind': 'bicycle', 'min_zoom': 15 })
 
 # http://www.openstreetmap.org/node/3801412161
 # San Francisco Bicycle Rentals
-assert_has_feature(
+test.assert_has_feature(
     16, 10476, 25332, 'pois',
     { 'kind': 'bicycle_rental', 'min_zoom': 16 })
 
 # http://www.openstreetmap.org/node/3708656264
 # Citi Bike - Broadway & W 24 St, with network, operator
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24633, 'pois',
     { 'kind': 'bicycle_rental_station', 'min_zoom': 17,
       'capacity': 52, 'network': 'Citi Bike', 'operator': 'NYC Bike Share' })
 
 # http://www.openstreetmap.org/node/1960994139
 # Alta Bike Share, Chattanooga, with network, operator, ref, capacity.
-assert_has_feature(
+test.assert_has_feature(
     16, 17238, 25950, 'pois',
     { 'kind': 'bicycle_rental_station', 'min_zoom': 17,
       'capacity': 19, 'network': 'Bike Chattanooga',
@@ -27,7 +27,7 @@ assert_has_feature(
 
 # http://www.openstreetmap.org/node/1993249660
 # Cycle barrier in Berkeley
-assert_has_feature(
+test.assert_has_feature(
     16, 10512, 25310, 'pois',
     { 'kind': 'cycle_barrier', 'min_zoom': 18 })
 
@@ -36,7 +36,7 @@ assert_has_feature(
 # WARNING: this kind of feature is only available in Europe
 # http://www.openstreetmap.org/node/3836406372
 # icn_ref=1
-assert_has_feature(
+test.assert_has_feature(
     16, 32382, 22860, 'pois',
     { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '1',
       'bicycle_network': 'icn' })
@@ -47,7 +47,7 @@ assert_has_feature(
 # WARNING: this kind of feature is only available in Europe
 # http://www.openstreetmap.org/node/340159623
 # rcn_ref=1
-assert_has_feature(
+test.assert_has_feature(
     16, 33322, 21990, 'pois',
     { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '1',
       'bicycle_network': 'rcn' })
@@ -55,7 +55,7 @@ assert_has_feature(
 # NOTE: this is strangely in Omaha, NE, USA
 # http://www.openstreetmap.org/node/3269815503
 # lcn_ref=1
-assert_has_feature(
+test.assert_has_feature(
     16, 15299, 24506, 'pois',
     { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '1',
       'bicycle_network': 'lcn' })
@@ -63,7 +63,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/node/287609621
 # lcn_ref=2
 #    16, 32570, 21059, 'pois',
-assert_has_feature(
+test.assert_has_feature(
     16, 32570, 21058, 'pois',
     { 'kind': 'bicycle_junction', 'min_zoom': 16, 'ref': '2',
       'bicycle_network': 'lcn' })
@@ -78,7 +78,7 @@ assert_has_feature(
 # WARNING: this kind of feature is only available in Europe
 # http://www.openstreetmap.org/node/300403808
 # rwn_ref=1
-assert_has_feature(
+test.assert_has_feature(
     16, 33492, 21929, 'pois',
     { 'kind': 'walking_junction', 'min_zoom': 16, 'ref': '1',
       'walking_network': 'rwn' })
@@ -86,7 +86,7 @@ assert_has_feature(
 # WARNING: this kind of feature is only available in Europe
 # http://www.openstreetmap.org/node/717593380
 # lwn_ref=1
-assert_has_feature(
+test.assert_has_feature(
     16, 34584, 21219, 'pois',
     { 'kind': 'walking_junction', 'min_zoom': 16, 'ref': 'ST',
       'walking_network': 'lwn' })
@@ -94,14 +94,14 @@ assert_has_feature(
 
 #http://www.openstreetmap.org/node/3161454672
 # bicycle parking with capacity, covered & fee
-assert_has_feature(
+test.assert_has_feature(
     16, 12378, 26258, 'pois',
     { 'kind': 'bicycle_parking',
       'capacity': 10, 'covered': True, 'fee': False })
 
 #http://www.openstreetmap.org/node/1618586234
 # bicycle parking with access, capacity, covered, fee & operator
-assert_has_feature(
+test.assert_has_feature(
     16, 10413, 22135, 'pois',
     { 'kind': 'bicycle_parking',
       'capacity': 100, 'covered': True, 'fee': False, 'access': 'customers',
@@ -110,7 +110,7 @@ assert_has_feature(
 # WARNING - EXAMPLE IS IN EUROPE
 #http://www.openstreetmap.org/node/1154262723
 # bicycle parking with capacity, covered, fee, maxstay, operator
-assert_has_feature(
+test.assert_has_feature(
     16, 31627, 21244, 'pois',
     { 'kind': 'bicycle_parking',
       'capacity': 200, 'covered': True, 'fee': False, 'maxstay': '2 days',
@@ -119,14 +119,14 @@ assert_has_feature(
 # WARNING - EXAMPLE IS IN EUROPE
 #http://www.openstreetmap.org/node/1116224894
 # bicycle parking with capacity and cyclestreets ID.
-assert_has_feature(
+test.assert_has_feature(
     16, 32745, 21789, 'pois',
     { 'kind': 'bicycle_parking',
       'capacity': 4, 'cyclestreets_id': '27815' })
 
 #http://www.openstreetmap.org/node/2921238315
 # bicycle parking with access, capacity, covered, operator and surveillance
-assert_has_feature(
+test.assert_has_feature(
     16, 17087, 24822, 'pois',
     { 'kind': 'bicycle_parking',
       'access': 'public', 'capacity': 10, 'covered': True,

--- a/integration-test/593-early-cycleway.py
+++ b/integration-test/593-early-cycleway.py
@@ -6,6 +6,6 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'roads',
         {'kind_detail': 'cycleway'})

--- a/integration-test/593-early-footway.py
+++ b/integration-test/593-early-footway.py
@@ -29,27 +29,27 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'roads',
         {'kind_detail': 'footway'})
 
 
 #SF State, way/346093021
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2617, 6335, 'roads',
     {'kind': 'path', 'footway': 'sidewalk'})
 
 #SF State, way/346093021
-assert_has_feature(
+test.assert_has_feature(
     15, 5235, 12671, 'roads',
     {'kind': 'path', 'footway': 'sidewalk'})
 
 #SF in the Avenues, way/344205837
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2617, 6333, 'roads',
     {'id': 344205837, 'kind': 'path', 'footway': 'sidewalk'})
 
 #SF in the Avenues, way/344205837
-assert_has_feature(
+test.assert_has_feature(
     15, 5234, 12667, 'roads',
     {'kind': 'path', 'footway': 'crossing'})

--- a/integration-test/593-early-path.py
+++ b/integration-test/593-early-path.py
@@ -1,7 +1,7 @@
 # highway=path, with route national (Pacific Crest Trail)
 # https://www.openstreetmap.org/way/236361475
 # https://www.openstreetmap.org/relation/1225378
-assert_has_feature(
+test.assert_has_feature(
 11, 345, 790, 'roads',
 { 'walking_network': 'nwn',
   'walking_shield_text': 'PCT' })
@@ -9,19 +9,19 @@ assert_has_feature(
 # highway=path, with route regional (Merced Pass Trail)
 # https://www.openstreetmap.org/way/373491941
 # https://www.openstreetmap.org/relation/5549623
-assert_has_feature(
+test.assert_has_feature(
 	12, 687, 1584, 'roads',
 	{'kind_detail': 'path', 'name': None, 'walking_network': None})
 
 # highway=path, with route regional (Merced Pass Trail)
 # https://www.openstreetmap.org/way/39996451
 # https://www.openstreetmap.org/relation/5549623
-assert_has_feature(
+test.assert_has_feature(
 	12, 688, 1584, 'roads',
 	{'kind_detail': 'path', 'name': None, 'walking_network': None})
 
 # highway=path, no route, but has name (Upper Yosemite Falls Trail)
 # https://www.openstreetmap.org/way/162322353
-assert_has_feature(
+test.assert_has_feature(
 	13, 1374, 3166, 'roads',
 	{'kind_detail': 'path', 'name': None})

--- a/integration-test/593-early-step.py
+++ b/integration-test/593-early-step.py
@@ -9,17 +9,17 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'roads',
         {'kind_detail': 'steps'})
 
 
 # way 25292070   highway=steps, no route, but has name (Esmeralda, Bernal, SF)
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 1310, 3167, 'roads',
     {'kind': 'path', 'kind_detail': 'steps', 'name': 'Esmeralda Ave.'})
 
 # way 25292070   highway=steps, no route, but has name (Esmeralda, Bernal, SF)
-assert_has_feature(
+test.assert_has_feature(
     14, 2620, 6334, 'roads',
     {'kind': 'path', 'kind_detail': 'steps', 'name': 'Esmeralda Ave.'})

--- a/integration-test/593-early-track.py
+++ b/integration-test/593-early-track.py
@@ -6,6 +6,6 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'roads',
         {'kind_detail': 'track'})

--- a/integration-test/594-trailhead.py
+++ b/integration-test/594-trailhead.py
@@ -1,4 +1,4 @@
 # node 3447700493
-assert_has_feature(
+test.assert_has_feature(
     15, 5234, 12664, 'pois',
     { 'kind': 'trailhead' })

--- a/integration-test/596-add-hiking-routes.py
+++ b/integration-test/596-add-hiking-routes.py
@@ -1,27 +1,27 @@
 # https://www.openstreetmap.org/way/12188550
 # https://www.openstreetmap.org/relation/2684235
-assert_has_feature(
+test.assert_has_feature(
     12, 654, 1582, 'roads',
     { 'kind': 'path', 'kind_detail': 'track' })
 
 # https://www.openstreetmap.org/way/109993139
 # NOTE: part of *cycle* network, not walking network.
-#assert_has_feature(
+#test.assert_has_feature(
 #    12, 655, 1586, 'roads',
 #    { 'kind': 'path', 'kind_detail': 'cycleway' })
 
 # https://www.openstreetmap.org/way/25292070
-assert_has_feature(
+test.assert_has_feature(
     14, 2620, 6334, 'roads',
     { 'kind': 'path', 'kind_detail': 'steps', 'name': 'Esmeralda Ave.' })
 
 # https://www.openstreetmap.org/way/346093021
-assert_has_feature(
+test.assert_has_feature(
     15, 5235, 12671, 'roads',
     { 'kind': 'path', 'kind_detail': 'footway' })
 
 # http://www.openstreetmap.org/way/344205837
-assert_has_feature(
+test.assert_has_feature(
     15, 5234, 12667, 'roads',
     { 'kind': 'path', 'kind_detail': 'footway' })
 
@@ -29,7 +29,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/relation/3718820
 # Baker River Road - residential - part of Pacific Northwest Trail (nwn)
 # should be visible at z11
-assert_has_feature(
+test.assert_has_feature(
     11, 331, 706, 'roads',
     { 'kind': 'minor_road', 'kind_detail': 'residential', 'walking_network': 'nwn' })
 
@@ -37,7 +37,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/relation/3718820
 # Mount Baker Highway - secondary - part of Pacific Northwest Trail (nwn)
 # should be visible at z11
-assert_has_feature(
+test.assert_has_feature(
     11, 331, 704, 'roads',
     { 'kind': 'major_road', 'kind_detail': 'secondary',
       'walking_network': 'nwn' })
@@ -46,7 +46,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/relation/3718820
 # Whiskey Bend Road - unclassified - part of Pacific Northwest Trail (nwn)
 # should be visible at z11
-assert_has_feature(
+test.assert_has_feature(
     11, 320, 712, 'roads',
     { 'kind': 'minor_road', 'kind_detail': 'unclassified',
       'walking_network': 'nwn' })
@@ -55,7 +55,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/relation/2381423
 # Matz Road - service - part of Ice Age National Scenic Trail (nwn)
 # should be visible at z11
-assert_has_feature(
+test.assert_has_feature(
     11, 514, 751, 'roads',
     { 'kind': 'minor_road', 'kind_detail': 'service', 'walking_network': 'nwn' })
 
@@ -63,7 +63,7 @@ assert_has_feature(
 # http://www.openstreetmap.org/relation/1544944
 # Dogbane - service=driveway - part of American Discovery Trail (nwn)
 # should be visible at z11
-assert_has_feature(
+test.assert_has_feature(
     11, 491, 762, 'roads',
     { 'kind': 'minor_road', 'kind_detail': 'service', 'service': 'driveway',
       'walking_network': 'nwn' })

--- a/integration-test/599-whitewater.py
+++ b/integration-test/599-whitewater.py
@@ -1,9 +1,9 @@
 # node 3134398100
-assert_has_feature(
+test.assert_has_feature(
     16, 19591, 23939, 'pois',
     { 'kind': 'put_in_egress' })
 
 # way 308154534
-assert_has_feature(
+test.assert_has_feature(
     13, 2448, 2992, 'roads',
     { 'kind': 'portage_way' })

--- a/integration-test/601-cliff-arete-ridge-valley.py
+++ b/integration-test/601-cliff-arete-ridge-valley.py
@@ -1,27 +1,27 @@
 #cliff in Yosemite
 # https://www.openstreetmap.org/way/291684864
-assert_has_feature(
+test.assert_has_feature(
     13, 1374, 3166, "earth",
     {"kind": "cliff", "id": 291684864,
      "sort_rank": 227})
 
 #arete in Yosemite
 # https://www.openstreetmap.org/way/375271242
-assert_has_feature(
+test.assert_has_feature(
     13, 1379, 3164, "earth",
     {"kind": "arete", "id": 375271242,
      "sort_rank": 228})
 
 #ridge with name in Santa Cruz Mountains, California
 # https://www.openstreetmap.org/way/115675159
-assert_has_feature(
+test.assert_has_feature(
     13, 1317, 3182, "earth",
     {"kind": "ridge", "id": 115675159,
      "name": "Castle Rock Ridge", "label_placement": True})
 
 #valley with name in Yosemite
 # https://www.openstreetmap.org/way/407467016
-assert_has_feature(
+test.assert_has_feature(
     13, 1381, 3164, "earth",
     {"kind": "valley", "id": 407467016,
      "name": "Lyell Canyon", "label_placement": True})

--- a/integration-test/602-add-boat-rental.py
+++ b/integration-test/602-add-boat-rental.py
@@ -6,6 +6,6 @@ tiles = [
 ]
 
 for z, x, y in tiles:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'pois',
         {'kind': 'boat_rental'})

--- a/integration-test/605-corridor.py
+++ b/integration-test/605-corridor.py
@@ -1,5 +1,5 @@
 # Way: The Nave (205644309)
 # http://www.openstreetmap.org/way/205644309
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25332, 'roads',
     { 'id': 205644309, 'kind': 'path', 'kind_detail': 'corridor' })

--- a/integration-test/605-crosswalk-sidewalk.py
+++ b/integration-test/605-crosswalk-sidewalk.py
@@ -1,18 +1,18 @@
 # http://www.openstreetmap.org/way/444491374
-assert_has_feature(
+test.assert_has_feature(
     16, 10475, 25332, 'roads',
     { 'id': 444491374, 'kind': 'path', 'crossing': 'traffic_signals' })
 
 # Way: The Embarcadero (397140734)
 # http://www.openstreetmap.org/way/397140734
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, 'roads',
     { 'id': 397140734, 'kind': 'major_road', 'sidewalk': 'separate' })
 
 
 # Way: Carrie Furnace Boulevard (438362919)
 # http://www.openstreetmap.org/way/438362919
-assert_has_feature(
+test.assert_has_feature(
     16, 18225, 24712, 'roads',
     { 'id': 438362919, 'kind': 'major_road',
       'sidewalk_left': 'sidepath', 'sidewalk_right': 'no' })

--- a/integration-test/611-add-bus-to-roads.py
+++ b/integration-test/611-add-bus-to-roads.py
@@ -6,6 +6,6 @@
 # https://www.openstreetmap.org/relation/3406708 -- 14R to Mission
 # https://www.openstreetmap.org/relation/3000713 -- 14R to Downtown
 # ... and many more bus route relations
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25329, 'roads',
     {'name': 'Mission St.', 'is_bus_route': True})

--- a/integration-test/628-standardize-water-kinds.py
+++ b/integration-test/628-standardize-water-kinds.py
@@ -1,9 +1,9 @@
 # ne_10m_lakes gid 1298: Great Salt Lake, UT
-assert_has_feature(
+test.assert_has_feature(
     8, 47, 95, 'water',
     { 'kind': 'lake', 'alkaline': True })
 
 # way 386662458
-assert_has_feature(
+test.assert_has_feature(
     16, 10481, 25324, 'water',
     { 'kind': 'lake', 'reservoir': True })

--- a/integration-test/629-trolleybus-is-a-bus.py
+++ b/integration-test/629-trolleybus-is-a-bus.py
@@ -1,17 +1,17 @@
 # http://www.openstreetmap.org/way/397268717
 # http://www.openstreetmap.org/relation/2996736
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25339, 'roads',
     { 'is_bus_route': True, 'name': 'Industrial St.' })
 
 # http://www.openstreetmap.org/way/32929419
 # http://www.openstreetmap.org/relation/3412979
-assert_has_feature(
+test.assert_has_feature(
     16, 10477, 25333, 'roads',
     { 'is_bus_route': True, 'name': 'Clayton St.' })
 
 # http://www.openstreetmap.org/way/254756528
 # http://www.openstreetmap.org/relation/3413068
-assert_has_feature(
+test.assert_has_feature(
     16, 10477, 25326, 'roads',
     { 'is_bus_route': True, 'name': 'Union St.' })

--- a/integration-test/630-bus-routes-z12.py
+++ b/integration-test/630-bus-routes-z12.py
@@ -11,12 +11,12 @@ z, x, y = (16, 10484, 25329)
 
 # test that at least one is present in tiles up to z12
 while z >= 12:
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'roads',
         { 'is_bus_route': True })
     z, x, y = (z-1, x/2, y/2)
 
 # but that none are present in the parent tile at z11
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     z, x, y, 'roads',
     { 'is_bus_route': True })

--- a/integration-test/647-cycle-route.py
+++ b/integration-test/647-cycle-route.py
@@ -1,103 +1,103 @@
 #  Way: The Embarcadero (24335490)
 # http://www.openstreetmap.org/way/24335490
 # http://www.openstreetmap.org/relation/32386
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25327, 'roads',
     { 'id': 24335490, 'kind': 'major_road', 'cycleway_right': 'lane', 'bicycle_network': 'lcn' })
 
 # Way: King Street (8920394) http://www.openstreetmap.org/way/8920394
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25329, 'roads',
     { 'id': 8920394, 'kind': 'major_road', 'cycleway_right': 'lane', 'bicycle_network': 'lcn'})
 
 # Way: King Street (397270776) http://www.openstreetmap.org/way/397270776
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25329, 'roads',
     { 'id': 397270776, 'kind': 'major_road', 'cycleway_right': 'lane', 'bicycle_network': 'lcn'})
 
 # Way: Clara-Immerwahr-Straße (287167007) http://www.openstreetmap.org/way/287167007
-assert_has_feature(
+test.assert_has_feature(
     16, 34494, 21846, 'roads',
     { 'id': 287167007, 'kind': 'minor_road', 'bicycle_network': 'icn'})
 
 # Way: 198th Street (138388021) http://www.openstreetmap.org/way/138388021
-assert_has_feature(
+test.assert_has_feature(
     16, 10435, 22457, 'roads',
     { 'id': 138388021, 'kind': 'major_road', 'bicycle_network': 'icn', 'cycleway': 'shared_lane'})
 
 # Way: 232603515 http://www.openstreetmap.org/way/232603515
-assert_has_feature(
+test.assert_has_feature(
     16, 18735, 25114, 'roads',
     { 'id': 232603515, 'kind': 'minor_road', 'bicycle_network': 'ncn', 'oneway': 'yes'})
 
 # Way: Longleaf Trace (165276857) http://www.openstreetmap.org/way/165276857
-assert_has_feature(
+test.assert_has_feature(
     16, 16505, 26756, 'roads',
     { 'id': 165276857, 'kind': 'path', 'bicycle_network': 'ncn'})
 
 # http://www.openstreetmap.org/way/44422697
-assert_has_feature(
+test.assert_has_feature(
     16, 10509, 25377, 'roads',
     { 'id': 44422697, 'kind': 'path', 'bicycle_network': 'rcn'})
 
 # Way: Adam Clayton Powell Jr. Boulevard (204085723) http://www.openstreetmap.org/way/204085723
-assert_has_feature(
+test.assert_has_feature(
     16, 19305, 24618, 'roads',
     { 'id': 204085723, 'kind': 'major_road', 'bicycle_network': 'rcn'})
 
 # Way: 11th Street (27029204) http://www.openstreetmap.org/way/27029204#map=16/37.7700/-122.4117
-assert_has_feature(
+test.assert_has_feature(
     16, 10483, 25332, 'roads',
     { 'id': 27029204, 'kind': 'major_road', 'bicycle_network': 'lcn', 'cycleway': 'lane'})
 
 # Way: Boulge Road
 # http://www.openstreetmap.org/way/50835689
 # http://www.openstreetmap.org/relation/2767188
-assert_has_feature(
+test.assert_has_feature(
     16, 33002, 21613, 'roads',
     { 'id': 50835689, 'kind': 'minor_road', 'bicycle_network': 'icn'})
 
 # Way: West National Ave (95578389)
 # http://www.openstreetmap.org/way/95578389
 # http://www.openstreetmap.org/relation/3318923
-assert_has_feature(
+test.assert_has_feature(
     16, 16842, 24939, 'roads',
     { 'id': 95578389, 'kind': 'major_road', 'bicycle_network': 'ncn'})
 
 # Way: Kananaskis Trail (385652955)
 # http://www.openstreetmap.org/way/385652955
 # http://www.openstreetmap.org/relation/5737942
-assert_has_feature(
+test.assert_has_feature(
     16, 11818, 22039, 'roads',
     { 'id': 385652955, 'kind': 'major_road', 'bicycle_network': 'rcn'})
 
 # Way: Foothill Expressway (173846425)
 # http://www.openstreetmap.org/way/173846425
 # http://www.openstreetmap.org/relation/1204994
-assert_has_feature(
+test.assert_has_feature(
     16, 10535, 25419, 'roads',
     { 'id': 173846425, 'kind': 'major_road', 'bicycle_network': 'lcn'})
 
 # http://www.openstreetmap.org/way/255652148
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25333, 'roads',
     { 'id': 255652148, 'kind': 'path', 'segregated': True})
 
 # http://www.openstreetmap.org/way/215528939
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10486, 25331, 'roads', { 'segregated': 'no'})
 
 # Way: Post Street (28841123) http://www.openstreetmap.org/way/28841123
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25327, 'roads',
     { 'id': 28841123, 'is_bicycle_related': True })
 
 # Way: 301442215 http://www.openstreetmap.org/way/301442215
-assert_has_feature(
+test.assert_has_feature(
     16, 34748, 22664, 'roads',
     { 'id': 301442215, 'is_bicycle_related': True })
 
 # Way: 428306786 http://www.openstreetmap.org/way/428306786
-assert_has_feature(
+test.assert_has_feature(
     16, 18649, 25417, 'roads',
     { 'id': 428306786, 'is_bicycle_related': True })

--- a/integration-test/653-unify-building-part.py
+++ b/integration-test/653-unify-building-part.py
@@ -1,28 +1,28 @@
 # http://www.openstreetmap.org/way/264768910
 # Way: One Madison
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24633, 'buildings',
     { 'id': 264768910, 'kind': 'building', 'root_id': type(None) })
 
 # http://www.openstreetmap.org/way/160967738
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24633, 'buildings',
     { 'id': 160967738, 'kind': 'building_part', 'root_id': 264768910 })
 
 #http://www.openstreetmap.org/way/160967739
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24633, 'buildings',
     { 'id': 160967739, 'kind': 'building_part', 'root_id': 264768910 })
 
 
 # http://www.openstreetmap.org/relation/6062613
 # Relation: Ferry Building
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, 'buildings',
     { 'id': 24460886, 'kind': 'building', 'root_id': type(None) })
 
 # http://www.openstreetmap.org/way/404449724
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, 'buildings',
     { 'id': 404449724, 'kind': 'building_part', 'root_id': 24460886 })
 
@@ -33,9 +33,9 @@ assert_has_feature(
 # Relation: Waterloo (tube station)
 # http://www.openstreetmap.org/relation/238792
 # Relation: London Waterloo
-assert_has_feature(
+test.assert_has_feature(
     16, 32747, 21793, 'pois',
     { 'id': 3638795617, 'root_id': 1242762, 'root_relation_id': type(None) })
-assert_has_feature(
+test.assert_has_feature(
     16, 32747, 21793, 'pois',
     { 'id': 3638795618, 'root_id': 1242762, 'root_relation_id': type(None) })

--- a/integration-test/655-landuse-scree.py
+++ b/integration-test/655-landuse-scree.py
@@ -1,4 +1,4 @@
 # way 59621863
-assert_has_feature(
+test.assert_has_feature(
     16, 10481, 25319, 'landuse',
     { 'kind': 'scree' })

--- a/integration-test/657-natural-man_made.py
+++ b/integration-test/657-natural-man_made.py
@@ -1,34 +1,34 @@
 # http://www.openstreetmap.org/node/4305375025
-assert_has_feature(
+test.assert_has_feature(
     15, 10394, 19077, 'pois',
     { 'kind': 'mineshaft' })
 
 # node 369156437
-assert_has_feature(
+test.assert_has_feature(
     16, 11932, 25298, 'pois',
     { 'kind': 'adit' })
 
 # node 2794798164
-assert_has_feature(
+test.assert_has_feature(
     16, 10549, 25431, 'pois',
     { 'kind': 'water_well', 'min_zoom': 17 })
 
 # node 966585438
-assert_has_feature(
+test.assert_has_feature(
     14, 2764, 6333, 'pois',
     { 'kind': 'saddle' })
 
 # node 358832354
-assert_has_feature(
+test.assert_has_feature(
     15, 5224, 12570, 'pois',
     { 'kind': 'geyser' })
 
 # node 4020311689
-assert_has_feature(
+test.assert_has_feature(
     16, 10805, 25827, 'pois',
     { 'kind': 'hot_spring' })
 
 # http://www.openstreetmap.org/node/1804644217
-assert_has_feature(
+test.assert_has_feature(
     16, 27431, 36586, 'pois',
     { 'kind': 'rock', 'min_zoom': 17 })

--- a/integration-test/661-historic-transit-stops.py
+++ b/integration-test/661-historic-transit-stops.py
@@ -2,54 +2,54 @@
 
 # Historic railway stop
 # https://www.openstreetmap.org/node/3039734894
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 2412, 3081, 'pois',
     {'id': 3039734894})
 
 # Historic tram stop
 # http://www.openstreetmap.org/node/413573669
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 1320, 3189, 'pois',
     {'id': 413573669})
 
 # Historic railway halt
 # http://www.openstreetmap.org/node/708144563
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 4433, 2416, 'pois',
     {'id': 708144563})
 
 # Historic railway halt
 # http://www.openstreetmap.org/node/2468597590
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 4304, 2906, 'pois',
     {'id': 2468597590})
 
 # Historic railway station
 # http://www.openstreetmap.org/node/985085275
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 4275, 2756, 'pois',
     {'id': 985085275})
 
 # Historic tram stop
 # http://www.openstreetmap.org/node/3367033945
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 1312, 2854, 'pois',
     {'id': 3367033945})
 
 # Current railway stop
 # http://www.openstreetmap.org/node/2986320002
-assert_has_feature(
+test.assert_has_feature(
     16, 19306, 24648, 'pois',
     {'id': 2986320002, 'min_zoom': 13})
 
 # Current tram stop
 # http://www.openstreetmap.org/node/257074010
-assert_has_feature(
+test.assert_has_feature(
 	13, 1310, 3166, 'pois',
     {'id': 257074010})
 
 # Current railway halt
 # http://www.openstreetmap.org/node/302735255
-assert_has_feature(
+test.assert_has_feature(
 	13, 4478, 2843, 'pois',
     {'id': 302735255})

--- a/integration-test/662-basic-outdoor-pois.py
+++ b/integration-test/662-basic-outdoor-pois.py
@@ -1,75 +1,75 @@
 #http://www.openstreetmap.org/node/1387024181
-assert_has_feature(
+test.assert_has_feature(
     16, 10550, 25297, 'pois',
     { 'kind': 'bbq', 'min_zoom': 18 })
 
 # Node: Valencia Cyclery (3443701422)
 # http://www.openstreetmap.org/node/3443701422
-assert_has_feature(
+test.assert_has_feature(
     16, 10481, 25335, 'pois',
     { 'id': 3443701422, 'kind': 'bicycle_repair_station', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/2910259124
-assert_has_feature(
+test.assert_has_feature(
     16, 10798, 25903, 'pois',
     { 'kind': 'dive_centre', 'min_zoom': 16 })
 
 #http://www.openstreetmap.org/node/2844159164
-assert_has_feature(
+test.assert_has_feature(
     16, 18308, 23892, 'pois',
     { 'kind': 'life_ring', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/4083762008
-assert_has_feature(
+test.assert_has_feature(
     16, 10805, 25927, 'pois',
     { 'kind': 'lifeguard_tower', 'min_zoom': 17 })
 
 #http://www.openstreetmap.org/node/696801847
-assert_has_feature(
+test.assert_has_feature(
     16, 10597, 25151, 'pois',
     { 'kind': 'picnic_table', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/1128776802
-assert_has_feature(
+test.assert_has_feature(
     16, 10466, 25372, 'pois',
     { 'kind': 'shower', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/2287784170
-assert_has_feature(
+test.assert_has_feature(
     16, 10514, 25255, 'pois',
     { 'kind': 'waste_disposal', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/2640323071
-assert_has_feature(
+test.assert_has_feature(
     16, 10502, 25290, 'pois',
     { 'kind': 'watering_place', 'min_zoom': 18 })
 
 #https://www.openstreetmap.org/node/3954505509
-assert_has_feature(
+test.assert_has_feature(
     16, 10174, 23848, 'pois',
     { 'kind': 'water_point', 'min_zoom': 18 })
 
 #https://www.openstreetmap.org/node/3984333433
-assert_has_feature(
+test.assert_has_feature(
     16, 12348, 25363, 'pois',
     { 'kind': 'water_point', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/1978323412
-assert_has_feature(
+test.assert_has_feature(
     16, 10878, 25000, 'pois',
     { 'kind': 'pylon', 'min_zoom': 17 })
 
 #http://www.openstreetmap.org/node/2398019418
-assert_has_feature(
+test.assert_has_feature(
     16, 10566, 25333, 'pois',
     { 'kind': 'power_pole', 'min_zoom': 18 })
 
 #http://www.openstreetmap.org/node/1378418272
-assert_has_feature(
+test.assert_has_feature(
     16, 10480, 25352, 'pois',
     { 'kind': 'power_tower', 'min_zoom': 16 })
 
 #http://www.openstreetmap.org/node/2890101480
-assert_has_feature(
+test.assert_has_feature(
     16, 11080, 26141, 'pois',
     { 'kind': 'petroleum_well', 'min_zoom': 17 })

--- a/integration-test/663-combo-outdoor-landuse-pois.py
+++ b/integration-test/663-combo-outdoor-landuse-pois.py
@@ -1,16 +1,16 @@
 #http://www.openstreetmap.org/way/31198945
 # Waterworld in Concord
-assert_has_feature(
+test.assert_has_feature(
     13, 1318, 3160, 'landuse',
     { 'kind': 'water_park', 'sort_rank': 107 })
 
-assert_has_feature(
+test.assert_has_feature(
     13, 1318, 3160, 'pois',
     { 'kind': 'water_park', 'min_zoom': 13 })
 
 #http://www.openstreetmap.org/node/2753215890
 # Antioch WaterPark
-assert_has_feature(
+test.assert_has_feature(
     16, 10600, 25287, 'pois',
     { 'kind': 'water_park', 'min_zoom': 15 })
 
@@ -18,27 +18,27 @@ assert_has_feature(
 
 #http://www.openstreetmap.org/way/381817396
 # Sandos Finisterra Los Cabos, extra large resort
-assert_has_feature(
+test.assert_has_feature(
     14, 3189, 7122, 'pois',
     { 'kind': 'beach_resort', 'min_zoom': 14 })
 
 #http://www.openstreetmap.org/node/2407351205
 # Hilton Hawaiian Village
 # really this should be merged with its large AOI!
-assert_has_feature(
+test.assert_has_feature(
     16, 4034, 28801, 'pois',
     { 'kind': 'beach_resort', 'min_zoom': 16 })
 
 #http://www.openstreetmap.org/node/3575812477
 # Silver Gull Beach Club
-assert_has_feature(
+test.assert_has_feature(
     16, 19314, 24677, 'pois',
     { 'kind': 'beach_resort', 'min_zoom': 16 })
 
 # https://www.openstreetmap.org/way/381817391
 # Terrasol Beach Resort
 # Needs to appear **before** tourism=hotel
-assert_has_feature(
+test.assert_has_feature(
     16, 12760, 28488, 'pois',
     { 'id': 381817391, 'kind': 'beach_resort'})
 
@@ -46,7 +46,7 @@ assert_has_feature(
 #https://www.openstreetmap.org/way/257716817
 # Needs to appear **after** natural=beach.
 # Unnamed beach in Maskenthine Lake area
-assert_has_feature(
+test.assert_has_feature(
     16, 15066, 24333, 'landuse',
     { 'kind': 'beach', 'id': 257716817 })
 
@@ -54,13 +54,13 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/3655879348
 # Camp Ahmek
-assert_has_feature(
+test.assert_has_feature(
     15, 9219, 11714, 'pois',
     { 'kind': 'summer_camp', 'min_zoom': 15 })
 
 #https://www.openstreetmap.org/node/4050178586
 # Camp Goodtimes
-assert_has_feature(
+test.assert_has_feature(
     15, 5225, 11211, 'pois',
     { 'kind': 'summer_camp', 'min_zoom': 15 })
 
@@ -68,34 +68,34 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/3838356961
 # Battle of Blackburn's Ford (1861)
-assert_has_feature(
+test.assert_has_feature(
     16, 18668, 25092, 'pois',
     { 'kind': 'battlefield', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/node/3992988013
 # 2nd Battle of Kernstown
-assert_has_feature(
+test.assert_has_feature(
     16, 18532, 25013, 'pois',
     { 'kind': 'battlefield', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/way/231393152
 # Antietam National Battlefield
-assert_has_feature(
+test.assert_has_feature(
     10, 290, 389, 'pois',
     { 'kind': 'battlefield', 'min_zoom': 10 })
 
-assert_has_feature(
+test.assert_has_feature(
     10, 290, 389, 'landuse',
     { 'kind': 'battlefield', 'sort_rank': 25 })
 
 
 #http://www.openstreetmap.org/way/316054549
 # White Oak Road Battlefield
-assert_has_feature(
+test.assert_has_feature(
     11, 582, 796, 'pois',
     { 'kind': 'battlefield', 'min_zoom': 10.07 })
 
-assert_has_feature(
+test.assert_has_feature(
     11, 582, 796, 'landuse',
     { 'kind': 'battlefield', 'sort_rank': 25 })
 
@@ -103,13 +103,13 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/2117389172
 # unnamed Boat Storage
-assert_has_feature(
+test.assert_has_feature(
     16, 10563, 25453, 'pois',
     { 'kind': 'boat_storage', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/way/261064362
 # in Tiburon, CA
-assert_has_feature(
+test.assert_has_feature(
     16, 10476, 25304, 'pois',
     { 'kind': 'boat_storage', 'min_zoom': 17 })
 
@@ -117,31 +117,31 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/3314950786
 # Red Cross monument in DC
-assert_has_feature(
+test.assert_has_feature(
     16, 18742, 25070, 'pois',
     { 'kind': 'monument', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/node/2316449632
 # Major General James B. McPherson in DC
-assert_has_feature(
+test.assert_has_feature(
     16, 18744, 25069, 'pois',
     { 'kind': 'monument', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/way/41273627
 # polygon but no landuse / Netherlands Carillon near DC
-assert_has_feature(
+test.assert_has_feature(
     16, 18737, 25072, 'pois',
     { 'kind': 'monument', 'min_zoom': (lambda z: z >= 16 and z < 17) })
 
 #https://www.openstreetmap.org/way/248460669
 # building, Jefferson Monument
-assert_has_feature(
+test.assert_has_feature(
     15, 9371, 12537, 'pois',
     { 'kind': 'monument', 'min_zoom': 15 })
 
 #https://www.openstreetmap.org/way/66418767
 # building, and tourism=attraction, National World War II Memorial
-assert_has_feature(
+test.assert_has_feature(
     15, 9371, 12536, 'pois',
     { 'kind': 'monument', 'min_zoom': 15 })
 
@@ -149,78 +149,78 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/358811238
 # Letts Valley 1-039 Dam
-assert_has_feature(
+test.assert_has_feature(
     14, 2607, 6243, 'pois',
     { 'kind': 'dam', 'min_zoom': 14 })
 
 #https://www.openstreetmap.org/way/189656737
 # O'Shaughnessy Dam, Yosemite
 # 13, 1370, 3161
-assert_has_feature(
+test.assert_has_feature(
     12, 685, 1580, 'landuse',
     { 'kind': 'dam', 'sort_rank': 223 })
 
-assert_has_feature(
+test.assert_has_feature(
     12, 685, 1580, 'pois',
     { 'kind': 'dam', 'min_zoom': 12 })
 
 #https://www.openstreetmap.org/way/62201624
 # Named dam line in front of Cherry Lake
 # Should be labeled in the stylesheet, no POI generate
-assert_has_feature(
+test.assert_has_feature(
     12, 683, 1580, 'landuse',
     { 'kind': 'dam', "sort_rank": 265 })
 
 
 #http://www.openstreetmap.org/node/262220409
 # Indian Lake Dog Exercise Area, near Madison, WI
-assert_has_feature(
+test.assert_has_feature(
     16, 16450, 24033, 'pois',
     { 'kind': 'dog_park', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/way/417184097
 # Dog Run at Upper Noe Valley Rec Center, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10480, 25338, 'pois',
     { 'kind': 'dog_park', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/375333476
 # Dog park at Walter Hass Playground, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10479, 25338, 'pois',
     { 'kind': 'dog_park', 'min_zoom': 16 })
 
-assert_has_feature(
+test.assert_has_feature(
     16, 10479, 25338, 'landuse',
     { 'kind': 'dog_park', 'sort_rank': 97 })
 
 
 # Red Gra / Running Track
 # http://www.openstreetmap.org/way/95922608
-assert_has_feature(
+test.assert_has_feature(
     15, 16384, 10951, 'landuse',
     { 'id': 95922608, 'kind': 'recreation_track', 'sort_rank': 59 })
 
 # Cox Stadium recreation track
-assert_has_feature(
+test.assert_has_feature(
     16, 32768, 21903, 'pois',
     { 'id': 95922608, 'kind': 'recreation_track', 'min_zoom': 16 })
 
 #http://www.openstreetmap.org/node/4218421638
 # Pista de Atletismo
-assert_has_feature(
+test.assert_has_feature(
     16, 21060, 39942, 'pois',
     { 'kind': 'recreation_track', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/node/418185265
 # cycle, Sand Pit
-assert_has_feature(
+test.assert_has_feature(
     16, 10556, 25509, 'pois',
     { 'kind': 'recreation_track', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/node/444949878
 # motor, Mazda Raceway Laguna Seca
-assert_has_feature(
+test.assert_has_feature(
     16, 10603, 25602, 'pois',
     { 'kind': 'recreation_track', 'min_zoom': 17 })
 
@@ -228,19 +228,19 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/2613055910
 # Unnamed fishing spot near Davis, CA
-assert_has_feature(
+test.assert_has_feature(
     16, 10602, 25159, 'pois',
     { 'kind': 'fishing_area', 'min_zoom': 17 })
 
 #https://www.openstreetmap.org/way/62099107
 #    16, 10471, 22459, 'pois',
-assert_has_feature(
+test.assert_has_feature(
     16, 10471, 22460, 'pois',
     { 'kind': 'fishing_area', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/234164554
 # Alpine Lake
-assert_has_feature(
+test.assert_has_feature(
     16, 12454, 24647, 'pois',
     { 'kind': 'fishing_area', 'min_zoom': 16 })
 
@@ -248,20 +248,20 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/3733554139
 # Seneca Rocks
-assert_has_feature(
+test.assert_has_feature(
     16, 18319, 25083, 'pois',
     { 'kind': 'swimming_area', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/368533731
 # Pine Lake Swimming Beach
-assert_has_feature(
+test.assert_has_feature(
 #    16, 10551, 22893, 'pois',
     16, 10551, 22892, 'pois',
     { 'kind': 'swimming_area', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/node/3733554139
 # Swimming hole at Seneca Rocks
-assert_has_feature(
+test.assert_has_feature(
     16, 18319, 25083, 'pois',
     { 'kind': 'swimming_area', 'min_zoom': 16 })
 
@@ -269,13 +269,13 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/3795571179
 # UC Berkeley area
-assert_has_feature(
+test.assert_has_feature(
     16, 10509, 25309, 'pois',
     { 'kind': 'firepit', 'min_zoom': 18 })
 
 #https://www.openstreetmap.org/way/349337076
 # Bloomfield area
-assert_has_feature(
+test.assert_has_feature(
     16, 10742, 24971, 'pois',
     { 'kind': 'firepit', 'min_zoom': 18 })
 
@@ -284,11 +284,11 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/way/329837642
 # Old Man Boulder
-assert_has_feature(
+test.assert_has_feature(
     16, 10442, 25304, 'landuse',
     { 'kind': 'stone', 'sort_rank': 28 })
 
-assert_has_feature(
+test.assert_has_feature(
     16, 10442, 25304, 'pois',
     { 'kind': 'stone', 'min_zoom': 17, 'name': 'Old Man Boulder' })
 
@@ -296,11 +296,11 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/way/377706598
 # Goodrich Pinnacle
-assert_has_feature(
+test.assert_has_feature(
     16, 11001, 25340, 'landuse',
     { 'kind': 'rock', 'sort_rank': 27 })
 
-assert_has_feature(
+test.assert_has_feature(
     16, 11001, 25340, 'pois',
     { 'kind': 'rock', 'min_zoom': 17, 'name': 'Goodrich Pinnacle' })
 
@@ -308,17 +308,17 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/2246385222
 # Redwood Acres RV Park, Eureka CA
-assert_has_feature(
+test.assert_has_feature(
     15, 5085, 12312, 'pois',
     { 'kind': 'caravan_site', 'min_zoom': 15 })
 
 #https://www.openstreetmap.org/way/291546386
 # Pillar Point RV Park
-assert_has_feature(
+test.assert_has_feature(
     14, 2618, 6348, 'landuse',
     { 'kind': 'caravan_site', 'sort_rank': 58 })
 
-assert_has_feature(
+test.assert_has_feature(
     14, 2618, 6348, 'pois',
     { 'kind': 'caravan_site', 'min_zoom': 14 })
 
@@ -326,30 +326,30 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/2401887217
 # South Park, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25329, 'pois',
     { 'kind': 'picnic_site', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/node/3297410094
 # Why is this missing?
 # Golden Gate Park, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10472, 25332, 'pois',
     { 'kind': 'picnic_site', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/400701941
 # Golden Gate Park, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10474, 25332, 'landuse',
     { 'kind': 'picnic_site', 'sort_rank': 108 })
 
-assert_has_feature(
+test.assert_has_feature(
     16, 10474, 25332, 'pois',
     { 'kind': 'picnic_site', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/231863022
 # building, South Park, SF
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25329, 'pois',
     { 'kind': 'picnic_site', 'min_zoom': 16, 'id': 231863022 })
 
@@ -357,26 +357,26 @@ assert_has_feature(
 
 #https://www.openstreetmap.org/node/1148222790
 # Fort Strong
-assert_has_feature(
+test.assert_has_feature(
     16, 19850, 24247, 'pois',
     { 'kind': 'fort', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/265893625
 # Battery 2
-assert_has_feature(
+test.assert_has_feature(
     16, 19303, 24607, 'landuse',
     { 'kind': 'fort', 'sort_rank': 47 })
 
-assert_has_feature(
+test.assert_has_feature(
     16, 19303, 24607, 'pois',
     { 'kind': 'fort', 'min_zoom': (lambda z: z >= 15 and z < 16) })
 
 #https://www.openstreetmap.org/way/51064272
 # Fort Monroe
-assert_has_feature(
+test.assert_has_feature(
     13, 2359, 3188, 'landuse',
     { 'kind': 'fort' })
 
-assert_has_feature(
+test.assert_has_feature(
     13, 2359, 3188, 'pois',
 	{ 'kind': 'fort', 'min_zoom': 13, 'name': 'Fort Monroe' })

--- a/integration-test/664-raceway.py
+++ b/integration-test/664-raceway.py
@@ -1,10 +1,10 @@
 # https://www.openstreetmap.org/way/28825404
-assert_has_feature(
+test.assert_has_feature(
     16, 10476, 25242, 'roads',
     { 'id': 28825404, 'kind': 'minor_road', 'kind_detail': 'raceway', 'sort_rank': 375 })
 
 # https://www.openstreetmap.org/way/59440900
 # Thunderoad Speedway Go-carts
-assert_has_feature(
+test.assert_has_feature(
     16, 10516, 25247, 'roads',
     { 'id': 59440900, 'kind': 'minor_road', 'kind_detail': 'raceway', 'sort_rank': 375 })

--- a/integration-test/668-intermittent-water.py
+++ b/integration-test/668-intermittent-water.py
@@ -1,29 +1,29 @@
 #http://www.openstreetmap.org/way/107817218
 # Arizona Canal Diversion Channel (ACDC) 
-assert_has_feature(
+test.assert_has_feature(
     16, 12353, 26272, 'water',
     { 'kind': 'river', 'intermittent': True })
 
 #http://www.openstreetmap.org/way/96528126
 # 10th Street Wash
-assert_has_feature(
+test.assert_has_feature(
     16, 12368, 26272, 'water',
     { 'kind': 'drain', 'intermittent': True })
 
 #http://www.openstreetmap.org/way/61954975
 # Unnamed drain
-assert_has_feature(
+test.assert_has_feature(
     16, 12372, 26272, 'water',
     { 'kind': 'drain', 'intermittent': True })
 
 #http://www.openstreetmap.org/way/321690441
 # Unnamed stream
-assert_has_feature(
+test.assert_has_feature(
     16, 12492, 26279, 'water',
     { 'kind': 'stream', 'intermittent': True })
 
 #http://www.openstreetmap.org/way/68709904
 # Unnamed water (lake)
-assert_has_feature(
+test.assert_has_feature(
     16, 12349, 26257, 'water',
     { 'kind': 'water', 'intermittent': True })

--- a/integration-test/671-ranger-station.py
+++ b/integration-test/671-ranger-station.py
@@ -1,26 +1,26 @@
 #http://www.openstreetmap.org/node/1996636138
 # Big Basin Redwoods State Park Headquarters
 # Node with amenity=ranger_station, but also has tourism=information set
-assert_has_feature(
+test.assert_has_feature(
     14, 2629, 6367, 'pois',
     { 'kind': 'ranger_station', 'min_zoom': 14 })
 
 #https://www.openstreetmap.org/node/351892607
 # Pantoll Ranger Station
 # Node with amenity=ranger_station, but also has tourism=information set
-assert_has_feature(
+test.assert_has_feature(
     14, 2612, 6325, 'pois',
     { 'kind': 'ranger_station', 'min_zoom': 14 })
 
 #http://www.openstreetmap.org/way/361301773
 # Building with amenity=ranger_station
-assert_has_feature(
+test.assert_has_feature(
     14, 2617, 6329, 'pois',
     { 'kind': 'ranger_station', 'min_zoom': 14 })
 
 #https://www.openstreetmap.org/way/269908344
 # Entrance Yosemite Nationalpark
 # Building with amenity=ranger_station
-assert_has_feature(
+test.assert_has_feature(
     14, 2742, 6337, 'pois',
     { 'kind': 'ranger_station', 'min_zoom': 14 })

--- a/integration-test/674-outdoor-shops.py
+++ b/integration-test/674-outdoor-shops.py
@@ -1,48 +1,48 @@
 #http://www.openstreetmap.org/node/3056897308
-assert_has_feature(
+test.assert_has_feature(
     16, 11111, 25360, 'pois',
     { 'kind': 'fishing', 'min_zoom': 16 })
 
 #http://www.openstreetmap.org/node/1467729495
-assert_has_feature(
+test.assert_has_feature(
     16, 10165, 24618, 'pois',
     { 'kind': 'hunting', 'min_zoom': 16 })
 
 #http://www.openstreetmap.org/node/766201791
-assert_has_feature(
+test.assert_has_feature(
     16, 10179, 24602, 'pois',
     { 'kind': 'outdoor', 'min_zoom': 16 })
     
 #http://www.openstreetmap.org/way/35343322
 # Smaller Sports Basement store in SF
 # This should really be in 16, 10483, 25332, but is in zoom 15 now
-assert_has_feature(
+test.assert_has_feature(
     15, 5241, 12666, 'pois',
     { 'kind': 'outdoor', 'id': 35343322 })
     
 #http://www.openstreetmap.org/way/377630800
 # Large Bass Pro building that should appear earlier
-assert_has_feature(
+test.assert_has_feature(
     15, 6842, 12520, 'pois',
     { 'kind': 'outdoor', 'id': 377630800 })
     
 #http://www.openstreetmap.org/way/290195878
 # Large REI building that should appear earlier
-assert_has_feature(
+test.assert_has_feature(
     15, 6207, 12321, 'pois',
     { 'kind': 'outdoor', 'id': 290195878 })
 
 #http://www.openstreetmap.org/node/3931687122
-assert_has_feature(
+test.assert_has_feature(
     16, 10467, 25309, 'pois',
     { 'kind': 'scuba_diving', 'min_zoom': 17 })
 
 #http://www.openstreetmap.org/node/2135237099
-assert_has_feature(
+test.assert_has_feature(
     16, 10558, 25443, 'pois',
     { 'kind': 'gas_canister', 'min_zoom': 18 })
 
 #https://www.openstreetmap.org/node/3799971066
-assert_has_feature(
+test.assert_has_feature(
     16, 10483, 25331, 'pois',
     { 'kind': 'motorcycle', 'min_zoom': 17 })

--- a/integration-test/675-man_made-outdoor-landmarks.py
+++ b/integration-test/675-man_made-outdoor-landmarks.py
@@ -1,49 +1,49 @@
 #http://www.openstreetmap.org/node/1230069003
-assert_has_feature(
+test.assert_has_feature(
     15, 5285, 12654, 'pois',
     { 'kind': 'communications_tower', 'min_zoom': 15 })
 
 #http://www.openstreetmap.org/node/747693102
 # ideally the landuse would show up at zoom 13, but that's sparse coverage
 # most features are buildings, some of which are incorrectly tagged (should be telescope)
-assert_has_feature(
+test.assert_has_feature(
     15, 9504, 12490, 'pois',
     { 'kind': 'observatory', 'min_zoom': 15 })
 
 #http://www.openstreetmap.org/node/258205070
-assert_has_feature(
+test.assert_has_feature(
     16, 10623, 25430, 'pois',
     { 'kind': 'telescope', 'min_zoom': 16 })
 
 #https://www.openstreetmap.org/way/53055408
 # If someone took the time to digitize a building, promote it up
-assert_has_feature(
+test.assert_has_feature(
     15, 5324, 12781, 'pois',
     { 'kind': 'telescope', 'min_zoom': 15 })
 
 #http://www.openstreetmap.org/node/2622856034
-assert_has_feature(
+test.assert_has_feature(
     13, 1409, 3281, 'pois',
     { 'kind': 'offshore_platform', 'min_zoom': 13 })
 
 #http://www.openstreetmap.org/way/346405529
-assert_has_feature(
+test.assert_has_feature(
     13, 1367, 3261, 'pois',
     { 'kind': 'offshore_platform', 'min_zoom': 13 })
 
 #http://www.openstreetmap.org/way/446514311
-assert_has_feature(
+test.assert_has_feature(
     13, 5399, 1881, 'pois',
     { 'kind': 'offshore_platform', 'min_zoom': 13, 'id': 446514311 })
 
 #http://www.openstreetmap.org/node/1501843094
-assert_has_feature(
+test.assert_has_feature(
     15, 5240, 12673, 'pois',
     { 'kind': 'water_tower', 'min_zoom': 15 })
 
 #https://www.openstreetmap.org/node/3679715072
 # This isn't part of the work, but because we split water_tower
 # off from mast, we should test mast still shows up
-assert_has_feature(
+test.assert_has_feature(
     16, 10588, 25442, 'pois',
     { 'kind': 'mast', 'min_zoom': 17 })

--- a/integration-test/677-waterfall.py
+++ b/integration-test/677-waterfall.py
@@ -1,73 +1,73 @@
 #https://www.openstreetmap.org/node/2389658224
 # Upper Yosemite Falls, because it's so tall at 550 meters, more than 300 meters
-assert_has_feature(
+test.assert_has_feature(
     12, 687, 1583, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 12, 'height': 550 })
 
 #https://www.openstreetmap.org/node/2384221575
 # Middle Yosemite Falls, 206 meters, more than 50 meters
-assert_has_feature(
+test.assert_has_feature(
     13, 1374, 3166, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 13 })
 
 #https://www.openstreetmap.org/node/2389657981
 # Lower Yosemite Falls, only 98 meters
-assert_has_feature(
+test.assert_has_feature(
     13, 1374, 3167, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 13 })
 
 #https://www.openstreetmap.org/way/56539663
 # Niagara Falls (Horseshoe Falls)
-assert_has_feature(
+test.assert_has_feature(
     12, 1148, 1503, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 12 })
 
 # We had considered this for label_placement:yes,
 # but there are only 19 in all of North America
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 1148, 1503, 'water',
     { 'kind': 'waterfall' })
 
 #https://www.openstreetmap.org/node/2375445789
 # Alamere Falls (no height)
 # Assume falls are important, show at zoom 14 default
-assert_has_feature(
+test.assert_has_feature(
     14, 2604, 6322, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 14 })
 
 #http://www.openstreetmap.org/node/3257658773
 # Abrigo Falls, 4.5 meters (less than 8 meters)
 # Allow short waterfalls to be suppressed a zoom
-assert_has_feature(
+test.assert_has_feature(
     15, 5265, 12645, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 15 })
 
 #http://www.openstreetmap.org/node/1247873121
 # Lower Chilnualna Fall, no height
-assert_has_feature(
+test.assert_has_feature(
     14, 2747, 6345, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 14 })
 
 #https://www.openstreetmap.org/node/1247872815
 # Chilnualna Creek Cascades, no height
-assert_has_feature(
+test.assert_has_feature(
     14, 2748, 6344, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 14 })
 
 # https://www.openstreetmap.org/node/877270365
 # Rainbow Falls - height 150ft = 45m
-assert_has_feature(
+test.assert_has_feature(
     14, 4416, 6484, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 14, 'height': 45.72 })
 
 # https://www.openstreetmap.org/node/404574988
 # Toccoa Falls - height 186' = 56.6929m
-assert_has_feature(
+test.assert_has_feature(
     13, 2199, 3256, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 13, 'height': 56.6928 })
 
 # https://www.openstreetmap.org/node/3647404249
 # Eternal Flame Falls - height 9m (with unit)
-assert_has_feature(
+test.assert_has_feature(
     15, 9215, 12077, 'pois',
     { 'kind': 'waterfall', 'min_zoom': 15, 'height': 9 })

--- a/integration-test/679-less-landuse-building-label-placements.py
+++ b/integration-test/679-less-landuse-building-label-placements.py
@@ -1,21 +1,21 @@
 # The landuse for a pier
 # http://www.openstreetmap.org/way/82206919
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2620, 6330, 'landuse',
     {'id': 82206919, 'kind': 'pier', 'label_placement': True})
 
-assert_has_feature(
+test.assert_has_feature(
     15, 5240, 12661, 'landuse',
     {'id': 82206919, 'kind': 'pier', 'label_placement': True})
 
 
 # The building known as 650 California Street
 # http://www.openstreetmap.org/way/260520160
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5242, 12663, 'buildings',
     {'id': 260520160, 'kind': 'building', 'label_placement': True})
 
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25326, 'buildings',
     {'id': 260520160, 'kind': 'building', 'label_placement': True})
 

--- a/integration-test/704-exclude-null-values-for-buildings.py
+++ b/integration-test/704-exclude-null-values-for-buildings.py
@@ -8,6 +8,5 @@ with features_in_tile_layer(16, 10481, 25319, 'buildings') as features:
     for f in features:
         for k, v in f['properties'].items():
             if v is None:
-                raise AssertionError(
-                    "%r is null, but there should be no null values in "
-                    "feature %r" % (k, f['properties']))
+                fail('%r is null, but there should be no null values in '
+                     'feature %r' % (k, f['properties']))

--- a/integration-test/704-exclude-null-values-for-buildings.py
+++ b/integration-test/704-exclude-null-values-for-buildings.py
@@ -1,12 +1,12 @@
 # way 128245373 - alcatraz prison main building
-assert_has_feature(
+test.assert_has_feature(
     16, 10481, 25319, 'buildings',
     { 'kind': 'building' })
 
 # but that same building should not have any "null" values in it
-with features_in_tile_layer(16, 10481, 25319, 'buildings') as features:
+with test.features_in_tile_layer(16, 10481, 25319, 'buildings') as features:
     for f in features:
         for k, v in f['properties'].items():
             if v is None:
-                fail('%r is null, but there should be no null values in '
+                test.fail('%r is null, but there should be no null values in '
                      'feature %r' % (k, f['properties']))

--- a/integration-test/713-urban-areas.py
+++ b/integration-test/713-urban-areas.py
@@ -1,23 +1,23 @@
 # update kind to read urban_areas instead of urban areas.
 
 # This is not an OSM feature it comes from Natural Earth
-assert_has_feature(
+test.assert_has_feature(
     4, 2, 6, 'landuse',
     {'kind': 'urban_area'})
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     4, 2, 6, 'landuse',
     {'kind': 'urban area'})
 
-assert_has_feature(
+test.assert_has_feature(
     7, 20, 49, 'landuse',
     {'kind': 'urban_area'})
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     7, 20, 49, 'landuse',
     {'kind': 'urban area'})
 
-assert_has_feature(
+test.assert_has_feature(
     9, 81, 197, 'landuse',
     {'kind': 'urban_area'})
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     9, 81, 197, 'landuse',
     {'kind': 'urban area'})

--- a/integration-test/719-add-kind-detail-for-pois.py
+++ b/integration-test/719-add-kind-detail-for-pois.py
@@ -1,20 +1,20 @@
 # https://www.openstreetmap.org/node/1426311638
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24629, 'pois',
     { 'id': 1426311638, 'kind': 'restaurant', 'kind_detail': 'seafood' })
 
 # https://www.openstreetmap.org/way/280288213
-assert_has_feature(
+test.assert_has_feature(
     16, 19319, 24634, 'pois',
     { 'id': 280288213, 'kind': 'restaurant', 'kind_detail': 'japanese' })
 
 # https://www.openstreetmap.org/node/4305351592
-assert_has_feature(
+test.assert_has_feature(
     16, 19336, 24608, 'pois',
     { 'id': 4305351592, 'kind': 'pitch', 'kind_detail': 'baseball' })
 
 # https://www.openstreetmap.org/way/326894220
-assert_has_feature(
+test.assert_has_feature(
     16, 19321, 24634, 'pois',
     { 'id': 326894220, 'kind': 'pitch', 'kind_detail': 'basketball' })
 

--- a/integration-test/729-route-name.py
+++ b/integration-test/729-route-name.py
@@ -1,6 +1,6 @@
 # Relation: M-Ocean View: Inbound to Downtown (91022)
 # http://www.openstreetmap.org/relation/91022
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, 'transit',
     { 'id': -91022, 'kind': 'light_rail', 'osm_relation': True,
       'name': 'M-Ocean View: Inbound to Downtown',

--- a/integration-test/731-return-of-the-zombie-buildings.py
+++ b/integration-test/731-return-of-the-zombie-buildings.py
@@ -1,9 +1,9 @@
 # mz_is_building is an internal tag and shouldn't be present on any output
 # feature.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 653, 1582, 'buildings',
     { 'mz_is_building': None })
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 653, 1582, 'landuse',
     { 'mz_is_building': None })

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -1,22 +1,22 @@
 # Node:358830410 Grave_yard in POIs
 # http://www.openstreetmap.org/node/358830410
-assert_has_feature(
+test.assert_has_feature(
     16, 10475, 25352, 'pois',
     {'id': 358830410, 'kind': 'grave_yard'})
 
 # Grave_yard in POIS
 # http://www.openstreetmap.org/way/395328265
-assert_has_feature(
+test.assert_has_feature(
     15, 5231, 12653, 'pois',
     {'id': 395328265, 'kind': 'grave_yard'})
 
 # Grave_yard in landuse (same way as above)
-assert_has_feature(
+test.assert_has_feature(
     15, 5231, 12653, 'landuse',
     {'id': 395328265, 'kind': 'grave_yard'})
 
 # Label placement Grave_yard in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5231, 12653, 'landuse',
     {'id': 395328265, 'kind': 'grave_yard', 'label_placement': True})
 
@@ -25,47 +25,47 @@ assert_no_matching_feature(
 #
 # http://www.openstreetmap.org/way/41654965
 # http://www.openstreetmap.org/relation/2475077
-assert_has_feature(
+test.assert_has_feature(
     12, 1171, 1567, 'pois',
     {'id': set([41654965, -2475077]), 'kind': 'cemetery', 'min_zoom': 12})
 
 # Label placement Cemetery in landuse
 # http://www.openstreetmap.org/way/44580948
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5471, 12981, 'landuse',
     {'id': 44580948, 'kind': 'cemetery', 'label_placement': True})
 
 # Way:179213166 Farm in POIs
 # http://www.openstreetmap.org/way/179213166
-assert_has_feature(
+test.assert_has_feature(
     15, 6660, 12542, 'pois',
     {'id': 179213166, 'kind': 'farm'})
 
 # Label placement farm in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 6660, 12542, 'landuse',
     {'id': 179213166, 'kind': 'farm', 'label_placement': True})
 
 # landuse: Forest in POIS
 # http://www.openstreetmap.org/way/444359931
-assert_has_feature(
+test.assert_has_feature(
     14, 2630, 5910, 'pois',
     {'id': 444359931, 'kind': 'forest'})
 
 # Label placement forest in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2630, 5910, 'landuse',
     {'id': 444359931, 'kind': 'forest', 'label_placement': True})
 
 # Node:357559979 landuse: Forest in POIS
 # http://www.openstreetmap.org/node/357559979
-assert_has_feature(
+test.assert_has_feature(
     14, 2842, 6101, 'pois',
     {'id': 357559979, 'kind': 'forest', 'min_zoom': 14})
 
 # Way:432810821 landuse: Forest protect class in POIS
 # http://www.openstreetmap.org/way/432810821
-assert_has_feature(
+test.assert_has_feature(
     8, 72, 94, 'pois',
     {'id': 432810821, 'kind': 'forest', 'protect_class': '6'})
 
@@ -73,12 +73,12 @@ assert_has_feature(
 # http://www.openstreetmap.org/way/202680509
 # note: since #1103, there should be no POIs for natural_forest, only label
 # placements in the landuse layer.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 4877, 6109, 'pois',
     {'id': 202680509, 'kind': 'natural_forest'})
 
 # Label placement forest in landuse
-assert_has_feature(
+test.assert_has_feature(
     15, 9755, 12218, 'landuse',
     {'id': 202680509, 'kind': 'natural_forest', 'label_placement': True})
 
@@ -86,172 +86,172 @@ assert_has_feature(
 # http://www.openstreetmap.org/node/4633280957
 # note: since #1103, there should be no POIs for natural_forest, only label
 # placements in the landuse layer.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 11852, 7770, 'pois',
     {'id': 4633280957, 'kind': 'natural_forest', 'min_zoom': 14})
 
 # Way:30903221 Golf_course in POIS
 # http://www.openstreetmap.org/way/30903221
-assert_has_feature(
+test.assert_has_feature(
     13, 1308, 3166, 'pois',
     {'id': 30903221, 'kind': 'golf_course'})
 
 # Label placement Golf_course in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5233, 12666, 'landuse',
     {'id': 30903221, 'kind': 'golf_course', 'label_placement': True})
 
 # Node:4035914099 Golf_course in POIS
 # http://www.openstreetmap.org/node/4035914099
-assert_has_feature(
+test.assert_has_feature(
     14, 2680, 6334, 'pois',
     {'id': 4035914099, 'kind': 'golf_course', 'min_zoom': 14})
 
 # Way:330274727 Military in POIS
 # http://www.openstreetmap.org/way/330274727
-assert_has_feature(
+test.assert_has_feature(
     13, 1308, 3174, 'pois',
     {'id': 330274727, 'kind': 'military'})
 
 # Label placement military in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5233, 12697, 'landuse',
     {'id': 330274727, 'kind': 'military', 'label_placement': True})
 
 # Node:369174053 Military in POIS
 # http://www.openstreetmap.org/node/369174053
-assert_has_feature(
+test.assert_has_feature(
     14, 2617, 6329, 'pois',
     {'id': 369174053, 'kind': 'military', 'min_zoom': 14})
 
 # Way:296096756 national_park in POIS
 # http://www.openstreetmap.org/way/296096756
-assert_has_feature(
+test.assert_has_feature(
     10, 164, 397, 'pois',
     {'id': 296096756, 'kind': 'park'})
 
 # Label placement national_park in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5267, 12722, 'landuse',
     {'id': 296096756, 'kind': 'park', 'label_placement': True})
 
 # Node:617506856 national_park in POIS
 # http://www.openstreetmap.org/node/617506856
-assert_has_feature(
+test.assert_has_feature(
     14, 3374, 6184, 'pois',
     {'id': 617506856, 'kind': 'park', 'min_zoom': 14})
 
 # Way:40260866 nature_reserve in POIS
 # http://www.openstreetmap.org/way/40260866
-assert_has_feature(
+test.assert_has_feature(
     12, 720, 1638, 'pois',
     {'id': 40260866, 'kind': 'nature_reserve'})
 
 # Label placement nature_reserve in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5766, 13111, 'landuse',
     {'id': 40260866, 'kind': 'nature_reserve', 'label_placement': True})
 
 # Node:1262562806 nature_reserve in POIS
 # http://www.openstreetmap.org/node/1262562806
-assert_has_feature(
+test.assert_has_feature(
     10, 247, 388, 'pois',
     {'id': 1262562806, 'kind': 'nature_reserve', 'min_zoom': 10})
 
 # Way:23871270 park in POIS
 # http://www.openstreetmap.org/way/23871270
-assert_has_feature(
+test.assert_has_feature(
     13, 1310, 3166, 'pois',
     {'id': 23871270, 'kind': 'park'})
 
 # Label placement park in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5240, 12667, 'landuse',
     {'id': 23871270, 'kind': 'park', 'label_placement': True})
 
 # park in POIS
 # http://www.openstreetmap.org/node/356541963
-assert_has_feature(
+test.assert_has_feature(
     14, 2622, 5725, 'pois',
     {'id': 356541963, 'kind': 'park', 'min_zoom': 14})
 
 # Way:26278098 plant in POIS
 # http://www.openstreetmap.org/way/26278098
-assert_has_feature(
+test.assert_has_feature(
     14, 2617, 6334, 'pois',
     {'id': 26278098, 'kind': 'plant'})
 
 # Label placement plant in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5235, 12668, 'landuse',
     {'id': 26278098, 'kind': 'plant', 'label_placement': True})
 
 # Node:902365126 plant in POIS
 # http://www.openstreetmap.org/node/902365126
-assert_has_feature(
+test.assert_has_feature(
     14, 2777, 6374, 'pois',
     {'id': 902365126, 'kind': 'plant', 'min_zoom': 14})
 
 # Node:2442093493 pitch in POIS
 # http://www.openstreetmap.org/node/2442093493
-assert_has_feature(
+test.assert_has_feature(
     16, 10910, 25062, 'pois',
     {'id': 2442093493, 'kind': 'pitch', 'min_zoom': 16})
 
 # Way:296573403 protected_area in POIS
 # http://www.openstreetmap.org/way/296573403
-assert_has_feature(
+test.assert_has_feature(
     9, 82, 198, 'pois',
     {'id': 296573403, 'kind': 'protected_area'})
 
 # Label placement protected_area in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5249, 12701, 'landuse',
     {'id': 296573403, 'kind': 'protected_area', 'label_placement': True})
 
 # boundary = protected_area in POIS
 # http://www.openstreetmap.org/node/1462300228
-assert_has_feature(
+test.assert_has_feature(
     14, 8695, 5583, 'pois',
     {'id': 1462300228, 'kind': 'protected_area', 'min_zoom': 14})
 
 # quarry in POIS
 # http://www.openstreetmap.org/way/362159618
-assert_has_feature(
+test.assert_has_feature(
     12, 660, 1437, 'pois',
     {'id': 362159618, 'kind': 'quarry', 'min_zoom': 12})
 
 # Label placement quarry in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5284, 11498, 'landuse',
     {'id': 362159618, 'kind': 'quarry', 'label_placement': True})
 
 # Node:585365655 quarry in POIS
 # http://www.openstreetmap.org/node/585365655
-assert_has_feature(
+test.assert_has_feature(
     14, 2622, 6334, 'pois',
     {'id': 585365655, 'kind': 'quarry', 'min_zoom': 14})
 
 # landuse=recreation_ground in POIS
 # http://www.openstreetmap.org/way/413471062
-assert_has_feature(
+test.assert_has_feature(
     14, 2629, 6331, 'pois',
     {'id': 413471062, 'kind': 'recreation_ground', 'min_zoom': 14})
 
 # Label placement recreation_ground in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10519, 25326, 'landuse',
     {'id': 413471062, 'kind': 'recreation_ground', 'label_placement': True})
 
 # recreation_ground in POIS
 # http://www.openstreetmap.org/node/417274812
-assert_has_feature(
+test.assert_has_feature(
     14, 2620, 6330, 'pois',
     {'id': 417274812, 'kind': 'recreation_ground', 'min_zoom': 14})
 
 # Node:4214350591 substation in POIS
 # http://www.openstreetmap.org/node/4214350591
-assert_has_feature(
+test.assert_has_feature(
     15, 5233, 12668, 'pois',
     {'id': 4214350591, 'kind': 'substation', 'min_zoom': 15})
 
@@ -259,80 +259,80 @@ assert_has_feature(
 # http://www.openstreetmap.org/way/128479579
 # note: since #1103, there should be no POIs for village_green, only label
 # placements in the landuse layer.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 6000, 9246, 'pois',
     {'id': 128479579, 'kind': 'village_green', 'min_zoom': 13.23})
 
 # Label placement village_green in landuse
-assert_has_feature(
+test.assert_has_feature(
     16, 24002, 36987, 'landuse',
     {'id': 128479579, 'kind': 'village_green', 'label_placement': True})
 
 # Node:3199567035 village_green in POIS
 # http://www.openstreetmap.org/node/3199567035
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 4186, 6018, 'pois',
     {'id': 3199567035, 'kind': 'village_green', 'min_zoom': 14})
 
 # Way:239634932 wastewater_plant in POIS
 # http://www.openstreetmap.org/way/239634932
-assert_has_feature(
+test.assert_has_feature(
     13, 1310, 3167, 'pois',
     {'id': 239634932, 'kind': 'wastewater_plant', 'min_zoom': 13})
 
 # Label placement wastewater_plant in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5243, 12669, 'landuse',
     {'id': 239634932, 'kind': 'wastewater_plant', 'label_placement': True})
 
 # Node:2838226695 wastewater_plant in POIS
 # http://www.openstreetmap.org/node/2838226695
-assert_has_feature(
+test.assert_has_feature(
     14, 2615, 6325, 'pois',
     {'id': 2838226695, 'kind': 'wastewater_plant', 'min_zoom': 14})
 
 # Way:93703732 water_works in POIS
 # http://www.openstreetmap.org/way/93703732
-assert_has_feature(
+test.assert_has_feature(
     14, 2620, 6330, 'pois',
     {'id': 93703732, 'kind': 'water_works', 'min_zoom': 14})
 
 # Label placement water_works in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5240, 12661, 'landuse',
     {'id': 93703732, 'kind': 'water_works', 'label_placement': True})
 
 # water_works in POIS
 # http://www.openstreetmap.org/node/1380919388
-assert_has_feature(
+test.assert_has_feature(
     14, 8173, 5372, 'pois',
     {'id': 1380919388, 'kind': 'water_works', 'min_zoom': 14})
 
 # Way:317721523 winter_sports in POIS
 # http://www.openstreetmap.org/way/317721523
-assert_has_feature(
+test.assert_has_feature(
     10, 170, 391, 'pois',
     {'id': 317721523, 'kind': 'winter_sports', 'min_zoom': 10})
 
 # Label placement winter_sports in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5470, 12530, 'landuse',
     {'id': 317721523, 'kind': 'winter_sports', 'label_placement': True})
 
 # Node:4042754024 winter_sports in POIS
 # http://www.openstreetmap.org/node/4042754024
-assert_has_feature(
+test.assert_has_feature(
     13, 4238, 2938, 'pois',
     {'id': 4042754024, 'kind': 'winter_sports', 'min_zoom': 13})
 
 # landuse: wood in POIS
 # http://www.openstreetmap.org/way/433247531
-assert_has_feature(
+test.assert_has_feature(
     14, 8113, 5428, 'pois',
     {'id': 433247531, 'kind': 'wood'})
 
 # Label placement landuse: wood in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 16227, 10856, 'landuse',
     {'id': 433247531, 'kind': 'wood', 'label_placement': True})
 
@@ -340,12 +340,12 @@ assert_no_matching_feature(
 # http://www.openstreetmap.org/way/249171216
 # note: since #1103, there should be no POIs for natural_wood, only label
 # placements in the landuse layer.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 8107, 5426, 'pois',
     {'id': 249171216, 'kind': 'natural_wood'})
 
 # Label placement natural: wood in landuse
-assert_has_feature(
+test.assert_has_feature(
     15, 16214, 10852, 'landuse',
     {'id': 249171216, 'kind': 'natural_wood', 'label_placement': True})
 
@@ -353,23 +353,23 @@ assert_has_feature(
 # http://www.openstreetmap.org/node/369162231
 # note: since #1103, there should be no POIs for natural_wood, only label
 # placements in the landuse layer.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2612, 6298, 'pois',
     {'id': 369162231, 'kind': 'natural_wood'})
 
 # works in POIS
 # http://www.openstreetmap.org/way/161371157
-assert_has_feature(
+test.assert_has_feature(
     14, 8111, 5443, 'pois',
     {'id': 161371157, 'kind': 'works', 'min_zoom': 14})
 
 # Label placement works in landuse
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 8111, 5443, 'landuse',
     {'id': 161371157, 'kind': 'works', 'label_placement': True})
 
 # Node:1004981713 works in POIS
 # http://www.openstreetmap.org/node/1004981713
-assert_has_feature(
+test.assert_has_feature(
     14, 3293, 6329, 'pois',
     {'id': 1004981713, 'kind': 'works', 'min_zoom': 14})

--- a/integration-test/744-remove-osm-neighbourhoods.py
+++ b/integration-test/744-remove-osm-neighbourhoods.py
@@ -1,17 +1,17 @@
 # Node: Mount Pocono (158473043)
 # http://www.openstreetmap.org/node/158473043
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 19048, 24541, 'places',
     { 'kind': 'borough', 'source': 'openstreetmap.org' })
 
 # Node: Centerville District (150939391)
 # http://www.openstreetmap.org/node/150939391
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10558, 25381, 'places',
     { 'kind': 'suburb', 'source': 'openstreetmap.org' })
 
 # Node: Northeast (2790349074)
 # http://www.openstreetmap.org/node/2790349074
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 18754, 25065, 'places',
     { 'kind': 'quarter', 'source': 'openstreetmap.org' })

--- a/integration-test/766-dont-merge-z16-roads.py
+++ b/integration-test/766-dont-merge-z16-roads.py
@@ -3,9 +3,9 @@
 #
 # http://www.openstreetmap.org/way/89912879
 # http://www.openstreetmap.org/way/89911760
-assert_has_feature(
+test.assert_has_feature(
     16, 19829, 24234, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 89912879})
-assert_has_feature(
+test.assert_has_feature(
     16, 19829, 24234, "roads",
     {"kind": "major_road", "kind_detail": "trunk", "id": 89911760})

--- a/integration-test/768-multiline-encoded.py
+++ b/integration-test/768-multiline-encoded.py
@@ -1,3 +1,3 @@
 # Way: Big Bear Boulevard (325846175) http://www.openstreetmap.org/way/325846175
-assert_feature_geom_type(16, 11473, 26126, 'roads',
+test.assert_feature_geom_type(16, 11473, 26126, 'roads',
                          325846175, 'LineString')

--- a/integration-test/774-cycleway-no.py
+++ b/integration-test/774-cycleway-no.py
@@ -1,20 +1,20 @@
 #  Way: Grant Avenue (184956229) http://www.openstreetmap.org/way/184956229
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10484, 25327, 'roads',
     { 'cycleway': 'no' })
 
 # Way: Wedge Parkway (263563960) http://www.openstreetmap.org/way/263563960
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10966, 24952, 'roads',
     { 'cycleway_left': 'no' })
-assert_has_feature(
+test.assert_has_feature(
     16, 10966, 24952, 'roads',
     { 'cycleway_right': 'lane' })
 
 # Way: Wedge Parkway (263563950) http://www.openstreetmap.org/way/263563950
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10965, 24952, 'roads',
     { 'cycleway_right': 'no' })
-assert_has_feature(
+test.assert_has_feature(
     16, 10965, 24952, 'roads',
     { 'cycleway_left': 'lane' })

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -7,7 +7,7 @@
 #
 # NOTE: it's part of two other relations, but these are not walking/hiking
 # routes.
-assert_has_feature(
+test.assert_has_feature(
     15, 17571, 11449, 'roads',
     { 'id': 127908481, 'kind': 'path', 'bicyle': type(None),
       'walking_network': 'rwn', 'walking_shield_text': '416',
@@ -22,7 +22,7 @@ assert_has_feature(
 #   type=route, route=foot, network=rwn, ref=JMT
 # https://www.openstreetmap.org/relation/1244686
 #   type=route, route=foot, network=rwn, ref="", name="PCT - California Section H"
-assert_has_feature(
+test.assert_has_feature(
     16, 11044, 25309, 'roads',
     { 'id': 373532611,
       'walking_network': 'nwn', 'walking_shield_text': 'PCT',

--- a/integration-test/776-duplicate-footway.py
+++ b/integration-test/776-duplicate-footway.py
@@ -1,15 +1,15 @@
 #  Way: 128534087 http://www.openstreetmap.org/way/128534087
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25330, 'roads',
     { 'id': 128534087 })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10482, 25330, 'landuse',
     { 'id': 128534087 })
 
 # Way: 367756094 http://www.openstreetmap.org/way/367756094
-assert_has_feature(
+test.assert_has_feature(
     16, 10465, 25331, 'roads',
     { 'id': 367756094 })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10465, 25331, 'landuse',
     { 'id': 367756094 })

--- a/integration-test/797-add-missing-boundaries.py
+++ b/integration-test/797-add-missing-boundaries.py
@@ -1,10 +1,10 @@
 # NE data - no OSM elements
 # boundary between NV and CA is _also_ a "statistical" boundary
-assert_has_feature(
+test.assert_has_feature(
     7, 21, 49, 'boundaries',
     { 'kind': 'region' })
 
 # boundary between MT and ND is _also_ a "statistical meta" boundary
-assert_has_feature(
+test.assert_has_feature(
     7, 27, 44, 'boundaries',
     { 'kind': 'region' })

--- a/integration-test/806-building-height.py
+++ b/integration-test/806-building-height.py
@@ -1,12 +1,12 @@
 # Way: R5 Tower A (431358377)
 # https://www.openstreetmap.org/way/431358377
-assert_has_feature(
+test.assert_has_feature(
     16, 55897, 25449, 'buildings',
     { 'id': 431358377, 'height': 77.0, 'kind': 'building',
       'building:levels': type(None), 'building_levels': type(None) })
 
 # http://www.openstreetmap.org/way/336433763
-assert_has_feature(
+test.assert_has_feature(
     16, 19086, 24821, 'buildings',
     { 'id': 336433763, 'min_height': 3.0, 'kind': 'building_part',
       'building_part': type(None), 'building:min_levels': type(None),

--- a/integration-test/820-gate-min-zoom.py
+++ b/integration-test/820-gate-min-zoom.py
@@ -3,46 +3,46 @@
 # Gate on secondary road
 # http://www.openstreetmap.org/node/3608363612
 # http://www.openstreetmap.org/way/83473200
-assert_has_feature(
+test.assert_has_feature(
     15, 5528, 12649, 'pois',
     {'id': 3608363612, 'kind': 'gate', 'min_zoom': 15})
 
 # Gate on minor road
 # http://www.openstreetmap.org/node/2591034891
 # http://www.openstreetmap.org/way/11621900
-assert_has_feature(
+test.assert_has_feature(
     16, 19244, 24628, 'pois',
     {'id': 2591034891, 'kind': 'gate', 'min_zoom': 16})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 9622, 12314, 'pois',
     {'id': 2591034891, 'kind': 'gate'})
 
 # Gate on unclassified road
 # http://www.openstreetmap.org/node/276321344
 # http://www.openstreetmap.org/way/70807512
-assert_has_feature(
+test.assert_has_feature(
     16, 10549, 25415, 'pois',
     {'id': 276321344, 'kind': 'gate', 'min_zoom': 16})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5274, 12707, 'pois',
     {'id': 276321344, 'kind': 'gate'})
 
 # Gate on footway
 # http://www.openstreetmap.org/node/302482019
 # http://www.openstreetmap.org/way/27553445
-assert_has_feature(
+test.assert_has_feature(
     16, 10466, 25328, 'pois',
     {'id': 302482019, 'kind': 'gate', 'min_zoom': 16})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 5233, 12664, 'pois',
     {'id': 302482019, 'kind': 'gate'})
 
 # Gate on a fence
 # http://www.openstreetmap.org/node/4320045170
 # http://www.openstreetmap.org/way/427290222
-assert_has_feature(
+test.assert_has_feature(
     16, 10479, 25344, 'pois',
     {'id': 4320045170, 'kind': 'gate', 'min_zoom': 17})

--- a/integration-test/829-garden-pois.py
+++ b/integration-test/829-garden-pois.py
@@ -2,18 +2,18 @@
 
 # garden with area in pois
 # https://www.openstreetmap.org/way/120480164
-assert_has_feature(
+test.assert_has_feature(
     13, 1309, 3166, 'pois',
     {'id': 120480164, 'kind': 'garden'})
 
 # garden with area in landuse
 # https://www.openstreetmap.org/way/120480164
-assert_has_feature(
+test.assert_has_feature(
     13, 1309, 3166, 'landuse',
     {'id': 120480164, 'kind': 'garden'})
 
 # garden without area in pois
 # https://www.openstreetmap.org/node/2969748431
-assert_has_feature(
+test.assert_has_feature(
     16, 10473, 25332, 'pois',
     {'id': 2969748431, 'kind': 'garden'})

--- a/integration-test/830-windmill-zoom.py
+++ b/integration-test/830-windmill-zoom.py
@@ -2,16 +2,16 @@
 
 # windmill with tourism = attraction
 # http://www.openstreetmap.org/way/287921407
-assert_has_feature(
+test.assert_has_feature(
     14, 2616, 6333, 'pois',
     {'id': 287921407, 'kind': 'windmill'})
 
 # windmill without tourism = attraction
 # http://www.openstreetmap.org/node/2304462088
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2675, 6412, 'pois',
     {'id': 2304462088, 'kind': 'windmill'})
 
-assert_has_feature(
+test.assert_has_feature(
     15, 5350, 12824, 'pois',
     {'id': 2304462088, 'kind': 'windmill'})

--- a/integration-test/832-pedestrian-paths-bicycle.py
+++ b/integration-test/832-pedestrian-paths-bicycle.py
@@ -2,12 +2,12 @@
 
 # Pedestrian path
 # http://www.openstreetmap.org/way/8919991
-assert_has_feature(
+test.assert_has_feature(
     13, 1309, 3165, 'roads',
     { 'id': 8919991, 'kind': 'path', 'is_bicycle_related': True, 'bicycle': 'designated'})
 
 # Pier
 # http://www.openstreetmap.org/way/133920164
-assert_has_feature(
+test.assert_has_feature(
     13, 1304, 2933, 'roads',
     { 'id': 133920164, 'kind': 'path', 'is_bicycle_related': True, 'bicycle': 'yes'})

--- a/integration-test/834-park-building.py
+++ b/integration-test/834-park-building.py
@@ -1,11 +1,11 @@
 # Way: Olympic Sculpture Park (239782410)
 # http://www.openstreetmap.org/way/239782410
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10493, 22885, 'buildings',
     { 'id': 239782410 })
 
 # Way: Olympic Sculpture Park (239782410)
 # http://www.openstreetmap.org/way/239782410
-assert_has_feature(
+test.assert_has_feature(
     16, 10493, 22885, 'landuse',
     { 'id': 239782410, 'kind': 'park' })

--- a/integration-test/837-no-country-label-low-zoom.py
+++ b/integration-test/837-no-country-label-low-zoom.py
@@ -1,9 +1,9 @@
 # United States
 # http://www.openstreetmap.org/node/424317935
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     0, 0, 0, 'places', {'kind': 'country'})
 
 # United States
 # http://www.openstreetmap.org/node/424317935
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     1, 0, 0, 'places', {'kind': 'country'})

--- a/integration-test/840-normalize-place-kind.py
+++ b/integration-test/840-normalize-place-kind.py
@@ -1,98 +1,98 @@
 # Node: California (671022)
 # http://www.openstreetmap.org/node/671022
-assert_has_feature(
+test.assert_has_feature(
     16, 11149, 25576, 'places',
     { 'id': 671022, 'kind': 'region', 'kind_detail': 'state' })
 
 # Node: Saga Prefecture (1499608655)
 # http://www.openstreetmap.org/node/1499608655
-assert_has_feature(
+test.assert_has_feature(
     16, 56457, 26350, 'places',
     { 'id': 1499608655, 'kind': 'region', 'kind_detail': 'province' })
 
 # Node: San Francisco (26819236)
 # http://www.openstreetmap.org/node/26819236
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25330, 'places',
     { 'id': 26819236, 'kind': 'locality', 'kind_detail': 'city' })
 
 
 # Node: Daly City (140983265)
 # http://www.openstreetmap.org/node/140983265
-assert_has_feature(
+test.assert_has_feature(
     16, 10474, 25346, 'places',
     { 'id': 140983265, 'kind': 'locality', 'kind_detail': 'town' })
 
 # Node: Broadmoor (140983130)
 # http://www.openstreetmap.org/node/140983130
-assert_has_feature(
+test.assert_has_feature(
     16, 10470, 25350, 'places',
     { 'id': 140983130, 'kind': 'locality', 'kind_detail': 'village' })
 
 # Node: Baden (150937258)
 # http://www.openstreetmap.org/node/150937258
-assert_has_feature(
+test.assert_has_feature(
     16, 10479, 25359, 'places',
     { 'id': 150937258, 'kind': 'locality', 'kind_detail': 'hamlet' })
 
 # Node: McCovey Cove (317091394)
 # http://www.openstreetmap.org/node/317091394
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25330, 'places',
     { 'id': 317091394, 'kind': 'locality', 'kind_detail': 'locality' })
 
 # Node: Gilman Ranch (2682626694)
 # http://www.openstreetmap.org/node/2682626694
-assert_has_feature(
+test.assert_has_feature(
     16, 10592, 25477, 'places',
     { 'id': 2682626694, 'kind': 'locality', 'kind_detail': 'isolated_dwelling' })
 
 # Node: Stevens Canyon Ranch (3219761323)
 # http://www.openstreetmap.org/node/3219761323
-assert_has_feature(
+test.assert_has_feature(
     16, 10539, 25446, 'places',
     { 'id': 3219761323, 'kind': 'locality', 'kind_detail': 'farm' })
 
 
 # ne historic place
-assert_has_feature(
+test.assert_has_feature(
     16, 38247, 21826, 'places',
     { 'id': int, 'name': 'Chernobyl',
       'kind': 'locality', 'kind_detail': 'hamlet'})
 
 # ne scientific station
-assert_has_feature(
+test.assert_has_feature(
     16, 22209, 47255, 'places',
     { 'id': int, 'name': 'Elephant Island',
       'kind': 'locality', 'kind_detail': 'scientific_station'})
 
 # ne capitals
-assert_has_feature(
+test.assert_has_feature(
     7, 109, 49, 'places',
     { 'id': int, 'name': 'Seoul',
       'kind': 'locality', 'country_capital': True})
-assert_has_feature(
+test.assert_has_feature(
     7, 112, 50, 'places',
     { 'id': int, 'name': 'Kyoto',
       'kind': 'locality', 'country_capital': True})
-assert_has_feature(
+test.assert_has_feature(
     7, 104, 55, 'places',
     { 'id': int, 'name': 'Hong Kong',
       'kind': 'locality', 'country_capital': True})
 
 
 # ne state_capitals
-assert_has_feature(
+test.assert_has_feature(
     7, 117, 76, 'places',
     { 'id': int, 'name': 'Sydney',
       'kind': 'locality', 'region_capital': True})
-assert_has_feature(
+test.assert_has_feature(
     7, 112, 50, 'places',
     { 'id': int, 'name': 'Osaka',
       'kind': 'locality', 'region_capital': True})
 
 # ne populated place
-assert_has_feature(
+test.assert_has_feature(
     7, 20, 49, 'places',
     { 'id': int, 'name': 'San Francisco',
       'kind': 'locality', 'region_capital': type(None), 'country_capital': type(None)})

--- a/integration-test/841-normalize-boundaries-kind.py
+++ b/integration-test/841-normalize-boundaries-kind.py
@@ -3,100 +3,100 @@
 #
 # Note: this is tagged as a "protected_area" rather than a political boundary,
 # but it seems that some "protect_class" values indicate political "protection"
-assert_has_feature(
+test.assert_has_feature(
     16, 10237, 24570, 'boundaries',
     {'id': -6214773, 'kind': 'aboriginal_lands', 'kind_detail': type(None)})
 
 # use relation instead of way, as osm2pgsql treats the relation as superseding
 # the way and removes its tags when both are present.
 # http://www.openstreetmap.org/relation/3854097
-assert_has_feature(
+test.assert_has_feature(
     16, 10483, 22987, 'boundaries',
     {'id': -3854097, 'kind': 'aboriginal_lands', 'kind_detail': type(None)})
 
 # Way: Upper Sumas 6 (55602811)
 # http://www.openstreetmap.org/way/55602811
 # http://www.openstreetmap.org/relation/6791772
-assert_has_feature(
+test.assert_has_feature(
     16, 10523, 22492, 'boundaries',
     {'id': -6791772, 'kind': 'aboriginal_lands', 'kind_detail': type(None)})
 
 # Relation: United States of America
 # https://www.openstreetmap.org/relation/148838
-assert_has_feature(
+test.assert_has_feature(
     16, 10417, 25370, 'boundaries',
     {'id': -148838, 'kind': 'country', 'kind_detail': '2'})
 
 # Relation: Wyoming (161991) & Idaho (162116)
 # http://www.openstreetmap.org/relation/161991
 # http://www.openstreetmap.org/relation/162116
-assert_has_feature(
+test.assert_has_feature(
     16, 12553, 24147, 'boundaries',
     {'id': set([-161991,-162116]), 'kind': 'region', 'kind_detail': '4'})
 
 # http://www.openstreetmap.org/relation/396487 -- SF City/County
 # http://www.openstreetmap.org/relation/396498 -- San Mateo County
-assert_has_feature(
+test.assert_has_feature(
     16, 10484, 25346, 'boundaries',
     {'id': set([-396487,-396498]), 'kind': 'county', 'kind_detail': '6'})
 
 # Relation: Brisbane (2834528)
 # http://www.openstreetmap.org/relation/2834528
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25355, 'boundaries',
     {'id': -2834528, 'kind': 'locality', 'kind_detail': '8'})
 
 # ne data
 
 # Admin-1 boundary
-assert_has_feature(
+test.assert_has_feature(
     7, 75, 70, 'boundaries',
     {'id': int, 'kind': 'region', 'kind_detail': '4'})
 # Admin-1 statistical boundary
-assert_has_feature(
+test.assert_has_feature(
     7, 101, 56, 'boundaries',
     {'id': int, 'kind': 'region', 'kind_detail': '4'})
 # Admin-1 statistical meta bounds
-assert_has_feature(
+test.assert_has_feature(
     7, 26, 52, 'boundaries',
     {'id': int, 'kind': 'region', 'kind_detail': '4'})
 
 # Admin-1 region boundary
-assert_has_feature(
+test.assert_has_feature(
     7, 99, 57, 'boundaries',
     {'id': int, 'kind': 'macroregion', 'kind_detail': '3'})
 
 # Disputed (please verify)
-assert_has_feature(
+test.assert_has_feature(
     7, 39, 71, 'boundaries',
     {'id': int, 'kind': 'disputed', 'kind_detail': '2'})
 
 # Indefinite (please verify)
-assert_has_feature(
+test.assert_has_feature(
     7, 20, 44, 'boundaries',
     {'id': int, 'kind': 'indefinite', 'kind_detail': '2'})
 
 # Indeterminant frontier
-assert_has_feature(
+test.assert_has_feature(
     7, 91, 50, 'boundaries',
     {'id': int, 'kind': 'indeterminate', 'kind_detail': '2'})
 
 # International boundary (verify)
-assert_has_feature(
+test.assert_has_feature(
     7, 67, 37, 'boundaries',
     {'id': int, 'kind': 'country', 'kind_detail': '2'})
 
 # Lease limit
-assert_has_feature(
+test.assert_has_feature(
     7, 86, 45, 'boundaries',
     {'id': int, 'kind': 'lease_limit', 'kind_detail': '2'})
 
 # Line of control (please verify)
-assert_has_feature(
+test.assert_has_feature(
     7, 90, 50, 'boundaries',
     {'id': int, 'kind': 'line_of_control', 'kind_detail': '2'})
 
 # Overlay limit
-assert_has_feature(
+test.assert_has_feature(
     7, 109, 49, 'boundaries',
     {'id': int, 'kind': 'overlay_limit', 'kind_detail': '2'})

--- a/integration-test/842-normalize-building-kind.py
+++ b/integration-test/842-normalize-building-kind.py
@@ -1,40 +1,40 @@
 # https://www.openstreetmap.org/way/431358377
-assert_has_feature(
+test.assert_has_feature(
     16, 55897, 25449, 'buildings',
     { 'id': 431358377, 'kind': 'building', 'kind_detail': 'office' })
 
 # http://www.openstreetmap.org/way/264768910
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24633, 'buildings',
     { 'id': 264768910, 'kind': 'building', 'kind_detail': 'apartments' })
 
 # Way: Forest Hill (136822046)
 # http://www.openstreetmap.org/way/136822046
-assert_has_feature(
+test.assert_has_feature(
     16, 10474, 25337, 'buildings',
     { 'id': 136822046, 'kind': 'building', 'kind_detail': 'transportation' })
 
 # http://www.openstreetmap.org/way/93817368
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25327, 'buildings',
     { 'id': 93817368, 'kind': 'building', 'kind_detail': type(None)})
 
 # http://www.openstreetmap.org/way/132605515
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25331, 'buildings',
     { 'id': 132605515, 'kind': 'building_part', 'kind_detail': type(None) })
 
 # http://www.openstreetmap.org/way/406710839
-assert_has_feature(
+test.assert_has_feature(
     16, 10486, 25326, 'buildings',
     { 'id': 406710839, 'kind': 'building_part', 'kind_detail': type(None) })
 
 # http://www.openstreetmap.org/way/257920199
-assert_has_feature(
+test.assert_has_feature(
     16, 18743, 25070, 'buildings',
     { 'id': 257920199, 'kind': 'building_part', 'kind_detail': 'steps' })
 
 # http://www.openstreetmap.org/way/352508405
-assert_has_feature(
+test.assert_has_feature(
     16, 29704, 27412, 'buildings',
     { 'id': 352508405, 'kind': 'building_part', 'kind_detail': 'steps' })

--- a/integration-test/843-normalize-underscore.py
+++ b/integration-test/843-normalize-underscore.py
@@ -1,19 +1,19 @@
 # http://www.openstreetmap.org/way/219071307
-assert_has_feature(
+test.assert_has_feature(
     16, 10478, 25338, 'roads',
     { 'id': 219071307, 'kind': 'minor_road', 'service': 'drive_through' })
 
 # http://www.openstreetmap.org/way/258020271
-assert_has_feature(
+test.assert_has_feature(
     16, 11077, 25458, 'roads',
     { 'id': 258020271, 'kind': 'aerialway', 'kind_detail': 't_bar' })
 
 # http://www.openstreetmap.org/way/256717307
-assert_has_feature(
+test.assert_has_feature(
     16, 18763, 24784, 'roads',
     { 'id': 256717307, 'kind': 'aerialway', 'kind_detail': 'j_bar' })
 
 # http://www.openstreetmap.org/way/232074914
-assert_has_feature(
+test.assert_has_feature(
     16, 13304, 24998, 'roads',
     { 'id': 232074914, 'kind': 'aerialway', 'kind_detail': type(None) })

--- a/integration-test/844-normalize-poi-kind.py
+++ b/integration-test/844-normalize-poi-kind.py
@@ -1,54 +1,54 @@
 # Node: Gate G102 (1096088604)
 # http://www.openstreetmap.org/node/1096088604
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25366, 'pois',
     { 'id': 1096088604, 'kind': 'aeroway_gate' })
 
 # Node: Gate 1 (2618197593)
 # http://www.openstreetmap.org/node/2618197593
 # http://www.openstreetmap.org/way/320595943
-assert_has_feature(
+test.assert_has_feature(
     16, 10309, 22665, 'pois',
     { 'id': 2618197593, 'kind': 'gate', 'aeroway': type(None) })
 
 # Node: Lone Star Sports
 # http://www.openstreetmap.org/node/2122898936
-assert_has_feature(
+test.assert_has_feature(
     16, 13462, 24933, 'pois',
     { 'id': 2122898936, 'kind': 'ski_rental' })
 
 # http://www.openstreetmap.org/way/52497271
-assert_has_feature(
+test.assert_has_feature(
     16, 10566, 25429, 'landuse',
     { 'id': 52497271, 'kind': 'wood' })
 
 # http://www.openstreetmap.org/way/207859675
-assert_has_feature(
+test.assert_has_feature(
     16, 11306, 26199, 'landuse',
     { 'id': 207859675, 'kind': 'wood' })
 
 # http://www.openstreetmap.org/way/417405367
-assert_has_feature(
+test.assert_has_feature(
     16, 10480, 25323, 'landuse',
     { 'id': 417405367, 'kind': 'natural_wood' })
 
 # http://www.openstreetmap.org/way/422270533
-assert_has_feature(
+test.assert_has_feature(
     16, 10476, 25324, 'landuse',
     { 'id': 422270533, 'kind': 'forest' })
 
 # http://www.openstreetmap.org/way/95360670
-assert_has_feature(
+test.assert_has_feature(
     16, 17780, 27428, 'landuse',
     { 'id': 95360670, 'kind': 'natural_forest' })
 
 # Way: Stables & Equestrian Area (393312618)
 # http://www.openstreetmap.org/way/393312618
-assert_has_feature(
+test.assert_has_feature(
     16, 10294, 25113, 'landuse',
     { 'id': 393312618, 'kind': 'park' })
 
 # http://www.openstreetmap.org/way/469494860
-assert_has_feature(
+test.assert_has_feature(
     16, 17612, 24209, 'landuse',
     { 'id': 469494860, 'kind': 'natural_park' })

--- a/integration-test/845-buildings-z13.py
+++ b/integration-test/845-buildings-z13.py
@@ -2,6 +2,6 @@
 
 # http://www.openstreetmap.org/way/23654700
 # http://www.openstreetmap.org/way/60500069
-assert_has_feature(
+test.assert_has_feature(
     13, 1310, 3170, 'buildings',
     {'kind': 'building'})

--- a/integration-test/852-remove-landuse_labels.py
+++ b/integration-test/852-remove-landuse_labels.py
@@ -1,2 +1,2 @@
 with layers_in_tile(16, 10486, 25325) as layers:
-    assert 'landuse_labels' not in layers
+    assertTrue('landuse_labels' not in layers)

--- a/integration-test/852-remove-landuse_labels.py
+++ b/integration-test/852-remove-landuse_labels.py
@@ -1,2 +1,2 @@
-with layers_in_tile(16, 10486, 25325) as layers:
-    assertTrue('landuse_labels' not in layers)
+with test.layers_in_tile(16, 10486, 25325) as layers:
+    test.assertTrue('landuse_labels' not in layers)

--- a/integration-test/857-move_barriers_to_landuse.py
+++ b/integration-test/857-move_barriers_to_landuse.py
@@ -2,66 +2,66 @@
 
 # city_wall in landuse
 # http://www.openstreetmap.org/way/81522922
-assert_has_feature(
+test.assert_has_feature(
     12, 2030, 1300, 'landuse',
     { 'kind': 'city_wall'})
 
 # city_wall not in boundaries
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 2030, 1300, 'boundaries',
     { 'kind': 'city_wall'})
 
 # citywalls in landuse
 # http://www.openstreetmap.org/way/392978585
-assert_has_feature(
+test.assert_has_feature(
     12, 2326, 1617, 'landuse',
     { 'kind': 'city_wall'})
 
 # citywalls not in boundaries
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 2326, 1617, 'boundaries',
     { 'kind': 'city_wall'})
 
 # dam in landuse
 # http://www.openstreetmap.org/way/109629543
-assert_has_feature(
+test.assert_has_feature(
     12, 740, 1606, 'landuse',
     { 'kind': 'dam'})
 
 # dam not in boundaries
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 740, 1606, 'boundaries',
     { 'kind': 'dam'})
 
 # fence in landuse
 #http://www.openstreetmap.org/way/345599214
-assert_has_feature(
+test.assert_has_feature(
     16, 19296, 24635, 'landuse',
     { 'kind': 'fence'})
 
 # fence not in boundaries
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 19296, 24635, 'boundaries',
     { 'kind': 'fence'})
 
 # retaining_wall in landuse
 #http://www.openstreetmap.org/way/288896098
-assert_has_feature(
+test.assert_has_feature(
     15, 9648, 12315, 'landuse',
     { 'kind': 'retaining_wall'})
 
 # retaining_wall not in boundaries
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 9648, 12315, 'boundaries',
     { 'kind': 'retaining_wall'})
 
 # snow_fence in landuse
 #http://www.openstreetmap.org/way/356771680
-assert_has_feature(
+test.assert_has_feature(
     15, 6788, 12264, 'landuse',
     { 'kind': 'snow_fence'})
 
 # snow_fence not in boundaries
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     15, 6788, 12264, 'boundaries',
     { 'kind': 'snow_fence'})

--- a/integration-test/859-add-bridleway.py
+++ b/integration-test/859-add-bridleway.py
@@ -1,6 +1,6 @@
 # Add bridleway from osm
 
 # http://www.openstreetmap.org/way/387216146
-assert_has_feature(
+test.assert_has_feature(
     16, 19302, 24623, 'roads',
     { 'id': 387216146, 'kind': 'path', 'kind_detail': 'bridleway'})

--- a/integration-test/860-lighthouse.py
+++ b/integration-test/860-lighthouse.py
@@ -2,16 +2,16 @@
 
 # lighthouse with tourism = attraction
 # https://www.openstreetmap.org/way/423023928
-assert_has_feature(
+test.assert_has_feature(
     14, 2615, 6330, 'pois',
     {'id': 423023928, 'kind': 'lighthouse'})
 
 # lighthouse without tourism = attraction
 # http://www.openstreetmap.org/node/1243877573
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2617, 6329, 'pois',
     {'id': 1243877573, 'kind': 'lighthouse'})
 
-assert_has_feature(
+test.assert_has_feature(
     15, 5235, 12659, 'pois',
     {'id': 1243877573, 'kind': 'lighthouse'})

--- a/integration-test/875-camp-grounds-zoom.py
+++ b/integration-test/875-camp-grounds-zoom.py
@@ -2,48 +2,48 @@
 
 # large campground in landuse zoom 16
 # http://www.openstreetmap.org/way/237314510
-assert_has_feature(
+test.assert_has_feature(
     16, 10599, 25679, 'landuse',
     { 'kind': 'camp_site', 'sort_rank': 92})
 
 # large campground in point zoom 16
 # http://www.openstreetmap.org/way/237314510
-assert_has_feature(
+test.assert_has_feature(
     16, 10599, 25679, 'pois',
     { 'kind': 'camp_site'})
 
 # large campground in landuse zoom 13
 # http://www.openstreetmap.org/way/237314510
-assert_has_feature(
+test.assert_has_feature(
     13, 1324, 3209, 'landuse',
     { 'kind': 'camp_site', 'sort_rank': 92})
 
 # large campground in point zoom 13
 # http://www.openstreetmap.org/way/237314510
-assert_has_feature(
+test.assert_has_feature(
     13, 1324, 3209, 'pois',
     { 'kind': 'camp_site'})
 
 # small campground in landuse zoom 16
 # http://www.openstreetmap.org/way/417405356
-assert_has_feature(
+test.assert_has_feature(
     16, 10471, 25326, 'landuse',
     { 'kind': 'camp_site', 'sort_rank': 92})
 
 # small campground in point zoom 16
 # http://www.openstreetmap.org/way/417405356
-assert_has_feature(
+test.assert_has_feature(
     16, 10471, 25326, 'pois',
     { 'kind': 'camp_site'})
 
 # small campground in landuse zoom 13
 # http://www.openstreetmap.org/way/417405356
-assert_has_feature(
+test.assert_has_feature(
     13, 1308, 3165, 'landuse',
     { 'kind': 'camp_site', 'sort_rank': 92})
 
 # small campground in point zoom 13
 # http://www.openstreetmap.org/way/417405356
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     13, 1308, 3165, 'pois',
     { 'kind': 'camp_site'})

--- a/integration-test/890-normalize-ne-roads.py
+++ b/integration-test/890-normalize-ne-roads.py
@@ -1,41 +1,41 @@
 # ferry
-assert_has_feature(
+test.assert_has_feature(
     7, 37, 48, 'roads',
     {'id': int, 'kind': 'ferry', 'type': type(None)})
 
 # expressway
-assert_has_feature(
+test.assert_has_feature(
     7, 37, 48, 'roads',
     {'id': int, 'kind': 'highway', 'kind_detail': 'motorway', 'type': type(None)})
 
 # major highway
-assert_has_feature(
+test.assert_has_feature(
     7, 108, 61, 'roads',
     {'id': int, 'kind': 'highway', 'kind_detail': 'trunk'})
 # beltway
-assert_has_feature(
+test.assert_has_feature(
     7, 30, 48, 'roads',
     {'id': int, 'kind': 'highway', 'kind_detail': 'trunk'})
 # bypass
-assert_has_feature(
+test.assert_has_feature(
     7, 34, 50, 'roads',
     {'id': int, 'kind': 'highway', 'kind_detail': 'trunk'})
 
 # secondary highway
-assert_has_feature(
+test.assert_has_feature(
     7, 28, 47, 'roads',
     {'id': int, 'kind': 'major_road', 'kind_detail': 'primary'})
 
 # road
-assert_has_feature(
+test.assert_has_feature(
     7, 71, 49, 'roads',
     {'id': int, 'kind': 'major_road', 'kind_detail': 'secondary'})
 
 # track
-assert_has_feature(
+test.assert_has_feature(
     7, 113, 70, 'roads',
     {'id': int, 'kind': 'minor_road', 'kind_detail': 'tertiary'})
 # unknown
-assert_has_feature(
+test.assert_has_feature(
     7, 107, 52, 'roads',
     {'id': int, 'kind': 'minor_road', 'kind_detail': 'tertiary'})

--- a/integration-test/895-extract-airport-lines-minor_road.py
+++ b/integration-test/895-extract-airport-lines-minor_road.py
@@ -1,11 +1,11 @@
 # Way: 10L/28R (22567191)
 # http://www.openstreetmap.org/way/22567191
-assert_has_feature(
+test.assert_has_feature(
     16, 10490, 25366, 'roads',
     {'id': 22567191, 'kind': 'aeroway', 'kind_detail': 'runway'})
 
 # Way: Q (23718500)
 # http://www.openstreetmap.org/way/23718500
-assert_has_feature(
+test.assert_has_feature(
     16, 10488, 25365, 'roads',
     {'id': 23718500, 'kind': 'aeroway', 'kind_detail': 'taxiway'})

--- a/integration-test/896-ne-shield-enums-2.py
+++ b/integration-test/896-ne-shield-enums-2.py
@@ -7,15 +7,15 @@
 #  * namealtt
 #
 # E30 (M4) in UK
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     7, 63, 42, 'roads',
     { 'source': 'naturalearthdata.com', 'kind': 'highway',
       'level': None })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     7, 63, 42, 'roads',
     { 'source': 'naturalearthdata.com', 'kind': 'highway',
       'namealt': None })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     7, 63, 42, 'roads',
     { 'source': 'naturalearthdata.com', 'kind': 'highway',
       'namealtt': None })
@@ -26,10 +26,10 @@ for z in range(5, 6):
     # tile 7/63/42 was tested in 896-ne-shield-enums.py
     x = 63 >> (7 - z)
     y = 42 >> (7 - z)
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'roads',
         { 'source': 'naturalearthdata.com', 'network': 'e-road',
           'kind': 'highway', 'shield_text': '30' })
     # but not name, ref or all_*
     for prop in ['name', 'ref', 'all_networks', 'all_shield_texts']:
-        assert_no_matching_feature(z, x, y, 'roads', { prop: None })
+        test.assert_no_matching_feature(z, x, y, 'roads', { prop: None })

--- a/integration-test/896-ne-shield-enums.py
+++ b/integration-test/896-ne-shield-enums.py
@@ -1,47 +1,47 @@
 # Trans-Canada Highway
-assert_has_feature(
+test.assert_has_feature(
     7, 20, 43, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'CA:??:primary',
       'kind': 'highway', 'shield_text': '1' })
 
 # I-20
-assert_has_feature(
+test.assert_has_feature(
     7, 35, 51, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'US:I',
       'kind': 'highway', 'shield_text': '20' })
 
 # US-76
-assert_has_feature(
+test.assert_has_feature(
     7, 35, 51, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'US:US',
       'kind': 'major_road', 'shield_text': '76' })
 
 # MEX 49 (interstate)
-assert_has_feature(
+test.assert_has_feature(
     7, 27, 55, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'MX',
       'kind': 'highway', 'shield_text': '49' })
 
 # MEX 54 (federal)
-assert_has_feature(
+test.assert_has_feature(
     7, 27, 55, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'MX:MX',
       'kind': 'major_road', 'shield_text': '54' })
 
 # E80 in Turkey
-assert_has_feature(
+test.assert_has_feature(
     7, 74, 47, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'e-road',
       'kind': 'highway', 'shield_text': '80' })
 
 # E30 (M4) in UK
-assert_has_feature(
+test.assert_has_feature(
     7, 63, 42, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'e-road',
       'kind': 'highway', 'shield_text': '30' })
 
 # SH16 in NZ
-assert_has_feature(
+test.assert_has_feature(
     7, 126, 78, 'roads',
     { 'source': 'naturalearthdata.com', 'network': 'NZ:SH',
       'kind': 'highway', 'shield_text': '16' })

--- a/integration-test/912-missing-building-part.py
+++ b/integration-test/912-missing-building-part.py
@@ -1,5 +1,5 @@
 # http://www.openstreetmap.org/way/287494678
-assert_has_feature(
+test.assert_has_feature(
     16, 19298, 24632, 'buildings',
     { 'kind': 'building_part',
       'id': 287494678,

--- a/integration-test/919-gates-line-geometry.py
+++ b/integration-test/919-gates-line-geometry.py
@@ -2,6 +2,6 @@
 
 # Line barrier:ghate feature
 # http://www.openstreetmap.org/way/391260223
-assert_has_feature(
+test.assert_has_feature(
     16, 10482, 25335, 'landuse',
     { 'id': 391260223, 'kind': 'gate'})

--- a/integration-test/922-source-in-POI.py
+++ b/integration-test/922-source-in-POI.py
@@ -1,6 +1,6 @@
 # Add source info in POIs
 
 # https://www.openstreetmap.org/way/423023928
-assert_has_feature(
+test.assert_has_feature(
     14, 2615, 6330, 'pois',
     {'id': 423023928, 'kind': 'lighthouse', 'source':'openstreetmap.org'})

--- a/integration-test/927-normalize-operator-values.py
+++ b/integration-test/927-normalize-operator-values.py
@@ -2,60 +2,60 @@
 
 # US National Park Service in POIS
 # http://www.openstreetmap.org/node/4285104560
-assert_has_feature(
+test.assert_has_feature(
     16, 15808, 25720, 'pois',
     {'id': 4285104560, 'operator': 'United States National Park Service'})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 15808, 25720, 'pois',
     {'id': 4285104560, 'operator': 'US National Park Service'})
 
 # National Park Service in landuse
 # http://www.openstreetmap.org/way/368766687
-assert_has_feature(
+test.assert_has_feature(
     16, 13163, 25153, 'landuse',
     {'id': 368766687, 'operator': 'United States National Park Service'})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 13163, 25153, 'landuse',
     {'id': 368766687, 'operator': 'National Park Service'})
 
 # US National Forest Service in POIS
 # http://www.openstreetmap.org/node/796692690
-assert_has_feature(
+test.assert_has_feature(
     16, 10542, 23271, 'pois',
     {'id': 796692690, 'operator': 'United States Forest Service'})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 10542, 23271, 'pois',
     {'id': 796692690, 'operator': 'US National Forest Service'})
 
 # US Forest Service in landuse
 # http://www.openstreetmap.org/way/432302983
-assert_has_feature(
+test.assert_has_feature(
     16, 11252, 25432, 'landuse',
     {'id': 432302983, 'operator': 'United States Forest Service'})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 11252, 25432, 'landuse',
     {'id': 432302983, 'operator': 'US Forest Service'})
 
 # NSW Parks and Wildlife Service in POIs
 # http://www.openstreetmap.org/node/2514034066
-assert_has_feature(
+test.assert_has_feature(
     16, 59800, 39773, 'pois',
     {'id': 2514034066, 'operator': 'National Parks & Wildife Service NSW'})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 59800, 39773, 'pois',
     {'id': 2514034066, 'operator': 'NSW Parks and Wildlife Service'})
 
 # Department of National Parks NSW in landuse
 # http://www.openstreetmap.org/way/429280600
-assert_has_feature(
+test.assert_has_feature(
     16, 60128, 39504, 'landuse',
     {'id': 429280600, 'operator': 'National Parks & Wildife Service NSW'})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     16, 60128, 39504, 'landuse',
     {'id': 429280600, 'operator': 'Department of National Parks NSW'})

--- a/integration-test/931-locality-changes-places.py
+++ b/integration-test/931-locality-changes-places.py
@@ -1,45 +1,45 @@
 # ne Admin-0 capital
-assert_has_feature(
+test.assert_has_feature(
     3, 6, 3, 'places',
     { 'kind': 'locality', 'name': 'Seoul', 'country_capital': True})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     3, 6, 3, 'places',
     { 'kind': 'city', 'name': 'Seoul', 'country_capital': True})
 
 # ne Admin-1 capital
-assert_has_feature(
+test.assert_has_feature(
     3, 7, 4, 'places',
     { 'kind': 'locality', 'name': 'Sydney', 'region_capital': True})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     3, 7, 4, 'places',
     { 'kind': 'city', 'name': 'Sydney', 'state_capital': True})
 
 # ne Populated place
-assert_has_feature(
+test.assert_has_feature(
     3, 1, 3, 'places',
     { 'kind': 'locality', 'name': 'San Francisco'})
 
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     3, 1, 3, 'places',
     { 'kind': 'city', 'name': 'San Francisco'})
 
 # ne Scientific station
-assert_has_feature(
+test.assert_has_feature(
     9, 164, 377, 'places',
     { 'kind': 'locality', 'name': 'Palmer Station', 'kind_detail': 'scientific_station'})
 
 # http://www.openstreetmap.org/node/158368533
 # Washington (158368533)
 # no region_capital false
-assert_has_feature(
+test.assert_has_feature(
     8, 73, 97, 'places',
     { 'id': 158368533, 'region_capital': type(None) })
 
 # http://www.openstreetmap.org/node/3441540432
 # Node: Deerfield, Nova Scotia (3441540432)
 # no country_capital when falsey
-assert_has_feature(
+test.assert_has_feature(
     16, 20752, 23846, 'places',
     { 'id': 3441540432, 'country_capital': type(None) })

--- a/integration-test/935-source-in-transit.py
+++ b/integration-test/935-source-in-transit.py
@@ -2,6 +2,6 @@
 
 #Way: 189011731
 # http://www.openstreetmap.org/way/189011731
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25332, 'transit',
     {'id': 189011731, 'kind': 'platform', 'source':'openstreetmap.org'})

--- a/integration-test/951-remove-sea.py
+++ b/integration-test/951-remove-sea.py
@@ -1,14 +1,14 @@
 # Drop sea polygon but keep the label
 
 # http://www.openstreetmap.org/relation/4594226
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 2315, 1580, 'water',
     {'id': -4594226, 'kind': 'sea', 'label_placement': None})
 
-assert_has_feature(
+test.assert_has_feature(
     9, 292, 197, 'water',
     {'id': -4594226, 'kind': 'sea', 'label_placement': True})
 
-assert_has_feature(
+test.assert_has_feature(
     12, 2338, 1579, 'water',
     {'id': -4594226, 'kind': 'sea', 'label_placement': True})

--- a/integration-test/970-kind-detail-for-all-roads.py
+++ b/integration-test/970-kind-detail-for-all-roads.py
@@ -1,15 +1,15 @@
 # kind: ferry
 # http://www.openstreetmap.org/way/98752535 - Alameda <-> SF Ferry bldg
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25326, 'roads',
     { 'kind': 'ferry', 'id': 98752535 })
 
 # http://www.openstreetmap.org/way/98752545 - SF Pier 41 <-> SF Ferry bldg
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25326, 'roads',
     { 'kind': 'ferry', 'id': 98752545 })
 
 # http://www.openstreetmap.org/way/289694213 - South SF <-> SF Ferry bldg
-assert_has_feature(
+test.assert_has_feature(
     16, 10487, 25326, 'roads',
     { 'kind': 'ferry', 'id': 289694213 })

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -1,24 +1,24 @@
 # https://www.openstreetmap.org/way/332223480
 # Apple Store, SF
-assert_has_feature(
+test.assert_has_feature(
     15, 5242, 12663, 'pois',
     { 'id': 332223480, 'min_zoom': 15.31 })
 
 # Test that source and min_zoom are set properly for boundaries, roads, transit, and water
-assert_has_feature(
+test.assert_has_feature(
     5, 9, 12, 'boundaries',
     { 'min_zoom': 2 , 'id': int,
     'source': 'naturalearthdata.com',
     'kind': 'region' })
 
-assert_has_feature(
+test.assert_has_feature(
     7, 37, 48, 'roads',
     { 'min_zoom': 3 , 'id': int, 'shield_text': '95',
     'source': 'naturalearthdata.com' })
 
 # There is no transit data from Natural Earth
 
-assert_has_feature(
+test.assert_has_feature(
     7, 36, 50, 'water',
     { 'min_zoom': 0 , 'id': int,
     'source': 'naturalearthdata.com',
@@ -26,14 +26,14 @@ assert_has_feature(
 
 # https://www.openstreetmap.org/relation/224951
 # https://www.openstreetmap.org/relation/61320
-assert_has_feature(
+test.assert_has_feature(
     9, 150, 192, 'boundaries',
     { 'min_zoom': 8, 'id':  -224951,
     'source': 'openstreetmap.org',
     'name': 'New Jersey - New York' })
 
 # http://www.openstreetmap.org/relation/568499
-assert_has_feature(
+test.assert_has_feature(
     9, 150, 192, 'roads',
     { 'min_zoom': 8, 'sort_rank':  381,
     'source': 'openstreetmap.org',
@@ -41,13 +41,13 @@ assert_has_feature(
     'network': 'US:NJ:Hudson' })
 
 # http://www.openstreetmap.org/relation/1359387
-assert_has_feature(
+test.assert_has_feature(
     9, 150, 192, 'transit',
     { 'min_zoom': 5, 'ref':  '54-57',
     'source': 'openstreetmap.org',
     'name': 'Vermonter' })
 
-assert_has_feature(
+test.assert_has_feature(
     9, 150, 192, 'water',
     { 'min_zoom': 0, 'id': int,
     'source': 'openstreetmapdata.com',

--- a/integration-test/981-remove-unstyled-ne-places.py
+++ b/integration-test/981-remove-unstyled-ne-places.py
@@ -1,20 +1,20 @@
 def assert_add_place(z, x, y, name):
-    assert_has_feature(
+    test.assert_has_feature(
         z, x, y, 'places',
         { 'kind': 'locality', 'name': name,
           'source': 'naturalearthdata.com',
           'min_zoom': z })
-    assert_no_matching_feature(
+    test.assert_no_matching_feature(
         z-1, x/2, y/2, 'places',
         { 'kind': 'locality', 'name': name,
           'source': 'naturalearthdata.com' })
 
 def assert_remove_place(z, x, y, name):
-    assert_no_matching_feature(
+    test.assert_no_matching_feature(
         z, x, y, 'places',
         { 'kind': 'locality', 'name': name,
           'source': 'naturalearthdata.com' })
-    assert_has_feature(
+    test.assert_has_feature(
         z-1, x/2, y/2, 'places',
         { 'kind': 'locality', 'name': name,
           'source': 'naturalearthdata.com' })
@@ -51,7 +51,7 @@ assert_remove_place(10, 159, 384, 'Arcata')
 assert_remove_place(10, 161, 390, 'Ukiah')
 
 # z11 Mendocino should still be here
-assert_has_feature(
+test.assert_has_feature(
     9, 79, 195, 'places',
     { 'kind': 'locality', 'name': 'Mendocino',
       'source': 'naturalearthdata.com' })

--- a/integration-test/982-remove-unstyled-localities.py
+++ b/integration-test/982-remove-unstyled-localities.py
@@ -2,7 +2,7 @@
 # include only those localities with name and population and kind_detail IN
 # (city, town).
 # example: Arcata https://www.openstreetmap.org/node/141029389 with population.
-assert_has_feature(
+test.assert_has_feature(
     8, 39, 96, 'places',
     { 'kind': 'locality', 'kind_detail': 'town', 'name': 'Arcata',
       'id': 141029389, 'min_zoom': 8 })
@@ -13,10 +13,10 @@ assert_has_feature(
 # drawn but with smaller type size) .
 # example: Hoopa http://www.openstreetmap.org/node/4270230299 has no population,
 # is included starting at zoom 9.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     8, 40, 95, 'places',
     { 'kind': 'locality', 'id': 4270230299 })
-assert_has_feature(
+test.assert_has_feature(
     9, 80, 191, 'places',
     { 'kind': 'locality', 'kind_detail': 'town', 'name': 'Hoopa',
       'id': 4270230299, 'min_zoom': 9 })
@@ -29,10 +29,10 @@ assert_has_feature(
 # (village).
 # example: Fairfax http://www.openstreetmap.org/node/150949805 is village with
 # population
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     10, 163, 395, 'places',
     { 'kind': 'locality', 'id': 150949805 })
-assert_has_feature(
+test.assert_has_feature(
     11, 326, 790, 'places',
     { 'kind': 'locality', 'kind_detail': 'village', 'name': 'Fairfax',
       'id': 150949805, 'min_zoom': 11 })
@@ -47,17 +47,17 @@ assert_has_feature(
 # (hamlet).
 # example: http://www.openstreetmap.org/node/150966610 - Duncans Mills, is
 # a hamlet with population.
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     11, 323, 786, 'places',
     { 'kind': 'locality', 'id': 150966610 })
-assert_has_feature(
+test.assert_has_feature(
     12, 647, 1573, 'places',
     { 'kind': 'locality', 'kind_detail': 'hamlet', 'name': 'Duncans Mills',
       'id': 150966610, 'min_zoom': 12 })
 
 # example: http://www.openstreetmap.org/node/150973394 - Inverness
 # hamlet with NO population should NOT show up
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     12, 650, 1578, 'places',
     { 'kind': 'locality', 'id': 150973394 })
 
@@ -66,7 +66,7 @@ assert_no_matching_feature(
 # This drops the population requirement (cities, towns, and all the other
 # kind_details without population are drawn but with smaller type size) .
 # example: Inverness 150973394 hamlet with no population should now show up
-assert_has_feature(
+test.assert_has_feature(
     13, 1300, 3156, 'places',
     { 'kind': 'locality', 'kind_detail': 'hamlet', 'name': 'Inverness',
       'id': 150973394, 'min_zoom': 13 })

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -2,7 +2,7 @@
 # kind:forest.
 #
 # http://www.openstreetmap.org/relation/972008
-assert_has_feature(
+test.assert_has_feature(
     11, 340, 788, 'landuse',
     { 'kind': 'forest', 'id': -972008 })
 
@@ -10,7 +10,7 @@ assert_has_feature(
 # guaranteed, should be kind:forest.
 #
 # http://www.openstreetmap.org/relation/2389847
-assert_has_feature(
+test.assert_has_feature(
     11, 369, 769, 'landuse',
     { 'kind': 'forest', 'id': -2389847 })
 
@@ -18,7 +18,7 @@ assert_has_feature(
 # (should be kind:forest).
 #
 # http://www.openstreetmap.org/relation/6213964
-assert_has_feature(
+test.assert_has_feature(
     14, 2559, 6099, 'landuse',
     { 'kind': 'forest', 'id': -6213964 })
 
@@ -27,7 +27,7 @@ assert_has_feature(
 # should be kind:national_park).
 #
 # http://www.openstreetmap.org/relation/175098
-assert_has_feature(
+test.assert_has_feature(
     12, 733, 1617, 'landuse',
     { 'kind': 'national_park', 'id': -175098 })
 
@@ -37,7 +37,7 @@ assert_has_feature(
 # kind:nature_reserve?
 #
 # http://www.openstreetmap.org/relation/1250137
-assert_has_feature(
+test.assert_has_feature(
     15, 5192, 12627, 'landuse',
     { 'kind': 'national_park', 'id': -1250137 })
 
@@ -47,7 +47,7 @@ assert_has_feature(
 # kind:park!
 #
 # http://www.openstreetmap.org/relation/3004556
-assert_has_feature(
+test.assert_has_feature(
     15, 5359, 12747, 'landuse',
     { 'kind': 'park', 'id': -3004556 })
 
@@ -61,7 +61,7 @@ assert_has_feature(
 # "Arapaho National Forest", so it should probably be classed as a forest.
 #
 # http://www.openstreetmap.org/relation/396026
-assert_has_feature(
+test.assert_has_feature(
     13, 1683, 3103, 'landuse',
     { 'kind': 'forest', 'id': -396026 })
 
@@ -71,7 +71,7 @@ assert_has_feature(
 # be kind:nature_reserve.
 #
 # https://www.openstreetmap.org/way/436801947
-assert_has_feature(
+test.assert_has_feature(
     11, 323, 791, 'landuse',
     { 'kind': 'nature_reserve', 'id': 436801947 })
 
@@ -81,7 +81,7 @@ assert_has_feature(
 # kind:nature_reserve.
 #
 # https://www.openstreetmap.org/way/297463477
-assert_has_feature(
+test.assert_has_feature(
     13, 1305, 3161, 'landuse',
     { 'kind': 'nature_reserve', 'id': 297463477 })
 
@@ -90,7 +90,7 @@ assert_has_feature(
 # and operator=Marin County Parks should just be kind:common.
 #
 # https://www.openstreetmap.org/way/297452972
-assert_has_feature(
+test.assert_has_feature(
     15, 5229, 12648, 'landuse',
     { 'kind': 'common', 'id': 297452972 })
 
@@ -100,7 +100,7 @@ assert_has_feature(
 # to kind:nature_reserve.
 #
 # http://www.openstreetmap.org/relation/5273153
-assert_has_feature(
+test.assert_has_feature(
     12, 784, 1585, 'landuse',
     { 'kind': 'nature_reserve', 'id': -5273153 })
 
@@ -108,7 +108,7 @@ assert_has_feature(
 # kind:nature_reserve.
 #
 # https://www.openstreetmap.org/way/373769670
-assert_has_feature(
+test.assert_has_feature(
     13, 4003, 3151, 'landuse',
     { 'kind': 'nature_reserve', 'id': 373769670 })
 
@@ -116,7 +116,7 @@ assert_has_feature(
 # should end up with kind: protected_area
 #
 # https://www.openstreetmap.org/relation/3875431
-assert_has_feature(
+test.assert_has_feature(
     13, 4336, 2787, 'landuse',
     { 'kind': 'protected_area', 'id': -3875431 })
 
@@ -125,7 +125,7 @@ assert_has_feature(
 # protect_class=3 should end up with kind:national_park
 #
 # https://www.openstreetmap.org/relation/6229828
-assert_has_feature(
+test.assert_has_feature(
     16, 10452, 25302, 'landuse',
     { 'kind': 'national_park', 'id': -6229828 })
 
@@ -133,7 +133,7 @@ assert_has_feature(
 # protect_class=5 should end up with kind:park.
 #
 # https://www.openstreetmap.org/relation/318202
-assert_has_feature(
+test.assert_has_feature(
     13, 1332, 3184, 'landuse',
     { 'kind': 'park', 'id': -318202 })
 
@@ -142,7 +142,7 @@ assert_has_feature(
 # leisure=nature_reserve should end up with kind:national_park.
 #
 # https://www.openstreetmap.org/relation/1643367
-assert_has_feature(
+test.assert_has_feature(
     13, 1371, 3164, 'landuse',
     { 'kind': 'national_park', 'id': -1643367 })
 
@@ -151,7 +151,7 @@ assert_has_feature(
 # end up with kind:national_park.
 #
 # https://www.openstreetmap.org/relation/215231
-assert_has_feature(
+test.assert_has_feature(
     13, 1274, 3066, 'landuse',
     { 'kind': 'national_park', 'id': -215231 })
 
@@ -160,14 +160,14 @@ assert_has_feature(
 # leisure=nature_reserve should end up with kind:national_park.
 #
 # https://www.openstreetmap.org/relation/1453306
-assert_has_feature(
+test.assert_has_feature(
     13, 1591, 2972, 'landuse',
     { 'kind': 'national_park', 'id': -1453306 })
 
 # boundary=national_park in Adirondack Park should end up with kind:park.
 #
 # https://www.openstreetmap.org/relation/1695394
-assert_has_feature(
+test.assert_has_feature(
     13, 2410, 3001, 'landuse',
     { 'kind': 'park', 'id': -1695394 })
 
@@ -176,7 +176,7 @@ assert_has_feature(
 # end up with kind:national_park.
 #
 # https://www.openstreetmap.org/relation/5548542
-assert_has_feature(
+test.assert_has_feature(
     13, 2313, 3142, 'landuse',
     { 'kind': 'national_park', 'id': -5548542 })
 
@@ -184,7 +184,7 @@ assert_has_feature(
 # boundary=national_park should end up with kind:national_park.
 #
 # https://www.openstreetmap.org/relation/1947603
-assert_has_feature(
+test.assert_has_feature(
     13, 4014, 2512, 'landuse',
     { 'kind': 'national_park', 'id': -1947603 })
 
@@ -192,7 +192,7 @@ assert_has_feature(
 # designation=area_of_outstanding_natural_beauty should end up with kind:park.
 #
 # https://www.openstreetmap.org/relation/2904192
-assert_has_feature(
+test.assert_has_feature(
     13, 4054, 2728, 'landuse',
     { 'kind': 'park', 'id': -2904192 })
 
@@ -200,6 +200,6 @@ assert_has_feature(
 # National Park with leisure=nature_reserve.
 #
 # http://www.openstreetmap.org/way/185735773
-assert_has_feature(
+test.assert_has_feature(
     13, 1812, 2748, 'landuse',
     { 'kind': 'national_park', 'id': 185735773 })

--- a/integration-test/990-add-art-galleries.py
+++ b/integration-test/990-add-art-galleries.py
@@ -1,9 +1,9 @@
 # http://www.openstreetmap.org/node/2026996113
-assert_has_feature(
+test.assert_has_feature(
     16, 10485, 25328, 'pois',
     { 'id': 2026996113, 'kind': 'gallery', 'min_zoom': 17 })
 
 # https://www.openstreetmap.org/way/83488820
-assert_has_feature(
+test.assert_has_feature(
     15, 16370, 10894, 'pois',
     { 'id': 83488820, 'kind': 'gallery' })

--- a/integration-test/992-boundaries-min_zoom-and-name.py
+++ b/integration-test/992-boundaries-min_zoom-and-name.py
@@ -26,7 +26,7 @@
 # map_unit min_zoom
 
 # England-Wales boundary in United Kingdom (scalerank=4, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     5, 15, 10, 'boundaries',
     { 'kind': 'map_unit', 'min_zoom': 5, 'sort_rank': 258})
 
@@ -34,42 +34,42 @@ assert_has_feature(
 # region min_zoom (via scalerank)
 
 # USA region (scalerank=2, 1:50m NE and 1:10m NE)
-assert_has_feature(
+test.assert_has_feature(
     2, 0, 1, 'boundaries',
     { 'kind': 'region', 'min_zoom': 2})
 
 # Germany region (scalerank=3, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     5, 17, 10, 'boundaries',
     { 'kind': 'region', 'min_zoom': 3})
 
 # Mexico region (scalerank=4, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     5, 7, 14, 'boundaries',
     { 'kind': 'region', 'min_zoom': 5})
 
 # Poland region (scalerank=5, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     5, 17, 10, 'boundaries',
     { 'kind': 'region', 'min_zoom': 5.5})
 
 # Austria region (scalerank=6, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     6, 34, 22, 'boundaries',
     { 'kind': 'region', 'min_zoom': 6})
 
 # Sweden region (scalerank=7, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     6, 35, 18, 'boundaries',
     { 'kind': 'region', 'min_zoom': 6.7})
 
 # United Kingdom region (scalerank=8, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     6, 31, 18, 'boundaries',
     { 'kind': 'region', 'min_zoom': 6.8})
 
 # Switzerland region (scalerank=9, 1:10m NE only)
-assert_has_feature(
+test.assert_has_feature(
     7, 66, 44, 'boundaries',
     { 'kind': 'region', 'min_zoom': 7})
 
@@ -77,32 +77,32 @@ assert_has_feature(
 # dropping of name
 
 # USA region NO name, Natural Earth
-assert_has_feature(
+test.assert_has_feature(
     2, 0, 1, 'boundaries',
     { 'kind': 'region', 'name': type(None)})
 
 # Germany region NO name, Natural Earth
-assert_has_feature(
+test.assert_has_feature(
     5, 17, 10, 'boundaries',
     { 'kind': 'region', 'name': type(None)})
 
 # Mexico region NO name, Natural Earth
-assert_has_feature(
+test.assert_has_feature(
     5, 7, 14, 'boundaries',
     { 'kind': 'region', 'name': type(None)})
 
 # Poland region NO name, Natural Earth
-assert_has_feature(
+test.assert_has_feature(
     5, 17, 10, 'boundaries',
     { 'kind': 'region', 'name': type(None)})
 
 # Austria region NO name, Natural Earth
-assert_has_feature(
+test.assert_has_feature(
     6, 34, 22, 'boundaries',
     { 'kind': 'region', 'name': type(None)})
 
 # Austria region HAS name, Natural Earth
-assert_has_feature(
+test.assert_has_feature(
     7, 68, 44, 'boundaries',
     { 'kind': 'region', 'name': 'Tirol - Salzburg'})
 
@@ -110,13 +110,13 @@ assert_has_feature(
 # Switzerland region HAS name, OpenStreetMap
 # http://www.openstreetmap.org/relation/1686447
 # http://www.openstreetmap.org/relation/1685677
-assert_has_feature(
+test.assert_has_feature(
     8, 133, 89, 'boundaries',
     { 'kind': 'region', 'name': 'Zug - Luzern'})
 
 # Austria region HAS name, OpenStreetMap
 # http://www.openstreetmap.org/relation/52343
 # http://www.openstreetmap.org/relation/86539
-assert_has_feature(
+test.assert_has_feature(
     8, 136, 89, 'boundaries',
     { 'kind': 'region', 'name': 'Salzburg - Tirol' })

--- a/integration-test/993-remove-props-road-merge.py
+++ b/integration-test/993-remove-props-road-merge.py
@@ -3,7 +3,7 @@
 #
 # testing that it dropped oneway, but hasn't dropped is_bridge. note that
 # the ID gets dropped due to a merge with the other carriageway.
-assert_has_feature(
+test.assert_has_feature(
     14, 4496, 6381, 'roads',
     { 'kind': 'highway', 'oneway': type(None), 'is_bridge': True })
 
@@ -12,29 +12,29 @@ assert_has_feature(
 # note that the ID gets dropped due to merging with other pedestrian
 # paths. best way to test this lacking the ID seems to be to assert the
 # presence of a path, but the absence of any crossing.
-assert_has_feature(
+test.assert_has_feature(
     14, 4933, 6066, 'roads',
     { 'kind': 'path' })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 4933, 6066, 'roads',
     { 'kind': 'path', 'crossing': None })
 
 # Way: The Embarcadero (397140734)
 # http://www.openstreetmap.org/way/397140734
-assert_has_feature(
+test.assert_has_feature(
     14, 2621, 6331, 'roads',
     { 'name': 'The Embarcadero', 'kind': 'major_road' })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 2621, 6331, 'roads',
     { 'name': 'The Embarcadero', 'kind': 'major_road',
       'sidewalk': None })
 
 # Way: Carrie Furnace Boulevard (438362919)
 # http://www.openstreetmap.org/way/438362919
-assert_has_feature(
+test.assert_has_feature(
     14, 4556, 6178, 'roads',
     { 'name': 'Carrie Furnace Blvd.', 'kind': 'major_road' })
-assert_no_matching_feature(
+test.assert_no_matching_feature(
     14, 4556, 6178, 'roads',
     { 'name': 'Carrie Furnace Blvd.', 'kind': 'major_road',
       'sidewalk_left': None, 'sidewalk_right': None })


### PR DESCRIPTION
The biggest change here is to namespace all the test assertion functions using `test`. This is to emphasize that all assertions should be done this way.