### PR TITLE
Translate new min zoom YAML to SQL

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -933,3 +933,10 @@ BEGIN
   RETURN mz_building_height(tags->'height', tags->'building:levels') * way_area;
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION trim_nz_sh(label TEXT)
+RETURNS TEXT AS $$
+BEGIN
+  RETURN trim(leading 'SH' from label);
+END
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -927,6 +927,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql STABLE;
 
+-- calculates the building height given the footprint area and the tags, which
+-- provide either the height or the number of levels to approximate the height.
 CREATE OR REPLACE FUNCTION mz_calculate_building_volume(way_area REAL, tags hstore)
 RETURNS REAL AS $$
 BEGIN
@@ -934,6 +936,10 @@ BEGIN
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 
+-- removes the leading 'SH' in the label text.
+-- this is used for removing that prefix from the refs of New Zealand highways
+-- (perhaps SH = State Highway?) because we put the 'SH' as part of the network
+-- and want to keep a numeric ref.
 CREATE OR REPLACE FUNCTION trim_nz_sh(label TEXT)
 RETURNS TEXT AS $$
 BEGIN

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ Werkzeug==0.9.6
 wsgiref==0.1.2
 git+https://github.com/ixc/python-edtf@aad32b8d5cd8848c50fbef92c73697a93cf182ba#edtf
 git+https://github.com/mapzen/mapbox-vector-tile@master#egg=mapbox-vector-tile
-git+https://github.com/mapzen/tilequeue@master#egg=tilequeue
-git+https://github.com/mapzen/tileserver@master#egg=tileserver
+# TODO! remember to change this back to 'master' branch!
+git+https://github.com/mapzen/tilequeue@migrate-sql-functions-to-python#egg=tilequeue
+git+https://github.com/mapzen/tileserver@migrate-sql-functions-to-python#egg=tileserver

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ git+https://github.com/tilezen/mapbox-vector-tile@master#egg=mapbox-vector-tile
 # TODO! remember to change this back to 'master' branch!
 git+https://github.com/tilezen/tilequeue@migrate-sql-functions-to-python#egg=tilequeue
 git+https://github.com/tilezen/tileserver@migrate-sql-functions-to-python#egg=tileserver
+# TODO! change this to the released version following https://github.com/darkfoxprime/python-astformatter/pull/8
+git+https://github.com/tilezen/python-astformatter@zerebubuth/add-parens-around-unary-operands-if-necessary#egg=ASTFormatter

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ StreetNames==0.1.5
 Werkzeug==0.9.6
 wsgiref==0.1.2
 git+https://github.com/ixc/python-edtf@aad32b8d5cd8848c50fbef92c73697a93cf182ba#edtf
-git+https://github.com/mapzen/mapbox-vector-tile@master#egg=mapbox-vector-tile
+git+https://github.com/tilezen/mapbox-vector-tile@master#egg=mapbox-vector-tile
 # TODO! remember to change this back to 'master' branch!
-git+https://github.com/mapzen/tilequeue@migrate-sql-functions-to-python#egg=tilequeue
-git+https://github.com/mapzen/tileserver@migrate-sql-functions-to-python#egg=tileserver
+git+https://github.com/tilezen/tilequeue@migrate-sql-functions-to-python#egg=tilequeue
+git+https://github.com/tilezen/tileserver@migrate-sql-functions-to-python#egg=tileserver

--- a/scripts/setup_and_run_tests.sh
+++ b/scripts/setup_and_run_tests.sh
@@ -147,7 +147,10 @@ counter=0
 limit=10
 while [[ ! -f "${test_server_port}" ]]; do
     sleep 1
-    let counter++
+    # note: don't use postfix ++ as let returns 1 when the arg evaluates to
+    # zero (as (counter=0)++ would), which makes `set -e` terminate the
+    # program.
+    let counter=counter+1
     if [[ $counter -gt $limit ]]; then
         echo "Test server didn't start up within ${limit}s."
         exit 1

--- a/scripts/setup_and_run_tests.sh
+++ b/scripts/setup_and_run_tests.sh
@@ -140,15 +140,17 @@ rm -f "${test_server_port}"
 python scripts/test_server.py "${dbname}" "${USER}" "${test_server_port}" &
 server_pid=$!
 
-# wait for file to exist
-if [[ ! -f "${test_server_port}" ]]; then
+# wait for file to exist, which means server has started up
+counter=0
+limit=10
+while [[ ! -f "${test_server_port}" ]]; do
     sleep 1
-fi
-
-if [[ ! -f "${test_server_port}" ]]; then
-    echo "Test server didn't start up within 1s."
-    exit 1
-fi
+    let counter++
+    if [[ $counter -gt $limit ]]; then
+        echo "Test server didn't start up within ${limit}s."
+        exit 1
+    fi
+done
 
 # run tests
 port=`cat "${test_server_port}"`

--- a/scripts/setup_and_run_tests.sh
+++ b/scripts/setup_and_run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -e
 
@@ -134,12 +134,14 @@ for tbl in `ls ${basedir}/integration-test/fixtures/`; do
 done
 shopt -u nullglob
 
+echo "=== Starting test tile server..."
 # make config for tileserver and serve
 test_server_port="${basedir}/test_server.port"
 rm -f "${test_server_port}"
 python scripts/test_server.py "${dbname}" "${USER}" "${test_server_port}" &
 server_pid=$!
 
+echo "=== Waiting for tile server to start..."
 # wait for file to exist, which means server has started up
 counter=0
 limit=10

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -287,7 +287,6 @@ class WaterTest(unittest.TestCase):
         self.assertEquals('riverbank', out_props.get('kind'))
         self.assertTrue(out_props.get('intermittent'))
 
-
     def test_ne(self):
         props = dict(featurecla='Lake')
         out_props = self.water.fn(None, props, None)

--- a/vectordatasource/meta/function.py
+++ b/vectordatasource/meta/function.py
@@ -152,7 +152,8 @@ def mz_building_kind_detail(val):
         return 'greenhouse'
     if val in ('apartment', 'flat'):
         return 'apartments'
-    if val in ('houses', 'residences', 'residence', 'perumahan permukiman', 'residentiel1'):
+    if val in ('houses', 'residences', 'residence', 'perumahan permukiman',
+               'residentiel1'):
         return 'residential'
     if val in ('semi_detached', 'semi-detached', 'semi'):
         return 'semidetached_house'

--- a/vectordatasource/meta/sql.jinja2
+++ b/vectordatasource/meta/sql.jinja2
@@ -84,7 +84,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_landuse_(
 {%- for param in layers['landuse']['params'] %}
         {{param.key}} {{param.typ}},
@@ -96,9 +95,7 @@ BEGIN
   RETURN {{ layers['landuse']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_landuse(
        planet_osm_point)
 RETURNS JSON AS $$
@@ -113,9 +110,7 @@ BEGIN
         0::real);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_landuse(
        planet_osm_polygon)
 RETURNS JSON AS $$
@@ -130,9 +125,7 @@ BEGIN
         row.way_area);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_landuse(
        planet_osm_line)
 RETURNS JSON AS $$
@@ -147,7 +140,6 @@ BEGIN
         0::real);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 ----------
 -- pois --
@@ -205,7 +197,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_pois_(
 {%- for param in layers['pois']['params'] %}
         {{param.key}} {{param.typ}},
@@ -217,9 +208,7 @@ BEGIN
   RETURN {{ layers['pois']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_pois(
        planet_osm_point)
 RETURNS JSON AS $$
@@ -234,9 +223,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_pois(
        planet_osm_polygon)
 RETURNS JSON AS $$
@@ -255,7 +242,6 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -------------
 -- transit --
@@ -300,7 +286,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_transit_(
 {%- for param in layers['transit']['params'] %}
         {{param.key}} {{param.typ}},
@@ -311,9 +296,7 @@ BEGIN
   RETURN {{ layers['transit']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_transit(
        planet_osm_line)
 RETURNS JSON AS $$
@@ -327,9 +310,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_transit(
        planet_osm_polygon)
 RETURNS JSON AS $$
@@ -343,7 +324,6 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 ----------------------------------------------------------------------
 -- WATER
@@ -351,7 +331,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- water kind "main" function
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water_(
 {%- for param in layers['water']['params'] %}
         {{param.key}} {{param.typ}},
@@ -362,7 +341,6 @@ BEGIN
   RETURN {{ layers['water']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- water min_zoom "main" function
 
@@ -390,7 +368,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- water kind table adaptors
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(planet_osm_polygon)
 RETURNS JSON AS $$
 DECLARE
@@ -403,9 +380,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(planet_osm_line)
 RETURNS JSON AS $$
 DECLARE
@@ -418,9 +393,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(planet_osm_point)
 RETURNS JSON AS $$
 DECLARE
@@ -433,9 +406,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_10m_coastline)
 RETURNS JSON AS $$
 DECLARE
@@ -448,9 +419,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_50m_coastline)
 RETURNS JSON AS $$
 DECLARE
@@ -463,9 +432,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_110m_coastline)
 RETURNS JSON AS $$
 DECLARE
@@ -478,9 +445,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_10m_ocean)
 RETURNS JSON AS $$
 DECLARE
@@ -493,9 +458,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_50m_ocean)
 RETURNS JSON AS $$
 DECLARE
@@ -508,9 +471,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_110m_ocean)
 RETURNS JSON AS $$
 DECLARE
@@ -523,9 +484,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_10m_lakes)
 RETURNS JSON AS $$
 DECLARE
@@ -538,9 +497,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_50m_lakes)
 RETURNS JSON AS $$
 DECLARE
@@ -553,9 +510,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_110m_lakes)
 RETURNS JSON AS $$
 DECLARE
@@ -568,9 +523,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_10m_playas)
 RETURNS JSON AS $$
 DECLARE
@@ -583,9 +536,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(ne_50m_playas)
 RETURNS JSON AS $$
 DECLARE
@@ -598,9 +549,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_water(water_polygons)
 RETURNS JSON AS $$
 DECLARE
@@ -613,7 +562,6 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- water min_zoom table adaptors
 
@@ -863,7 +811,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- places kind "main" function
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_places_(
 {%- for param in layers['places']['params'] %}
         {{param.key}} {{param.typ}},
@@ -874,7 +821,6 @@ BEGIN
   RETURN {{ layers['places']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- places min_zoom "main" function
 
@@ -900,7 +846,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- places kind table adaptors
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_places(planet_osm_point)
 RETURNS JSON AS $$
 DECLARE
@@ -913,9 +858,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_places(ne_10m_populated_places)
 RETURNS JSON AS $$
 DECLARE
@@ -928,7 +871,6 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- NOTE: this transaction including a DROP FUNCTION is here to deal with the
 -- change of return type, and can be deleted after the migrations have been
@@ -968,7 +910,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- boundaries kind "main" function
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_boundaries_(
 {%- for param in layers['boundaries']['params'] %}
         {{param.key}} {{param.typ}},
@@ -979,7 +920,6 @@ BEGIN
   RETURN {{ layers['boundaries']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- boundaries min_zoom "main" function
 
@@ -1002,7 +942,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- boundaries kind table adaptors
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_boundaries(planet_osm_line)
 RETURNS JSON AS $$
 DECLARE
@@ -1015,9 +954,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_boundaries(planet_osm_polygon)
 RETURNS JSON AS $$
 DECLARE
@@ -1030,17 +967,13 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
-no longer generating kind calculation
 {{ table_func('json', param, 'ne', 'ne_110m_admin_0_boundary_lines_land', 'JSON') }}
 {{ table_func('json', param, 'ne', 'ne_50m_admin_0_boundary_lines_land', 'JSON') }}
 {{ table_func('json', param, 'ne', 'ne_50m_admin_1_states_provinces_lines', 'JSON') }}
 {{ table_func('json', param, 'ne', 'ne_10m_admin_0_boundary_lines_land', 'JSON') }}
 {{ table_func('json', param, 'ne', 'ne_10m_admin_0_boundary_lines_map_units', 'JSON') }}
 {{ table_func('json', param, 'ne', 'ne_10m_admin_1_states_provinces_lines', 'JSON') }}
-#}
 
 DROP FUNCTION IF EXISTS mz_calculate_min_zoom_boundaries(planet_osm_line);
 
@@ -1085,7 +1018,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- buildings kind "main" function
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_buildings_(
 {%- for param in layers['buildings']['params'] %}
         {{param.key}} {{param.typ}},
@@ -1099,7 +1031,6 @@ BEGIN
   RETURN {{ layers['buildings']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- buildings min_zoom "main" function
 
@@ -1156,7 +1087,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_buildings(planet_osm_polygon)
 RETURNS JSON AS $$
 DECLARE
@@ -1170,9 +1100,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_buildings(planet_osm_point)
 RETURNS JSON AS $$
 DECLARE
@@ -1186,7 +1114,6 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 ----------------------------------------------------------------------
 -- ROADS
@@ -1194,7 +1121,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- roads kind "main" function
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_roads_(
 {%- for param in layers['roads']['params'] %}
         {{param.key}} {{param.typ}},
@@ -1207,7 +1133,6 @@ BEGIN
   RETURN {{ layers['roads']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- roads min_zoom "main" function
 
@@ -1270,7 +1195,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_roads(planet_osm_line)
 RETURNS JSON AS $$
 DECLARE
@@ -1285,9 +1209,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_roads(ne_10m_roads)
 RETURNS JSON AS $$
 DECLARE
@@ -1302,7 +1224,6 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 ----------------------------------------------------------------------
 -- EARTH
@@ -1310,7 +1231,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- earth kind "main" function
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth_(
 {%- for param in layers['earth']['params'] %}
         {{param.key}} {{param.typ}},
@@ -1321,7 +1241,6 @@ BEGIN
   RETURN {{ layers['earth']['kind_case_statement'] }};
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- earth min_zoom "main" function
 
@@ -1349,7 +1268,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- earth kind table adaptors
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth(planet_osm_polygon)
 RETURNS JSON AS $$
 DECLARE
@@ -1362,9 +1280,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth(planet_osm_line)
 RETURNS JSON AS $$
 DECLARE
@@ -1377,9 +1293,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth(planet_osm_point)
 RETURNS JSON AS $$
 DECLARE
@@ -1392,9 +1306,7 @@ BEGIN
         row.tags);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth(ne_10m_land)
 RETURNS JSON AS $$
 DECLARE
@@ -1407,9 +1319,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth(ne_50m_land)
 RETURNS JSON AS $$
 DECLARE
@@ -1422,9 +1332,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth(ne_110m_land)
 RETURNS JSON AS $$
 DECLARE
@@ -1437,9 +1345,7 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
-{#
 CREATE OR REPLACE FUNCTION mz_calculate_json_earth(land_polygons)
 RETURNS JSON AS $$
 DECLARE
@@ -1452,7 +1358,6 @@ BEGIN
         NULL);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-#}
 
 -- earth min_zoom table adaptors
 

--- a/vectordatasource/meta/sql.jinja2
+++ b/vectordatasource/meta/sql.jinja2
@@ -149,7 +149,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_min_zoom_pois_(
 {%- for param in layers['pois']['params'] %}
         {{param.key}} {{param.typ}},
 {%- endfor %}
-        osm_id bigint,
+        fid bigint,
         tags hstore,
         way_area real)
 RETURNS REAL AS $$
@@ -201,7 +201,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_json_pois_(
 {%- for param in layers['pois']['params'] %}
         {{param.key}} {{param.typ}},
 {%- endfor %}
-        osm_id bigint,
+        fid bigint,
         tags hstore)
 RETURNS JSON AS $$
 BEGIN
@@ -1125,7 +1125,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_json_roads_(
 {%- for param in layers['roads']['params'] %}
         {{param.key}} {{param.typ}},
 {%- endfor %}
-        osm_id bigint,
+        fid bigint,
         name text,
         tags hstore)
 RETURNS JSON AS $$
@@ -1140,7 +1140,7 @@ DROP FUNCTION IF EXISTS mz_calculate_min_zoom_roads_(
 {%- for param in layers['roads']['params'] %}
         {{param.key}} {{param.typ}},
 {%- endfor %}
-        osm_id bigint,
+        fid bigint,
         name text,
         way geometry,
         tags hstore);
@@ -1149,7 +1149,7 @@ CREATE OR REPLACE FUNCTION mz_calculate_min_zoom_roads_(
 {%- for param in layers['roads']['params'] %}
         {{param.key}} {{param.typ}},
 {%- endfor %}
-        osm_id bigint,
+        fid bigint,
         name text,
         way geometry,
         tags hstore)

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -42,6 +42,8 @@ def format_value(val, table):
         return "%f" % val
     elif isinstance(val, list):
         return format_array_sql(val, table)
+    elif val is None:
+        return "NULL"
     else:
         return "'%s'" % val
 
@@ -106,9 +108,14 @@ def value_columns(val, table):
     return []
 
 
-def format_case_sql(case_stmt, table):
-    assert isinstance(case_stmt, list)
-    assert len(case_stmt) >= 1
+def format_case_sql(case_stmt_orig, table):
+    assert isinstance(case_stmt_orig, list)
+    assert len(case_stmt_orig) >= 1
+
+    # copy the case statement so that we can modify it (for the else removal)
+    # without modifying the original in case the original is re-used (for
+    # example in YAML aliases).
+    case_stmt = list(case_stmt_orig)
 
     if 'else' in case_stmt[-1]:
         else_val = format_value(case_stmt.pop()['else'], table)

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -72,8 +72,8 @@ def value_columns(val, table):
         elif 'col' in val:
             if val.get('ignore'):
                 return []
-            elif val['col'].startswith('tags->') or \
-                 table.column_is_tag(val['col']):
+            elif (val['col'].startswith('tags->') or
+                  table.column_is_tag(val['col'])):
                 return ['tags']
             else:
                 return [val['col']]
@@ -127,7 +127,6 @@ def format_case_sql(case_stmt_orig, table):
         assert set(when_then.keys()) == set(['when', 'then'])
         when_filters = when_then['when']
         then_part = when_then['then']
-        then_val = format_value(then_part, table)
 
         conds = []
         if not isinstance(when_filters, list):

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -151,6 +151,7 @@ def format_case_sql(case_stmt_orig, table):
 
 UTIL_FUNCTIONS = {
     'util.calculate_path_major_route': 'mz_calculate_path_major_route',
+    'util.cycling_network': 'mz_cycling_network',
 }
 
 

--- a/vectordatasource/meta/sql2.py
+++ b/vectordatasource/meta/sql2.py
@@ -111,8 +111,8 @@ def fn_name(node):
     elif isinstance(node, (str, unicode)):
         return node
     else:
-        import pdb; pdb.set_trace()
-        raise RuntimeError("Don't know how to make a function name from %r" % (node,))
+        raise RuntimeError("Don't know how to make a function name from %r"
+                           % (node,))
 
 
 class SQLExpression(ast.NodeVisitor):
@@ -191,7 +191,8 @@ class SQLExpression(ast.NodeVisitor):
             name = fn_name(call.func)
             func = KNOWN_FUNCS.get(name)
             if not func:
-                raise RuntimeError("Call to name not implemented yet: %r" % (name,))
+                raise RuntimeError("Call to name not implemented yet: %r"
+                                   % (name,))
             self.buf.write(func)
             self.buf.write("(")
             first = True
@@ -278,10 +279,10 @@ class SQLExpression(ast.NodeVisitor):
         if name == 'shape' and attr == 'type':
             self.buf.write("ST_GeomType(way)")
         else:
-            raise RuntimeError("Unknown attribute pair (%r, %r)" % (name, attr))
+            raise RuntimeError("Unknown attribute pair (%r, %r)"
+                               % (name, attr))
 
     def generic_visit(self, node):
-        import pdb; pdb.set_trace()
         self.buf.write("<<<%s>>>" % type(node))
 
     def __str__(self):
@@ -306,10 +307,10 @@ def merge_case(stmts):
     for stmt in stmts:
         if isinstance(stmt, ast.Assign):
             assigns.append(stmt)
-        elif isinstance(stmt, ast.If) and \
-           len(stmt.orelse) == 0 and \
-           len(stmt.body) == 1 and \
-           isinstance(stmt.body[0], ast.Return):
+        elif (isinstance(stmt, ast.If) and
+              len(stmt.orelse) == 0 and
+              len(stmt.body) == 1 and
+              isinstance(stmt.body[0], ast.Return)):
             whens.append(stmt)
         else:
             return stmts
@@ -388,7 +389,6 @@ class SQLVisitor(ast.NodeVisitor):
                      % defn.name)
         self.writeln("RETURNS JSON AS $$")
         self.add_indent(2)
-        #import pdb; pdb.set_trace()
         seen_begin = False
         wrote_declare = False
         for stmt in merge_case(defn.body):
@@ -396,7 +396,8 @@ class SQLVisitor(ast.NodeVisitor):
                 if assign_is_global(stmt):
                     continue
                 if seen_begin:
-                    raise RuntimeError("Assignment statement after function body begins.")
+                    raise RuntimeError(
+                        "Assignment statement after function body begins.")
                 if not wrote_declare:
                     self.add_indent(-2)
                     self.writeln("DECLARE")
@@ -453,7 +454,8 @@ class SQLVisitor(ast.NodeVisitor):
         self.writeln("%s REAL := %s;" % (name, expr))
 
     def generic_visit(self, node):
-        self.writeln("<<< don't yet understand what a %s is for... >>>" % (type(node),))
+        self.writeln("<<< don't yet understand what a %s is for... >>>"
+                     % (type(node),))
 
 
 def main(argv=None):

--- a/vectordatasource/util.py
+++ b/vectordatasource/util.py
@@ -60,11 +60,18 @@ def calculate_1px_zoom(way_area):
         return 17.256 - math.log(way_area) / math.log(4)
 
 
+# returns the min_zoom for the most important walking or cycling network
+# that the road with the given fid is part of.
 def calculate_path_major_route(fid):
     # TODO: implement me! current implementation is a stub.
     return 18
 
 
+# calculates the "most important" cycle network for a road with the given tags
+# and fid, or None if the road isn't part of a cycle network.
+#
+# cycle networks are considered in the following order of importance: icn,
+# ncn, rcn, lcn.
 def cycling_network(tags, fid):
     # TODO: implement me! current implementation is a stub.
     return None

--- a/vectordatasource/util.py
+++ b/vectordatasource/util.py
@@ -64,6 +64,7 @@ def calculate_path_major_route(fid):
     # TODO: implement me! current implementation is a stub.
     return 18
 
+
 def cycling_network(tags, fid):
     # TODO: implement me! current implementation is a stub.
     return None

--- a/vectordatasource/util.py
+++ b/vectordatasource/util.py
@@ -63,3 +63,7 @@ def calculate_1px_zoom(way_area):
 def calculate_path_major_route(fid):
     # TODO: implement me! current implementation is a stub.
     return 18
+
+def cycling_network(tags, fid):
+    # TODO: implement me! current implementation is a stub.
+    return None

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -18,6 +18,8 @@ filters:
   - filter: {source: whosonfirst.mapzen.com}
     min_zoom: {col: min_zoom}
     output: {kind: {col: kind}}
+    table: wof
+    extra_columns: [ min_zoom ]
   - filter: {name: true, place: country}
     min_zoom: 2
     output: {kind: country}

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -716,7 +716,7 @@ filters:
     min_zoom: { clamp: { min: 0, max: 17, value: { sum: [ { col: zoom }, 3.98 ] } } }
     output: {kind: fitness_station}
   - filter: {leisure: beach_resort}
-    min_zoom: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 0.5 ] } } }
+    min_zoom: { clamp: { min: 14, max: 16, value: { sum: [ { col: zoom }, 0.5 ] } } }
     output: {kind: beach_resort }
   - filter:
       tourism: [hotel, motel]
@@ -727,7 +727,7 @@ filters:
     min_zoom: 12
     output: {kind: motorway_junction}
   - filter: {historic: monument}
-    min_zoom: { clamp: { min: 0, max: 17, value: { sum: [ { col: zoom }, 2.24 ] } } }
+    min_zoom: { clamp: { min: 15, max: 17, value: { sum: [ { col: zoom }, 2.24 ] } } }
     output: {kind: monument }
   - filter:
       tags->zoo: [enclosure, petting_zoo, aviary]

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -791,7 +791,7 @@ filters:
     min_zoom: 18
     output: {kind: toilets}
   - filter: {barrier: gate}
-    min_zoom: { call: { func: mz_get_min_zoom_highway_level_gate, args: { col: fid } } }
+    min_zoom: { call: { func: mz_get_min_zoom_highway_level_gate, args: [ { col: fid } ] } }
     output: {kind: gate}
   - filter: {barrier: toll_booth}
     min_zoom: 15

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -22,9 +22,13 @@ global:
       service: {col: service}
       sport: {col: sport}
       surface: {col: tags->surface}
-      # NOTE: moved directly to sql
-      # bicycle_network: {call: { func: mz_cycling_network, args: [tags, osm_id] }}
-      bicycle_network: {col: mz_cycling_network}
+      bicycle_network: {call: { func: mz_cycling_network, args: [tags, osm_id] }}
+      bicycle_network:
+        call:
+          func: mz_cycling_network
+          args:
+            - { col: tags }
+            - { col: osm_id }
       oneway: {col: oneway}
       oneway_bicycle: {col: "tags->oneway:bicycle"}
       cycleway:
@@ -66,13 +70,11 @@ global:
       sidewalk_left: {col: 'sidewalk:left'}
       sidewalk_right: {col: 'sidewalk:right'}
   - &osm_network
-      # NOTE: moved directly to sql
-      # mz_networks:
-      #   call:
-      #     func: mz_get_rel_networks
-      #     args:
-      #       - osm_id
-      mz_networks: {col: mz_networks}
+      mz_networks:
+        call:
+          func: mz_get_rel_networks
+          args:
+            - { col: osm_id }
       network: {col: network}
   - &osm_piste_properties
       kind: piste

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -28,7 +28,7 @@ global:
           func: mz_cycling_network
           args:
             - { col: tags }
-            - { col: osm_id }
+            - { col: fid }
       oneway: {col: oneway}
       oneway_bicycle: {col: "tags->oneway:bicycle"}
       cycleway:
@@ -74,7 +74,7 @@ global:
         call:
           func: mz_get_rel_networks
           args:
-            - { col: osm_id }
+            - { col: fid }
       network: {col: network}
   - &osm_piste_properties
       kind: piste

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -22,7 +22,12 @@ global:
       service: {col: service}
       sport: {col: sport}
       surface: {col: tags->surface}
-      bicycle_network: {call: { func: util.cycling_network, args: [tags, fid] }}
+      bicycle_network:
+        call:
+          func: mz_cycling_network
+          args:
+            - { col: tags }
+            - { col: fid }
       oneway: {col: oneway}
       oneway_bicycle: {col: "tags->oneway:bicycle"}
       cycleway:

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -22,12 +22,9 @@ global:
       service: {col: service}
       sport: {col: sport}
       surface: {col: tags->surface}
-      bicycle_network:
-        call:
-          func: mz_cycling_network
-          args:
-            - { col: tags }
-            - { col: fid }
+      # NOTE: moved directly to sql
+      # bicycle_network: {call: { func: mz_cycling_network, args: [tags, osm_id] }}
+      bicycle_network: {col: mz_cycling_network}
       oneway: {col: oneway}
       oneway_bicycle: {col: "tags->oneway:bicycle"}
       cycleway:
@@ -69,11 +66,13 @@ global:
       sidewalk_left: {col: 'sidewalk:left'}
       sidewalk_right: {col: 'sidewalk:right'}
   - &osm_network
-      mz_networks:
-        call:
-          func: mz_get_rel_networks
-          args:
-            - { col: fid }
+      # NOTE: moved directly to sql
+      # mz_networks:
+      #   call:
+      #     func: mz_get_rel_networks
+      #     args:
+      #       - osm_id
+      mz_networks: {col: mz_networks}
       network: {col: network}
   - &osm_piste_properties
       kind: piste

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -22,13 +22,7 @@ global:
       service: {col: service}
       sport: {col: sport}
       surface: {col: tags->surface}
-      bicycle_network: {call: { func: mz_cycling_network, args: [tags, osm_id] }}
-      bicycle_network:
-        call:
-          func: mz_cycling_network
-          args:
-            - { col: tags }
-            - { col: fid }
+      bicycle_network: {call: { func: util.cycling_network, args: [tags, fid] }}
       oneway: {col: oneway}
       oneway_bicycle: {col: "tags->oneway:bicycle"}
       cycleway:


### PR DESCRIPTION
This updates the `sql.py` which was previously being used to generate the SQL functions to handle the new structures in YAML that we added to support the Python output. This means that the repo should be self-contained again, and be able to run the tests without having to import the server-side function definitions from `master` branch.

Not to be confused with `sql2.py`, which is the new Python `ast`-based SQL output. That's a separate thing which hopefully will be coming soon.
