### PR TITLE
include testing-related debris in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ vector_datasource.egg-info/
 data/Makefile-import-data
 data/Makefile-prepare-data
 data/import-shapefiles.sh
+
+# files generated during testing
+empty.osm
+data.osc
+
+# files generated during installation of software necessary for testing
+.eggs/*


### PR DESCRIPTION
I was following instructions in https://github.com/tilezen/vector-datasource/blob/master/TESTS.md

During tests git status was displaying some unwanted debris that I think should be in .gitignore.