### PR TITLE
Fix test 1252.

### DIFF
--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -31,26 +31,27 @@ test.assert_no_matching_feature(
 # min zoom to be assigned correctly.
 # http://www.openstreetmap.org/relation/2599024
 
+# first, test at high zoom, where we do not expect the road to be merged,
+# so should still retain its original ID.
 test.assert_has_feature(
     15, 17456, 10780, 'roads',
     { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
 
-test.assert_has_feature(
-    13, 4364, 2695, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
+# check at a bunch of lower zooms, where we're expecting the road to be
+# merged, so be stricter with the set of properties we expect to see.
+for z in (13, 11, 10, 9, 8):
+    delta_z = 15 - z
+    coord_scale = 2 ** delta_z
 
-test.assert_has_feature(
-    11, 1091, 673, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
+    props = {
+        'kind': 'path',
+        'kind_detail': 'track',
+        'is_bicycle_related': True,
+        'surface': 'concrete_lanes',
+        'bicycle_network': 'ncn',
+        'min_zoom': 8,
+        'bicycle_shield_text': 'D10',
+    }
 
-test.assert_has_feature(
-    10, 545, 336, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
-
-test.assert_has_feature(
-    9, 272, 168, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
-
-test.assert_has_feature(
-    8, 136, 84, 'roads',
-    { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
+    test.assert_has_feature(
+        z, 17456 / coord_scale, 10780 / coord_scale, 'roads', props)

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -26,6 +26,10 @@ test.assert_no_matching_feature(
 
 # track with cycling route in Schartau, Germany
 # http://www.openstreetmap.org/way/58691615
+#
+# the track is part of this NCN relation, which needs to be present for the
+# min zoom to be assigned correctly.
+# http://www.openstreetmap.org/relation/2599024
 
 test.assert_has_feature(
     15, 17456, 10780, 'roads',
@@ -48,5 +52,5 @@ test.assert_has_feature(
     { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})
 
 test.assert_has_feature(
-    9, 136, 84, 'roads',
+    8, 136, 84, 'roads',
     { 'id': 58691615, 'kind_detail': 'track', 'surface': 'concrete_lanes'})


### PR DESCRIPTION
Two issues were preventing the test from passing:

1. The track by itself was only visible up to z13, as on its own it had no cycleway information. It is included in an NCN route relation, and including that in the test allowed the information to be joined onto the way to boost the min zoom to z8.
2. The final test was not a tile which included these features. Looks like a simple typo on the zoom level in the tile coordinate.

@matkoniecz, I hope this fixes #1344, and I would appreciate any comments you have.
