### PR TITLE
Shorten index names

### DIFF
--- a/data/apply-planet_osm_line.sql
+++ b/data/apply-planet_osm_line.sql
@@ -33,8 +33,8 @@ UPDATE planet_osm_line
   SET mz_label_placement = ST_PointOnSurface(way);
 
 -- only these 2 columns are relevant in lower zoom queries
-CREATE
-  INDEX planet_osm_line_geom_min_zoom_8_index
+CREATE INDEX
+  planet_osm_line_geom_min_zoom_8_index
   ON planet_osm_line USING gist(way)
   WHERE
     mz_landuse_min_zoom < 8 OR

--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -46,7 +46,7 @@ UPDATE planet_osm_polygon
 
 -- polygon low zoom
 CREATE INDEX
-  planet_osm_polygon_landuse_poi_transit_geom_7_index
+  planet_osm_polygon_geom_min_zoom_7_index
   ON planet_osm_polygon USING gist(way)
   WHERE
     mz_landuse_min_zoom < 7 OR

--- a/data/migrations/v1.5.0-planet_osm_line.sql
+++ b/data/migrations/v1.5.0-planet_osm_line.sql
@@ -1,6 +1,6 @@
 -- only these 2 columns are relevant in lower zoom queries
-CREATE
-  INDEX planet_osm_line_landuse_transit_geom_8_index
+CREATE INDEX
+  planet_osm_line_geom_min_zoom_8_index
   ON planet_osm_line USING gist(way)
   WHERE
     mz_landuse_min_zoom < 8 OR
@@ -8,7 +8,7 @@ CREATE
 
 -- ladder the higher zoom level indexes
 CREATE INDEX IF NOT EXISTS
-  planet_osm_line_earth_landuse_road_transit_water_geom_9_index
+  planet_osm_line_geom_min_zoom_9_index
   ON planet_osm_line USING gist(way)
   WHERE
     mz_earth_min_zoom < 9 OR
@@ -18,7 +18,7 @@ CREATE INDEX IF NOT EXISTS
     mz_water_min_zoom < 9;
 
 CREATE INDEX IF NOT EXISTS
-  planet_osm_line_earth_landuse_road_transit_water_geom_12_index
+  planet_osm_line_geom_min_zoom_12_index
   ON planet_osm_line USING gist(way)
   WHERE
     mz_earth_min_zoom < 12 OR
@@ -28,7 +28,7 @@ CREATE INDEX IF NOT EXISTS
     mz_water_min_zoom < 12;
 
 CREATE INDEX IF NOT EXISTS
-  planet_osm_line_earth_landuse_road_transit_water_geom_15_index
+  planet_osm_line_geom_min_zoom_15_index
   ON planet_osm_line USING gist(way)
   WHERE
     mz_earth_min_zoom < 15 OR
@@ -38,7 +38,7 @@ CREATE INDEX IF NOT EXISTS
     mz_water_min_zoom < 15;
 
 CREATE INDEX IF NOT EXISTS
-  planet_osm_line_earth_landuse_road_transit_water_geom_index
+  planet_osm_line_geom_min_zoom_index
   ON planet_osm_line USING gist(way)
   WHERE
     mz_earth_min_zoom IS NOT NULL OR

--- a/data/migrations/v1.5.0-planet_osm_point.sql
+++ b/data/migrations/v1.5.0-planet_osm_point.sql
@@ -1,5 +1,6 @@
 -- ladder the point indexes
-CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geom_6_index
+CREATE INDEX IF NOT EXISTS
+  planet_osm_point_geom_min_zoom_6_index
   ON planet_osm_point USING gist(way)
   WHERE
     mz_building_min_zoom < 6 OR
@@ -8,7 +9,8 @@ CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geo
     mz_poi_min_zoom < 6 OR
     mz_water_min_zoom < 6;
 
-CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geom_9_index
+CREATE INDEX IF NOT EXISTS
+  planet_osm_point_geom_min_zoom_9_index
   ON planet_osm_point USING gist(way)
   WHERE
     mz_building_min_zoom < 9 OR
@@ -17,7 +19,8 @@ CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geo
     mz_poi_min_zoom < 9 OR
     mz_water_min_zoom < 9;
 
-CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geom_12_index
+CREATE INDEX IF NOT EXISTS
+  planet_osm_point_geom_min_zoom_12_index
   ON planet_osm_point USING gist(way)
   WHERE
     mz_building_min_zoom < 12 OR
@@ -26,7 +29,8 @@ CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geo
     mz_poi_min_zoom < 12 OR
     mz_water_min_zoom < 12;
 
-CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geom_15_index
+CREATE INDEX IF NOT EXISTS
+  planet_osm_point_geom_min_zoom_15_index
   ON planet_osm_point USING gist(way)
   WHERE
     mz_building_min_zoom < 15 OR
@@ -35,7 +39,8 @@ CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geo
     mz_poi_min_zoom < 15 OR
     mz_water_min_zoom < 15;
 
-CREATE INDEX IF NOT EXISTS planet_osm_point_building_earth_places_pois_water_geom_index
+CREATE INDEX IF NOT EXISTS
+  planet_osm_point_geom_min_zoom_index
   ON planet_osm_point USING gist(way)
   WHERE
     mz_building_min_zoom IS NOT NULL OR

--- a/data/migrations/v1.5.0-planet_osm_polygon.sql
+++ b/data/migrations/v1.5.0-planet_osm_polygon.sql
@@ -1,6 +1,6 @@
 -- polygon low zoom
 CREATE INDEX IF NOT EXISTS
-  planet_osm_polygon_landuse_poi_transit_geom_7_index
+  planet_osm_polygon_geom_min_zoom_7_index
   ON planet_osm_polygon USING gist(way)
   WHERE
     mz_landuse_min_zoom < 7 OR
@@ -9,7 +9,7 @@ CREATE INDEX IF NOT EXISTS
 
 -- polygon zoom 7 specific query
 CREATE INDEX IF NOT EXISTS
-  planet_osm_polygon_earth_landuse_poi_transit_geom_8_index
+  planet_osm_polygon_geom_min_zoom_8_index
   ON planet_osm_polygon USING gist(way)
   WHERE
     mz_earth_min_zoom < 8 OR
@@ -19,7 +19,7 @@ CREATE INDEX IF NOT EXISTS
 
 -- ladder the rest of the polygon queries
 CREATE INDEX IF NOT EXISTS
-  planet_osm_polygon_building_earth_landuse_poi_transit_water_geom_9_index
+  planet_osm_polygon_geom_min_zoom_9_index
   ON planet_osm_polygon USING gist(way)
   WHERE
     mz_building_min_zoom < 9 OR
@@ -30,7 +30,7 @@ CREATE INDEX IF NOT EXISTS
     mz_water_min_zoom < 9;
 
 CREATE INDEX IF NOT EXISTS
-  planet_osm_polygon_building_earth_landuse_poi_transit_water_geom_12_index
+  planet_osm_polygon_geom_min_zoom_12_index
   ON planet_osm_polygon USING gist(way)
   WHERE
     mz_building_min_zoom < 12 OR
@@ -41,7 +41,7 @@ CREATE INDEX IF NOT EXISTS
     mz_water_min_zoom < 12;
 
 CREATE INDEX IF NOT EXISTS
-  planet_osm_polygon_building_earth_landuse_poi_transit_water_geom_15_index
+  planet_osm_polygon_geom_min_zoom_15_index
   ON planet_osm_polygon USING gist(way)
   WHERE
     mz_building_min_zoom < 15 OR
@@ -52,7 +52,7 @@ CREATE INDEX IF NOT EXISTS
     mz_water_min_zoom < 15;
 
 CREATE INDEX IF NOT EXISTS
-  planet_osm_polygon_building_earth_landuse_poi_transit_water_geom_index
+  planet_osm_polygon_geom_min_zoom_index
   ON planet_osm_polygon USING gist(way)
   WHERE
     mz_building_min_zoom IS NOT NULL OR


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/296

Postgresql has a limit on index names. Shorten the naming convention
used to ensure that they are all valid.