### PR TITLE
: to _ in surface=cobblestone:flattened

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1063,7 +1063,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `all_bus_networks` and `all_bus_shield_texts`: All of the bus and trolley-bus routes of which this road is a part, and each corresponding shield text. See `bus_network` and `bus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
 * `bus_network`: Note that this is often not present for bus routes / networks. This may be replaced with `operator` in the future, see [issue 1194](https://github.com/tilezen/vector-datasource/issues/1194).
 * `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus or trolley-bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
-* `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`. `concrete:plates` and `concrete:lanes` values are transformed to `concrete_plates` and `concrete_lanes` respectively.
+* `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`. `cobblestone:flattened`, `concrete:plates` and `concrete:lanes` values are transformed to `cobblestone_flattened`, `concrete_plates` and `concrete_lanes` respectively.
 
 #### Road properties (optional):
 

--- a/integration-test/1337-roads-surface-cobblestone-value-transformed.py
+++ b/integration-test/1337-roads-surface-cobblestone-value-transformed.py
@@ -1,0 +1,7 @@
+# transform cobblestone:flattened to cobblestone_flattened
+
+# Illicha Avenue in Donetsk, Ukraine
+# http://www.openstreetmap.org/way/239860289
+test.assert_has_feature(
+    16, 39650, 22780, 'roads',
+    { 'id': 239860289, 'name:en':'Illicha Avenue', 'kind': 'major_road', 'surface': 'cobblestone_flattened'})

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -33,6 +33,7 @@ global:
         case:
           - { when: { surface: 'concrete:plates' }, then: 'concrete_plates' }
           - { when: { surface: 'concrete:lanes' }, then: 'concrete_lanes' }
+          - { when: { surface: 'cobblestone:flattened' }, then: 'cobblestone_flattened' }
           - else: { col: 'tags->surface' }
       # NOTE: moved directly to sql
       # bicycle_network: {call: { func: mz_cycling_network, args: [tags, osm_id] }}


### PR DESCRIPTION
> Note: we don't use : in Tilezen property names or values so the following are re-mapped:
>
>    cobblestone:flattened to cobblestone_flattened
>    concrete:lanes to concrete_lanes
>    concrete:plates to concrete_plates

from https://github.com/tilezen/vector-datasource/issues/1335#issue-245771071 indicates that this is missing