### PR TITLE
include surface at mid-zooms

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1063,7 +1063,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `all_bus_networks` and `all_bus_shield_texts`: All of the bus and trolley-bus routes of which this road is a part, and each corresponding shield text. See `bus_network` and `bus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
 * `bus_network`: Note that this is often not present for bus routes / networks. This may be replaced with `operator` in the future, see [issue 1194](https://github.com/tilezen/vector-datasource/issues/1194).
 * `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus or trolley-bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
-* `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`.
+* `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`. `concrete:plates` and `concrete:lanes` values are transformed to `concrete_plates` and `concrete_lanes` respectively.
 
 #### Road properties (optional):
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1016,7 +1016,7 @@ Road names are **abbreviated** so directionals like `North` is replaced with `N`
 
 Mapzen calculates the `landuse_kind` value by intercutting `roads` with the `landuse` layer to determine if a road segment is over a parks, hospitals, universities or other landuse features. Use this property to modify the visual appearance of roads over these features. For instance, light grey minor roads look great in general, but aren't legible over most landuse colors unless they are darkened.
 
-To improve performance, some road segments are merged at low and mid-zooms. To facilitate this, certain properties are dropped at those zooms. Examples include `is_bridge` and `is_tunnel`, `name`, `network`, `oneway` and `ref`. The exact zoom varies per feature class (major roads keep this properties over a wider range, minor roads drop them starting at zoom 14). When roads are merged, the original OSM `id` values are dropped.
+To improve performance, some road segments are merged at low and mid-zooms. To facilitate this, certain properties are dropped at those zooms. Examples include `is_bridge` and `is_tunnel`, `name`, `network`, `oneway`, and `ref`. The exact zoom varies per feature class (major roads keep this properties over a wider range, minor roads drop them starting at zoom 14). When roads are merged, the original OSM `id` values are dropped.
 
 #### Road properties (common):
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1016,7 +1016,7 @@ Road names are **abbreviated** so directionals like `North` is replaced with `N`
 
 Mapzen calculates the `landuse_kind` value by intercutting `roads` with the `landuse` layer to determine if a road segment is over a parks, hospitals, universities or other landuse features. Use this property to modify the visual appearance of roads over these features. For instance, light grey minor roads look great in general, but aren't legible over most landuse colors unless they are darkened.
 
-To improve performance, some road segments are merged at low and mid-zooms. To facilitate this, certain properties are dropped at those zooms. Examples include `is_bridge` and `is_tunnel`, `name`, `network`, `oneway`, `ref`, and `surface`. The exact zoom varies per feature class (major roads keep this properties over a wider range, minor roads drop them starting at zoom 14). When roads are merged, the original OSM `id` values are dropped.
+To improve performance, some road segments are merged at low and mid-zooms. To facilitate this, certain properties are dropped at those zooms. Examples include `is_bridge` and `is_tunnel`, `name`, `network`, `oneway` and `ref`. The exact zoom varies per feature class (major roads keep this properties over a wider range, minor roads drop them starting at zoom 14). When roads are merged, the original OSM `id` values are dropped.
 
 #### Road properties (common):
 

--- a/integration-test/1020-roads-surface.py
+++ b/integration-test/1020-roads-surface.py
@@ -5,8 +5,3 @@
 test.assert_has_feature(
     15, 9371, 12546, 'roads',
     { 'id': 190536019, 'kind': 'minor_road', 'surface': 'cobblestone'})
-
-# But strip that surface property off at earlier zooms
-test.assert_no_matching_feature(
-    13, 2342, 3136, 'roads',
-    { 'surface': 'cobblestone'})

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -1,0 +1,52 @@
+# Add surface properties to roads layer (at max zooms)
+
+# Prince St with cobblestones in Alexandria, VA
+# https://www.openstreetmap.org/way/190536019
+test.assert_has_feature(
+    15, 9371, 12546, 'roads',
+    { 'id': 190536019, 'kind': 'minor_road', 'surface': 'cobblestone'})
+
+# and that surface property stays at earlier zooms
+test.assert_has_feature(
+    13, 2342, 3136, 'roads',
+    { 'id': 190536019, 'kind': 'minor_road', 'surface': 'cobblestone'})
+
+
+# motorway in Kraków, Poland
+# http://www.openstreetmap.org/way/431783017
+test.assert_has_feature(
+    12, 2273, 1388, 'roads',
+    { 'id': 431783017, 'kind_detail': 'motorway', 'surface': 'asphalt'})
+
+
+# But strip that surface property off at earlier zooms
+test.assert_no_matching_feature(
+    7, 71, 43, 'roads',
+    { 'kind_detail': 'motorway', 'surface': 'asphalt'})
+
+# track with cycling route in Schartau, Germany
+# http://www.openstreetmap.org/way/58691615
+
+test.assert_has_feature(
+    15, 17456, 10780, 'roads',
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+
+test.assert_has_feature(
+    13, 4364, 2695, 'roads',
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+
+test.assert_has_feature(
+    11, 1091, 673, 'roads',
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+
+test.assert_has_feature(
+    10, 545, 336, 'roads',
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+
+test.assert_has_feature(
+    9, 272, 168, 'roads',
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+
+test.assert_has_feature(
+    9, 136, 84, 'roads',
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -29,24 +29,24 @@ test.assert_no_matching_feature(
 
 test.assert_has_feature(
     15, 17456, 10780, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
 
 test.assert_has_feature(
     13, 4364, 2695, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
 
 test.assert_has_feature(
     11, 1091, 673, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
 
 test.assert_has_feature(
     10, 545, 336, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
 
 test.assert_has_feature(
     9, 272, 168, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
 
 test.assert_has_feature(
     9, 136, 84, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete:lanes'})
+    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})

--- a/queries.yaml
+++ b/queries.yaml
@@ -502,13 +502,6 @@ post_process:
     params:
       source_layer: roads
       start_zoom: 0
-      end_zoom: 7
-      properties:
-        - surface
-  - fn: vectordatasource.transform.drop_properties
-    params:
-      source_layer: roads
-      start_zoom: 0
       end_zoom: 11
       properties:
         - bicycle

--- a/queries.yaml
+++ b/queries.yaml
@@ -502,6 +502,13 @@ post_process:
     params:
       source_layer: roads
       start_zoom: 0
+      end_zoom: 7
+      properties:
+        - surface
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
       end_zoom: 11
       properties:
         - bicycle
@@ -514,7 +521,6 @@ post_process:
         - route_name     # NVK (2017425): this is a suspicious tag
         - sac_scale
         - state
-        - surface
         - symbol
         - tracktype
         - type           # NVK (2017425): this is a suspicious tag
@@ -554,7 +560,6 @@ post_process:
         - sidewalk_left
         - sidewalk_right
         - sport
-        - surface
         - trail_visibility
   # drop name and other properties on early paths to
   # allow more line merging (use walking network for labeling)

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -29,7 +29,11 @@ global:
       bicycle: {col: bicycle}
       service: {col: service}
       sport: {col: sport}
-      surface: {col: tags->surface}
+      surface:
+        case:
+          - { when: { surface: 'concrete:plates' }, then: 'concrete_plates' }
+          - { when: { surface: 'concrete:lanes' }, then: 'concrete_lanes' }
+          - else: { col: 'tags->surface' }
       # NOTE: moved directly to sql
       # bicycle_network: {call: { func: mz_cycling_network, args: [tags, osm_id] }}
       bicycle_network: {col: mz_cycling_network}


### PR DESCRIPTION
enables surface tag on z8 to z14 (as bicycle routes appear on z8)
fixes #1252

- [x] Update tests
- [x] ~~Update data migrations~~ (not needed as doesn't impact `min_zoom`)
- [x] Update docs

WIP, I created PR to run tests independently from my local instance (after reload of testing database test failed with claim that 11/1091/673 has no road layer (and that tile at http://tile.mapzen.com/mapzen/vector/v1/roads/11/1091/673.json has road layer).