### PR TITLE
Fix safe_int area error

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -266,6 +266,12 @@ class LanduseTest(unittest.TestCase):
         out_props = self.landuse.fn(None, props, None, meta)
         self.assertEquals(4, out_props.get('min_zoom'))
 
+    def test_area_tag(self):
+        props = dict(barrier='fence', area='no')
+        meta = make_test_metadata()
+        out_props = self.landuse.fn(None, props, None, meta)
+        self.assertIsNone(out_props.get('area'))
+
 
 class PlacesTest(unittest.TestCase):
 

--- a/vectordatasource/util.py
+++ b/vectordatasource/util.py
@@ -101,4 +101,8 @@ def is_building(building_tag, building_part_tag):
 def safe_int(x):
     if x is None:
         return None
-    return int(x)
+    try:
+        return int(x)
+    except ValueError:
+        pass
+    return None


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/1373

The fix was [cherry picked](https://github.com/tilezen/vector-datasource/commit/d37710068c8df838df6c727c43c0f23f022513a6) from the local-fixtures branch. Instead of merging this we can just wait until that branch lands. A test was added in this pr in a separate commit too.