### PR TITLE
remove duplicate symbol output

### DIFF
--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -61,7 +61,6 @@ global:
       colour: {col: tags->colour}
       network: {col: tags->network}
       state: {col: tags->state}
-      symbol: {col: tags->symbol}
       description: {col: tags->description}
       distance: {col: tags->distance}
       ascent: {col: tags->ascent}


### PR DESCRIPTION
Symbol was listed twice under the `osm_piste_properties` outputs in yaml/roads.yaml

I left the one at the end since it was more alphabetical like.