### PR TITLE
Split up sources by templates

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -11,21 +11,33 @@ all:
 
 sources:
 
-  # NOTE: these are split this way to represent each query that goes to the database
+  # NOTE: each source represents a query to the database
+  # within each source, a list of templates can be used
+  # the templates will be combined with a sql `union all` in between
+  # therefore, it's necessary that the query results of each template
+  # have the same types
+
   planet_osm_polygon:
-    template: planet_osm_polygon.jinja2
+    - template: planet_osm_polygon.jinja2
   planet_osm_line:
-    template: planet_osm_line.jinja2
+    - template: planet_osm_line.jinja2
   planet_osm_point:
-    template: planet_osm_point.jinja2
+    - template: planet_osm_point.jinja2
+
   ne:
-    template: ne.jinja2
+    - template: ne.jinja2
+
   osmdata:
-    template: osmdata.jinja2
-    start_zoom: 8
+
+    - template: osmdata-earth.jinja2
+      start_zoom: 9
+
+    - template: osmdata-water.jinja2
+      start_zoom: 9
+
   wof:
-    template: wof.jinja2
-    start_zoom: 11
+    - template: wof.jinja2
+      start_zoom: 11
 
 layers:
   water:

--- a/queries.yaml
+++ b/queries.yaml
@@ -64,7 +64,7 @@ sources:
     # ne_10m_land
     - template: ne-earth-10m.jinja2
       zoom_start: 5
-      zoom_stop: 9
+      zoom_stop: 8
 
     ## landuse
 
@@ -108,7 +108,7 @@ sources:
     # ne_10m_lakes
     - template: ne-water-10m.jinja2
       zoom_start: 5
-      zoom_stop: 9
+      zoom_stop: 8
 
     # ne_50m_playas
     - template: ne-water-playas-50m.jinja2
@@ -118,15 +118,15 @@ sources:
     # ne_10m_playas
     - template: ne-water-playas-10m.jinja2
       zoom_start: 5
-      zoom_stop: 9
+      zoom_stop: 8
 
   osmdata:
 
     - template: osmdata-earth.jinja2
-      zoom_start: 9
+      zoom_start: 8
 
     - template: osmdata-water.jinja2
-      zoom_start: 9
+      zoom_start: 8
 
   wof:
     - template: wof.jinja2

--- a/queries.yaml
+++ b/queries.yaml
@@ -17,6 +17,8 @@ sources:
   # therefore, it's necessary that the query results of each template
   # have the same types
 
+  # NOTE: zoom_stop is exclusive
+
   planet_osm_polygon:
     - template: planet_osm_polygon.jinja2
   planet_osm_line:
@@ -25,19 +27,110 @@ sources:
     - template: planet_osm_point.jinja2
 
   ne:
-    - template: ne.jinja2
+    ## places
+    # ne_10m_populated_places
+    - template: ne-places.jinja2
+
+    ## boundaries
+
+    # ne_110m_admin_0_boundary_lines_land
+    - template: ne-boundaries-110m.jinja2
+      zoom_stop: 2
+
+    # ne_50m_admin_0_boundary_lines_land
+    # ne_50m_admin_1_states_provinces_lines
+    - template: ne-boundaries-50m.jinja2
+      zoom_start: 2
+      zoom_stop: 5
+
+    # ne_10m_admin_0_boundary_lines_land
+    # ne_10m_admin_0_boundary_lines_map_units
+    # ne_10m_admin_1_states_provinces_lines
+    - template: ne-boundaries-10m.jinja2
+      zoom_start: 5
+      zoom_stop: 8
+
+    ## earth
+
+    # ne_110m_land
+    - template: ne-earth-110m.jinja2
+      zoom_stop: 2
+
+    # ne_50m_land
+    - template: ne-earth-50m.jinja2
+      zoom_start: 2
+      zoom_stop: 5
+
+    # ne_10m_land
+    - template: ne-earth-10m.jinja2
+      zoom_start: 5
+      zoom_stop: 9
+
+    ## landuse
+
+    # ne_50m_urban_areas
+    - template: ne-landuse-50m.jinja2
+      zoom_start: 4
+      zoom_stop: 6
+
+    # ne_10m_urban_areas
+    - template: ne-landuse-10m.jinja2
+      zoom_start: 6
+      zoom_stop: 10
+
+    ## roads
+
+    # ne_10m_roads
+    - template: ne-roads.jinja2
+      zoom_start: 5
+      zoom_stop: 8
+
+    ## water
+
+    # ne_110m_ocean
+    # ne_110m_lakes
+    # ne_110m_coastline
+    # ne_110m_lakes
+    - template: ne-water-110m.jinja2
+      zoom_stop: 2
+
+    # ne_50m_ocean
+    # ne_50m_lakes
+    # ne_50m_coastline
+    # ne_50m_lakes
+    - template: ne-water-50m.jinja2
+      zoom_start: 2
+      zoom_stop: 5
+
+    # ne_10m_ocean
+    # ne_10m_lakes
+    # ne_10m_coastline
+    # ne_10m_lakes
+    - template: ne-water-10m.jinja2
+      zoom_start: 5
+      zoom_stop: 9
+
+    # ne_50m_playas
+    - template: ne-water-playas-50m.jinja2
+      zoom_start: 4
+      zoom_stop: 5
+
+    # ne_10m_playas
+    - template: ne-water-playas-10m.jinja2
+      zoom_start: 5
+      zoom_stop: 9
 
   osmdata:
 
     - template: osmdata-earth.jinja2
-      start_zoom: 9
+      zoom_start: 9
 
     - template: osmdata-water.jinja2
-      start_zoom: 9
+      zoom_start: 9
 
   wof:
     - template: wof.jinja2
-      start_zoom: 11
+      zoom_start: 11
 
 layers:
   water:

--- a/queries/ne-boundaries-10m.jinja2
+++ b/queries/ne-boundaries-10m.jinja2
@@ -1,0 +1,8 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_boundaries_query(True, 'ne_10m_admin_0_boundary_lines_land') }}
+UNION ALL
+{{ ne_boundaries_query(False, 'ne_10m_admin_0_boundary_lines_map_units') }}
+UNION ALL
+{{ ne_boundaries_query(True, 'ne_10m_admin_1_states_provinces_lines') }}
+{% endblock %}

--- a/queries/ne-boundaries-110m.jinja2
+++ b/queries/ne-boundaries-110m.jinja2
@@ -1,0 +1,4 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_boundaries_query(False, 'ne_110m_admin_0_boundary_lines_land') }}
+{% endblock %}

--- a/queries/ne-boundaries-50m.jinja2
+++ b/queries/ne-boundaries-50m.jinja2
@@ -1,0 +1,6 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_boundaries_query(False, 'ne_50m_admin_0_boundary_lines_land') }}
+UNION ALL
+{{ ne_boundaries_query(False, 'ne_50m_admin_1_states_provinces_lines') }}
+{% endblock %}

--- a/queries/ne-earth-10m.jinja2
+++ b/queries/ne-earth-10m.jinja2
@@ -1,0 +1,4 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_earth_query('ne_10m_land') }}
+{% endblock %}

--- a/queries/ne-earth-110m.jinja2
+++ b/queries/ne-earth-110m.jinja2
@@ -1,0 +1,4 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_earth_query('ne_110m_land') }}
+{% endblock %}

--- a/queries/ne-earth-50m.jinja2
+++ b/queries/ne-earth-50m.jinja2
@@ -1,0 +1,4 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_earth_query('ne_50m_land') }}
+{% endblock %}

--- a/queries/ne-landuse-10m.jinja2
+++ b/queries/ne-landuse-10m.jinja2
@@ -1,0 +1,4 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_landuse_query('ne_10m_urban_areas') }}
+{% endblock %}

--- a/queries/ne-landuse-50m.jinja2
+++ b/queries/ne-landuse-50m.jinja2
@@ -1,0 +1,4 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_landuse_query('ne_50m_urban_areas') }}
+{% endblock %}

--- a/queries/ne-places.jinja2
+++ b/queries/ne-places.jinja2
@@ -1,0 +1,41 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+SELECT
+
+  gid AS __id__,
+
+  {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
+  NULL::bytea AS __label__,
+
+  {{ ne_common_properties() }},
+
+  NULL::jsonb AS __boundaries_properties__,
+  NULL::jsonb AS __earth_properties__,
+  NULL::jsonb AS __landuse_properties__,
+
+  jsonb_build_object(
+    'name', name,
+    'population', pop_max::text,
+    'featurecla', featurecla,
+    'scalerank', scalerank,
+    'min_zoom', mz_places_min_zoom
+  ) AS __places_properties__,
+
+  NULL::jsonb AS __roads_properties__,
+  NULL::jsonb AS __water_properties__
+
+FROM ne_10m_populated_places
+
+WHERE
+
+  {{ bounds['point']|bbox_filter('the_geom', 3857) }} AND
+  mz_places_min_zoom < {{ zoom + 1 }}
+{% if zoom >= 8 and zoom < 10 %}
+  AND pop_max <= 50000
+{% elif zoom >= 10 and zoom < 11 %}
+  AND pop_max <= 20000
+{% elif zoom >= 11 %}
+  AND pop_max <= 5000
+{% endif %}
+
+{% endblock %}

--- a/queries/ne-roads.jinja2
+++ b/queries/ne-roads.jinja2
@@ -1,0 +1,42 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+
+SELECT
+
+  gid AS __id__,
+
+  {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
+  NULL::bytea AS __label__,
+
+  {{ ne_common_properties() }},
+
+  NULL::jsonb AS __boundaries_properties__,
+  NULL::jsonb AS __earth_properties__,
+  NULL::jsonb AS __landuse_properties__,
+  NULL::jsonb AS __places_properties__,
+
+  jsonb_build_object(
+      'min_zoom', scalerank,
+      'scalerank', scalerank,
+      'featurecla', featurecla,
+      'type', type,
+      'expressway', expressway,
+      'sov_a3', sov_a3,
+      'level', level,
+      'continent', continent,
+      'label', label,
+      'name', name
+  ) AS __roads_properties__,
+
+  NULL::jsonb AS __water_properties__
+
+FROM
+
+  ne_10m_roads
+
+WHERE
+
+  {{ bounds['line']|bbox_filter('the_geom', 3857) }}
+  AND scalerank <= {{ zoom }}
+
+{% endblock %}

--- a/queries/ne-water-10m.jinja2
+++ b/queries/ne-water-10m.jinja2
@@ -1,0 +1,11 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_water_query(False, True, False, False, True, 'ne_10m_ocean') }}
+UNION ALL
+{{ ne_water_query(False, True, True, False, True, 'ne_10m_lakes') }}
+UNION ALL
+{{ ne_water_query(False, False, False, True, False, 'ne_10m_coastline') }}
+UNION ALL
+-- boundaries
+{{ ne_water_query(True, True, True, True, True, 'ne_10m_lakes') }}
+{% endblock %}

--- a/queries/ne-water-110m.jinja2
+++ b/queries/ne-water-110m.jinja2
@@ -1,0 +1,11 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_water_query(False, True, False, False, True, 'ne_110m_ocean') }}
+UNION ALL
+{{ ne_water_query(False, True, True, False, True, 'ne_110m_lakes') }}
+UNION ALL
+{{ ne_water_query(False, False, False, True, False, 'ne_110m_coastline') }}
+UNION ALL
+-- boundaries
+{{ ne_water_query(True, True, True, True, True, 'ne_110m_lakes') }}
+{% endblock %}

--- a/queries/ne-water-50m.jinja2
+++ b/queries/ne-water-50m.jinja2
@@ -1,0 +1,11 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+{{ ne_water_query(False, True, False, False, True, 'ne_50m_ocean') }}
+UNION ALL
+{{ ne_water_query(False, True, True, False, True, 'ne_50m_lakes') }}
+UNION ALL
+{{ ne_water_query(False, False, False, True, False, 'ne_50m_coastline') }}
+UNION ALL
+-- boundaries
+{{ ne_water_query(True, True, True, True, True, 'ne_50m_lakes') }}
+{% endblock %}

--- a/queries/ne-water-playas-10m.jinja2
+++ b/queries/ne-water-playas-10m.jinja2
@@ -1,0 +1,8 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+-- polygons
+{{ ne_water_query(False, True, True, False, True, 'ne_10m_playas') }}
+UNION ALL
+-- boundaries
+{{ ne_water_query(True, True, True, True, True, 'ne_10m_playas') }}
+{% endblock %}

--- a/queries/ne-water-playas-50m.jinja2
+++ b/queries/ne-water-playas-50m.jinja2
@@ -1,0 +1,8 @@
+{% extends 'ne.jinja2' %}
+{% block query %}
+-- polygons
+{{ ne_water_query(False, True, True, False, True, 'ne_50m_playas') }}
+UNION ALL
+-- boundaries
+{{ ne_water_query(True, True, True, True, True, 'ne_50m_playas') }}
+{% endblock %}

--- a/queries/ne.jinja2
+++ b/queries/ne.jinja2
@@ -1,5 +1,3 @@
--- normalize layer properties throughout all
-
 {% macro ne_common_properties() %}
 
   -- common properties
@@ -8,64 +6,6 @@
   ) AS __properties__
 
 {% endmacro %}
-
-{# places query always present across all zooms, so include first #}
-{# simplifes UNION ALL combination logic #}
-
---------------------------------------------------------------------------------
--- places
---------------------------------------------------------------------------------
-
-SELECT
-
-  gid AS __id__,
-
-  {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
-  NULL::bytea AS __label__,
-
-  {{ ne_common_properties() }},
-
-  NULL::jsonb AS __boundaries_properties__,
-  NULL::jsonb AS __earth_properties__,
-  NULL::jsonb AS __landuse_properties__,
-
-  jsonb_build_object(
-    'name', name,
-    'population', pop_max::text,
-    'featurecla', featurecla,
-    'scalerank', scalerank,
-    'min_zoom', mz_places_min_zoom
-  ) AS __places_properties__,
-
-  NULL::jsonb AS __roads_properties__,
-  NULL::jsonb AS __water_properties__
-
-FROM ne_10m_populated_places
-
-WHERE
-
-  {{ bounds['point']|bbox_filter('the_geom', 3857) }} AND
-  mz_places_min_zoom < {{ zoom + 1 }}
-{% if zoom >= 8 and zoom < 10 %}
-  AND pop_max <= 50000
-{% elif zoom >= 10 and zoom < 11 %}
-  AND pop_max <= 20000
-{% elif zoom >= 11 %}
-  AND pop_max <= 5000
-{% endif %}
-
---------------------------------------------------------------------------------
--- end places
---------------------------------------------------------------------------------
-
-{# conditional boundaries include #}
-{% if zoom < 8 %}
-
-UNION ALL
-
---------------------------------------------------------------------------------
--- boundaries
---------------------------------------------------------------------------------
 
 {% macro ne_boundaries_query(name, table) %}
 
@@ -101,35 +41,7 @@ WHERE
 
 {% endmacro %}
 
-{% if zoom < 2 %}
-{{ ne_boundaries_query(False, 'ne_110m_admin_0_boundary_lines_land') }}
-{% elif 2 <= zoom < 5 %}
-{{ ne_boundaries_query(False, 'ne_50m_admin_0_boundary_lines_land') }}
-UNION ALL
-{{ ne_boundaries_query(False, 'ne_50m_admin_1_states_provinces_lines') }}
-{% elif 5 <= zoom < 8 %}
-{{ ne_boundaries_query(True, 'ne_10m_admin_0_boundary_lines_land') }}
-UNION ALL
-{{ ne_boundaries_query(False, 'ne_10m_admin_0_boundary_lines_map_units') }}
-UNION ALL
-{{ ne_boundaries_query(True, 'ne_10m_admin_1_states_provinces_lines') }}
-{% endif %}
-
---------------------------------------------------------------------------------
--- end boundaries
---------------------------------------------------------------------------------
-
-{# end conditional boundaries include #}
-{% endif %}
-
-{# conditional earth include #}
-{% if zoom < 8 %}
-
-UNION ALL
-
---------------------------------------------------------------------------------
--- earth
---------------------------------------------------------------------------------
+{% macro ne_earth_query(table) %}
 
 SELECT
 
@@ -151,36 +63,15 @@ SELECT
   NULL::jsonb AS __roads_properties__,
   NULL::jsonb AS __water_properties__
 
-FROM
-{% if zoom < 2 %}
-  ne_110m_land t
-{% elif 2 <= zoom < 5 %}
-  ne_50m_land t
-{% elif 5 <= zoom < 8 %}
-  ne_10m_land t
-{% endif %}
+FROM {{ table }}
 
 WHERE
   mz_earth_min_zoom < {{ zoom + 1 }} AND
   {{ bounds['polygon']|bbox_filter('the_geom', 3857) }}
 
---------------------------------------------------------------------------------
--- end earth
---------------------------------------------------------------------------------
+{% endmacro %}
 
-{# end conditional earth include #}
-{% endif %}
-
-{# conditional landuse include #}
-{% if zoom < 10 %}
-
-UNION ALL
-
---------------------------------------------------------------------------------
--- landuse
---------------------------------------------------------------------------------
-
-{% macro ne_landuse(table) %}
+{% macro ne_landuse_query(table) %}
 
 SELECT
 
@@ -210,82 +101,7 @@ WHERE
 
 {% endmacro %}
 
-{% if 4 <= zoom < 6 %}
-{{ ne_landuse('ne_50m_urban_areas') }}
-{% elif zoom < 10 %}
-{{ ne_landuse('ne_10m_urban_areas') }}
-{% endif %}
-
---------------------------------------------------------------------------------
--- end landuse
---------------------------------------------------------------------------------
-
-{# end conditional landuse include #}
-{% endif %}
-
-{# conditional roads include #}
-{% if zoom < 8 and zoom >= 5 %}
-UNION ALL
-
---------------------------------------------------------------------------------
--- roads
---------------------------------------------------------------------------------
-
-SELECT
-
-  gid AS __id__,
-
-  {% filter geometry %}the_geom{% endfilter %} AS __geometry__,
-  NULL::bytea AS __label__,
-
-  {{ ne_common_properties() }},
-
-  NULL::jsonb AS __boundaries_properties__,
-  NULL::jsonb AS __earth_properties__,
-  NULL::jsonb AS __landuse_properties__,
-  NULL::jsonb AS __places_properties__,
-
-  jsonb_build_object(
-      'min_zoom', scalerank,
-      'scalerank', scalerank,
-      'featurecla', featurecla,
-      'type', type,
-      'expressway', expressway,
-      'sov_a3', sov_a3,
-      'level', level,
-      'continent', continent,
-      'label', label,
-      'name', name
-  ) AS __roads_properties__,
-
-  NULL::jsonb AS __water_properties__
-
-FROM
-
-  ne_10m_roads
-
-WHERE
-
-  {{ bounds['line']|bbox_filter('the_geom', 3857) }}
-  AND scalerank <= {{ zoom }}
-
---------------------------------------------------------------------------------
--- end roads
---------------------------------------------------------------------------------
-
-{# end conditional roads include #}
-{% endif %}
-
-{# conditional water include #}
-{% if zoom < 8 %}
-
-UNION ALL
-
---------------------------------------------------------------------------------
--- water
---------------------------------------------------------------------------------
-
-{% macro ne_water(boundary_geometry, label_geometry, name, boundary, has_area, table) %}
+{% macro ne_water_query(boundary_geometry, label_geometry, name, boundary, has_area, table) %}
 
 SELECT
 
@@ -332,70 +148,5 @@ WHERE
 
 {% endmacro %}
 
-{% if zoom < 2 %}
-{{ ne_water(False, True, False, False, True, 'ne_110m_ocean') }}
-{% elif 2 <= zoom < 5 %}
-{{ ne_water(False, True, False, False, True, 'ne_50m_ocean') }}
-{% elif 5 <= zoom < 8 %}
-{{ ne_water(False, True, False, False, True, 'ne_10m_ocean') }}
-{% endif %}
-
-UNION ALL
-
-{% if zoom < 2 %}
-{{ ne_water(False, True, True, False, True, 'ne_110m_lakes') }}
-{% elif 2 <= zoom < 5 %}
-{{ ne_water(False, True, True, False, True, 'ne_50m_lakes') }}
-{% elif 5 <= zoom < 8 %}
-{{ ne_water(False, True, True, False, True, 'ne_10m_lakes') }}
-{% endif %}
-
-UNION ALL
-
-{% if zoom < 2 %}
-{{ ne_water(False, False, False, True, False, 'ne_110m_coastline') }}
-{% elif 2 <= zoom < 5 %}
-{{ ne_water(False, False, False, True, False, 'ne_50m_coastline') }}
-{% elif 5 <= zoom < 8 %}
-{{ ne_water(False, False, False, True, False, 'ne_10m_coastline') }}
-{% endif %}
-
-UNION ALL
-
-{% if zoom < 2 %}
-{{ ne_water(True, True, True, True, True, 'ne_110m_lakes') }}
-{% elif 2 <= zoom < 5 %}
-{{ ne_water(True, True, True, True, True, 'ne_50m_lakes') }}
-{% elif 5 <= zoom < 8 %}
-{{ ne_water(True, True, True, True, True, 'ne_10m_lakes') }}
-{% endif %}
-
-{# playas #}
-{% if 4 <= zoom < 8 %}
-
-UNION ALL
-
--- playa polygons
-{% if 4 <= zoom < 5 %}
-{{ ne_water(False, True, True, False, True, 'ne_50m_playas') }}
-{% elif 5 <= zoom < 8 %}
-{{ ne_water(False, True, True, False, True, 'ne_10m_playas') }}
-{% endif %}
-
-UNION ALL
-
--- playa boundaries
-{% if 4 <= zoom < 5 %}
-{{ ne_water(True, True, True, True, True, 'ne_50m_playas') }}
-{% elif 5 <= zoom < 8 %}
-{{ ne_water(True, True, True, True, True, 'ne_10m_playas') }}
-{% endif %}
-
-{% endif %}
-
---------------------------------------------------------------------------------
--- end water
---------------------------------------------------------------------------------
-
-{# end conditional water #}
-{% endif %}
+{% block query %}
+{% endblock %}

--- a/queries/osmdata-earth.jinja2
+++ b/queries/osmdata-earth.jinja2
@@ -1,0 +1,4 @@
+{% extends 'osmdata.jinja2' %}
+{% block query %}
+{{ osmdata_query(False, 'mz_earth_min_zoom', True) }}
+{% endblock %}

--- a/queries/osmdata-water.jinja2
+++ b/queries/osmdata-water.jinja2
@@ -1,0 +1,4 @@
+{% extends 'osmdata.jinja2' %}
+{% block query %}
+{{ osmdata_query(True, 'mz_water_min_zoom', False) }}
+{% endblock %}

--- a/queries/osmdata.jinja2
+++ b/queries/osmdata.jinja2
@@ -34,8 +34,5 @@ WHERE
 
 {% endmacro %}
 
-{{ osmdata_query(False, 'mz_earth_min_zoom', True) }}
-
-UNION ALL
-
-{{ osmdata_query(True, 'mz_water_min_zoom', False) }}
+{% block query %}
+{% endblock %}


### PR DESCRIPTION
This allows specifing start and stop zooms within a particular source, on a template level. The python code will take the templates for a particular source, and merge them together with a `UNION ALL`.

Some of the tests are currently failing. Will still need to look into those.