### PR TITLE
Fix SQL and unit tests

### DIFF
--- a/data/perform-sql-updates.sh
+++ b/data/perform-sql-updates.sh
@@ -2,37 +2,51 @@
 
 set -e
 
+PSQLOPTS="--set ON_ERROR_STOP=on"
+
 # apply schema updates first, some functions now depend on it.
 echo "Creating custom schema..."
-psql $@ -f schema.sql
+psql $PSQLOPTS $@ -f schema.sql
 echo "done."
 
 # subsequent sql depends on functions installed
 echo "Creating functions..."
-psql $@ -f functions.sql
+psql $PSQLOPTS  $@ -f functions.sql
 echo "done."
 
 # update the schema of the tables
 echo "Updating table schemas..."
-psql $@ -f apply-schema-update.sql
+psql $PSQLOPTS  $@ -f apply-schema-update.sql
 echo "done."
 
-# dynamic functions generated from csv
-echo "Generating functions from csv..."
-(cd ../vectordatasource/meta && python sql.py) | psql $@
+# dynamic functions generated from YAML
+echo "Generating functions from YAML..."
+
+# store SQL in a temporary file, so make a temporary directory for it.
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp/}$(basename 0).XXXXXXXXXXXX")
+sqlfile="${tmpdir}/generated-fuctions.sql"
+trap "{ rm -rf $tmpdir; }" EXIT
+
+# the reason for doing it this way is that the failure of `python sql.py`
+# will now be picked up by `set -e` and fail the script, whereas piping it
+# into psql  would have given the illusion of success.
+pushd ../vectordatasource/meta
+python sql.py > $sqlfile
+popd
+psql $PSQLOPTS  -f $sqlfile $@
 echo "done."
 
 # apply updates in parallel across tables
 echo -e "\nApplying updates in parallel across tables..."
-psql $@ -f apply-updates-non-planet-tables.sql &
-psql $@ -f apply-planet_osm_polygon.sql &
-psql $@ -f apply-planet_osm_line.sql &
-psql $@ -f apply-planet_osm_point.sql &
+psql $PSQLOPTS  $@ -f apply-updates-non-planet-tables.sql &
+psql $PSQLOPTS  $@ -f apply-planet_osm_polygon.sql &
+psql $PSQLOPTS  $@ -f apply-planet_osm_line.sql &
+psql $PSQLOPTS  $@ -f apply-planet_osm_point.sql &
 wait
 echo "done."
 
 echo -e '\nApplying triggers...'
-psql $@ -f triggers.sql
+psql $PSQLOPTS  $@ -f triggers.sql
 echo 'done.'
 
 echo -e "\nAll updates complete. Exiting."

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ wsgiref==0.1.2
 git+https://github.com/ixc/python-edtf@aad32b8d5cd8848c50fbef92c73697a93cf182ba#edtf
 git+https://github.com/tilezen/mapbox-vector-tile@master#egg=mapbox-vector-tile
 # TODO! remember to change this back to 'master' branch!
-git+https://github.com/tilezen/tilequeue@migrate-sql-functions-to-python#egg=tilequeue
+git+https://github.com/tilezen/tilequeue@rmarianski/migrate-sql-functions-to-python#egg=tilequeue
 git+https://github.com/tilezen/tileserver@migrate-sql-functions-to-python#egg=tileserver
 # TODO! change this to the released version following https://github.com/darkfoxprime/python-astformatter/pull/8
 git+https://github.com/tilezen/python-astformatter@zerebubuth/add-parens-around-unary-operands-if-necessary#egg=ASTFormatter

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -605,8 +605,8 @@ filters:
   ############################################################
   # TIER 5
   ############################################################
-  # theme_park
-  - filter: {tourism: theme_park}
+  # theme_park (NOTE: also allow and normalise 'Theme Park' to deal with vandalism)
+  - filter: {tourism: [theme_park, 'Theme Park']}
     min_zoom: *tier5_min_zoom
     output:
       - *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -573,8 +573,8 @@ filters:
     output:
       - *output_properties
       - {kind: resort, tier: 5}
-  # theme_park
-  - filter: {tourism: theme_park}
+  # theme_park (NOTE: also allow and normalise 'Theme Park' to deal with vandalism)
+  - filter: {tourism: [theme_park, 'Theme Park']}
     min_zoom: { min: [ { max: [ 13, { sum: [ { col: zoom }, 6.32 ] }, *tier5_min_zoom ] }, 17 ] }
     output:
       - *output_properties


### PR DESCRIPTION
* Fixed unit tests to make use of new `meta` parameter.
* Made `perform-sql-updates.sh` stop on error so that issues with setting up the database are easier to debug.
* Added `meta.source` to SQL to match Python implementation.
* Hack to work around vandalism on the OSM feature we use to test theme parks.