### PR TITLE
Override to run develop instead of install for python code.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,12 +14,13 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get install osm2pgsql proj-data
     - pip install -Ur requirements.txt
+  override:
+    - python setup.py develop
 
 test:
   override:
     - pip install -U flake8
     - find . -not -path '*/.eggs/*' -not -path '*/integration-test*' -not -path '*/data/*' -name '*.py' | xargs flake8
-    - python setup.py develop
     - python setup.py test
     - ./scripts/setup_and_run_tests.sh -j 4
 


### PR DESCRIPTION
This should (fingers crossed) prevent CircleCI from running `python setup.py install` as part of the `dependencies` step.