### PR TITLE
Make Natural Earth roads start at zoom 5

### DIFF
--- a/integration-test/1353-ne-min-zoom-roads.py
+++ b/integration-test/1353-ne-min-zoom-roads.py
@@ -1,0 +1,17 @@
+# note: uses existing fixture from 976-fractional-pois
+
+# the road should be present at zoom 5
+test.assert_has_feature(
+    5, 9, 12, 'roads',
+    { 'source': 'naturalearthdata.com', 'kind': 'highway',
+      'shield_text': '95' })
+
+# but not at zoom 3 or 4
+test.assert_no_matching_feature(
+    3, 2, 3, 'roads',
+    { 'source': 'naturalearthdata.com', 'kind': 'highway',
+      'shield_text': '95' })
+test.assert_no_matching_feature(
+    4, 4, 6, 'roads',
+    { 'source': 'naturalearthdata.com', 'kind': 'highway',
+      'shield_text': '95' })

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -13,7 +13,7 @@ test.assert_has_feature(
 
 test.assert_has_feature(
     7, 37, 48, 'roads',
-    { 'min_zoom': 3 , 'id': int, 'shield_text': '95',
+    { 'min_zoom': 5 , 'id': int, 'shield_text': '95',
     'source': 'naturalearthdata.com' })
 
 # There is no transit data from Natural Earth

--- a/queries/ne.jinja2
+++ b/queries/ne.jinja2
@@ -225,7 +225,7 @@ WHERE
 {% endif %}
 
 {# conditional roads include #}
-{% if zoom < 8 %}
+{% if zoom < 8 and zoom >= 5 %}
 UNION ALL
 
 --------------------------------------------------------------------------------
@@ -268,7 +268,7 @@ FROM
 WHERE
 
   {{ bounds['line']|bbox_filter('the_geom', 3857) }}
-  AND {{ zoom }} >= 5 AND scalerank <= {{ zoom }}
+  AND scalerank <= {{ zoom }}
 
 --------------------------------------------------------------------------------
 -- end roads

--- a/queries/ne.jinja2
+++ b/queries/ne.jinja2
@@ -247,7 +247,7 @@ SELECT
   NULL::jsonb AS __places_properties__,
 
   jsonb_build_object(
-      'min_zoom', scalerank,
+      'min_zoom', GREATEST(scalerank, 5),
       'scalerank', scalerank,
       'featurecla', featurecla,
       'type', type,
@@ -268,7 +268,7 @@ FROM
 WHERE
 
   {{ bounds['line']|bbox_filter('the_geom', 3857) }}
-  AND scalerank <= {{ zoom }}
+  AND {{ zoom }} >= 5 AND scalerank <= {{ zoom }}
 
 --------------------------------------------------------------------------------
 -- end roads

--- a/test-data-update-osm.sh
+++ b/test-data-update-osm.sh
@@ -59,7 +59,7 @@ fi
 
 curl -o update.osm $api_url
 xsltproc test-data-osm-template.xsl update.osm > update.osc
-osm2pgsql -s -C 1024 -S osm2pgsql.style --hstore-all -d $db -a -H localhost update.osc
+osm2pgsql -s -C 1024 -S osm2pgsql.style --hstore-all -d $db -a update.osc
 rm -f update.osc update.osm
 
 echo "Done!"

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -170,6 +170,14 @@ KNOWN_FUNCS = {
 }
 
 
+# this is a bit of a hack to force the type of expressions with least/greatest
+# in them to be of numeric type.
+FUNC_FORCE_TYPE = {
+    'LEAST':    float,
+    'GREATEST': float,
+}
+
+
 GLOBALS = [
     'way_area',
 ]
@@ -354,7 +362,7 @@ class SQLExpression(ast.NodeVisitor):
                 raise RuntimeError("Call to name not implemented yet: %r"
                                    % (name,))
             force_type = self.force_type
-            self.force_type = None
+            self.force_type = FUNC_FORCE_TYPE.get(func)
 
             self.buf.write(func)
             self.buf.write("(")

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -177,7 +177,7 @@ filters:
       scalerank: true
       featurecla: Road
       expressway: 1
-    min_zoom: { col: scalerank }
+    min_zoom: { clamp: { min: 5, max: 17, value: { col: scalerank } } }
     table: ne
     output:
       <<: *ne_properties
@@ -187,7 +187,7 @@ filters:
       scalerank: true
       featurecla: Road
       type: [Major Highway, Beltway, Bypass]
-    min_zoom: { col: scalerank }
+    min_zoom: { clamp: { min: 5, max: 17, value: { col: scalerank } } }
     table: ne
     output:
       <<: *ne_properties
@@ -197,7 +197,7 @@ filters:
       scalerank: true
       featurecla: Road
       type: Secondary Highway
-    min_zoom: { col: scalerank }
+    min_zoom: { clamp: { min: 5, max: 17, value: { col: scalerank } } }
     table: ne
     output:
       <<: *ne_properties
@@ -207,7 +207,7 @@ filters:
       scalerank: true
       featurecla: Road
       type: Road
-    min_zoom: { col: scalerank }
+    min_zoom: { clamp: { min: 5, max: 17, value: { col: scalerank } } }
     table: ne
     output:
       <<: *ne_properties
@@ -217,7 +217,7 @@ filters:
       scalerank: true
       featurecla: Road
       type: [Track, Unknown]
-    min_zoom: { col: scalerank }
+    min_zoom: { clamp: { min: 5, max: 17, value: { col: scalerank } } }
     table: ne
     output:
       <<: *ne_properties


### PR DESCRIPTION
It looks like the query doesn't (yet?) use the `mz_calculate_*_roads` functions for calculating the properties or min zoom, so both the YAML and queries have been changed to make sure roads only start showing up at zoom 5.

Connects to #1353.