### PR TITLE
Use metadata namespace for source in filter rules

### DIFF
--- a/data/perform-sql-updates.sh
+++ b/data/perform-sql-updates.sh
@@ -2,37 +2,51 @@
 
 set -e
 
+PSQLOPTS="--set ON_ERROR_STOP=on"
+
 # apply schema updates first, some functions now depend on it.
 echo "Creating custom schema..."
-psql $@ -f schema.sql
+psql $PSQLOPTS $@ -f schema.sql
 echo "done."
 
 # subsequent sql depends on functions installed
 echo "Creating functions..."
-psql $@ -f functions.sql
+psql $PSQLOPTS  $@ -f functions.sql
 echo "done."
 
 # update the schema of the tables
 echo "Updating table schemas..."
-psql $@ -f apply-schema-update.sql
+psql $PSQLOPTS  $@ -f apply-schema-update.sql
 echo "done."
 
-# dynamic functions generated from csv
-echo "Generating functions from csv..."
-(cd ../vectordatasource/meta && python sql.py) | psql $@
+# dynamic functions generated from YAML
+echo "Generating functions from YAML..."
+
+# store SQL in a temporary file, so make a temporary directory for it.
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp/}$(basename 0).XXXXXXXXXXXX")
+sqlfile="${tmpdir}/generated-fuctions.sql"
+trap "{ rm -rf $tmpdir; }" EXIT
+
+# the reason for doing it this way is that the failure of `python sql.py`
+# will now be picked up by `set -e` and fail the script, whereas piping it
+# into psql  would have given the illusion of success.
+pushd ../vectordatasource/meta
+python sql.py > $sqlfile
+popd
+psql $PSQLOPTS  -f $sqlfile $@
 echo "done."
 
 # apply updates in parallel across tables
 echo -e "\nApplying updates in parallel across tables..."
-psql $@ -f apply-updates-non-planet-tables.sql &
-psql $@ -f apply-planet_osm_polygon.sql &
-psql $@ -f apply-planet_osm_line.sql &
-psql $@ -f apply-planet_osm_point.sql &
+psql $PSQLOPTS  $@ -f apply-updates-non-planet-tables.sql &
+psql $PSQLOPTS  $@ -f apply-planet_osm_polygon.sql &
+psql $PSQLOPTS  $@ -f apply-planet_osm_line.sql &
+psql $PSQLOPTS  $@ -f apply-planet_osm_point.sql &
 wait
 echo "done."
 
 echo -e '\nApplying triggers...'
-psql $@ -f triggers.sql
+psql $PSQLOPTS  $@ -f triggers.sql
 echo 'done.'
 
 echo -e "\nAll updates complete. Exiting."

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ wsgiref==0.1.2
 git+https://github.com/ixc/python-edtf@aad32b8d5cd8848c50fbef92c73697a93cf182ba#edtf
 git+https://github.com/tilezen/mapbox-vector-tile@master#egg=mapbox-vector-tile
 # TODO! remember to change this back to 'master' branch!
-git+https://github.com/tilezen/tilequeue@migrate-sql-functions-to-python#egg=tilequeue
+git+https://github.com/tilezen/tilequeue@rmarianski/migrate-sql-functions-to-python#egg=tilequeue
 git+https://github.com/tilezen/tileserver@migrate-sql-functions-to-python#egg=tileserver
 # TODO! change this to the released version following https://github.com/darkfoxprime/python-astformatter/pull/8
 git+https://github.com/tilezen/python-astformatter@zerebubuth/add-parens-around-unary-operands-if-necessary#egg=ASTFormatter

--- a/vectordatasource/meta/python.py
+++ b/vectordatasource/meta/python.py
@@ -224,6 +224,11 @@ def ast_column(ast_state, col):
         result = ast.Name('fid', ast.Load())
     elif col == 'shape':
         result = ast.Name('shape', ast.Load())
+    elif col.startswith('meta.'):
+        meta_fields = col.split('.', 1)
+        meta_prop = meta_fields[1]
+        result = ast.Attribute(
+            ast.Name('meta', ast.Load()), meta_prop, ast.Load())
     else:
         result = ast.Call(
             ast.Attribute(
@@ -509,6 +514,7 @@ def parse_layer_from_yaml(
             ast.Name('shape', ast.Param()),
             ast.Name('props', ast.Param()),
             ast.Name('fid', ast.Param()),
+            ast.Name('meta', ast.Param()),
         ], None, None, []),
         stmts,
         [])

--- a/yaml/earth.yaml
+++ b/yaml/earth.yaml
@@ -71,24 +71,9 @@ filters:
       - {kind: valley}
     table: osm
 
-  # TODO: need to sort out the source
   - filter:
-      source:
-        - naturalearthdata.com
-        - openstreetmapdata.com
+      meta.source: [ne, shp]
     min_zoom: 0
     output:
       - *output_properties
       - {kind: earth}
-  # - filter: {gid: true}
-  #   min_zoom: 0
-  #   output:
-  #     - *output_properties
-  #     - {kind: earth}
-  #   table: ne
-  # - filter: {fid: true}
-  #   min_zoom: 0
-  #   output:
-  #     - *output_properties
-  #     - {kind: earth}
-  #   table: shp

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -121,7 +121,7 @@ global:
         - U.S. National Park Service
         - US National Park service
 filters:
-  - filter: {source: naturalearthdata.com}
+  - filter: {meta.source: ne}
     min_zoom: 4
     output:
       - *output_properties

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -605,8 +605,8 @@ filters:
   ############################################################
   # TIER 5
   ############################################################
-  # theme_park
-  - filter: {tourism: theme_park}
+  # theme_park (NOTE: also allow and normalise 'Theme Park' to deal with vandalism)
+  - filter: {tourism: [theme_park, 'Theme Park']}
     min_zoom: *tier5_min_zoom
     output:
       - *output_properties

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -27,7 +27,7 @@ global:
       default: 10
 
 filters:
-  - filter: {source: whosonfirst.mapzen.com}
+  - filter: {meta.source: wof}
     min_zoom: {col: min_zoom}
     output:
       - *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -573,8 +573,8 @@ filters:
     output:
       - *output_properties
       - {kind: resort, tier: 5}
-  # theme_park
-  - filter: {tourism: theme_park}
+  # theme_park (NOTE: also allow and normalise 'Theme Park' to deal with vandalism)
+  - filter: {tourism: [theme_park, 'Theme Park']}
     min_zoom: { min: [ { max: [ 13, { sum: [ { col: zoom }, 6.32 ] }, *tier5_min_zoom ] }, 17 ] }
     output:
       - *output_properties

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -165,7 +165,7 @@ filters:
   #     - *output_properties
   #     - {kind: ocean}
   #   table: shp
-  - filter: {source: openstreetmapdata.com}
+  - filter: {meta.source: shp}
     min_zoom: 0
     output:
       - *output_properties


### PR DESCRIPTION
Instead of updating all the queries to include a new metadata column, it seemed both easier and better to port that in after that fact in [python code](https://github.com/tilezen/tilequeue/pull/222). Because this is going to be temporary anyway and will change soon with rawr tiles, this made sense to me as a better trade-off to make.
