### PR TITLE
Return exit code of test run

### DIFF
--- a/scripts/setup_and_run_tests.sh
+++ b/scripts/setup_and_run_tests.sh
@@ -176,3 +176,5 @@ fi
 
 kill -HUP "${server_pid}"
 wait
+
+exit $success


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/1339

This should make the circleci run fail when the tests fail.