### PR TITLE
Docs - remove rate limits info, try to fix bullet formatting

### DIFF
--- a/docs/migrate-to-vector-tiles-v1.md
+++ b/docs/migrate-to-vector-tiles-v1.md
@@ -16,7 +16,7 @@ To use vector tiles 1.0, replace your URL with the following scheme, depending o
 - TopoJSON: `http://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson`
 - Mapbox Vector Tile: `http://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt`
 
-You need to append your own [API key](https://mapzen.com/documentation/overview/) at the end for access to the full rate limits.
+You need to append your own [API key](https://mapzen.com/documentation/overview/).
 
 Mapzen offers several different types of tiles in vector and raster formats and the service combines data from multiple sources. Because of data model changes in 1.0, it was not possible to redirect existing queries automatically to use the 1.0 URL.
 
@@ -95,6 +95,7 @@ Below is a summary of the major, breaking changes listed for the vector tiles 1.
   		  * minor_road:
   		  *   * filter: { kind: minor_road }
   	  ```
+     
     * for OSM roads in mid- and high zooms, optionally:
 
         ```


### PR DESCRIPTION
This removes the note about "for full rate limits" because keyless access is no longer supported. 

Also, I hope this fixes an issue in the bullet list when displayed on the documentation where the markdown is rendering as an * and not a bullet symbol.