### PR TITLE
Update planet polygon query and indexes

### DIFF
--- a/data/apply-planet_osm_polygon.sql
+++ b/data/apply-planet_osm_polygon.sql
@@ -68,6 +68,7 @@ CREATE INDEX
   planet_osm_polygon_geom_min_zoom_9_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom < 9 OR
     mz_building_min_zoom < 9 OR
     mz_earth_min_zoom < 9 OR
     mz_landuse_min_zoom < 9 OR
@@ -79,6 +80,7 @@ CREATE INDEX
   planet_osm_polygon_geom_min_zoom_12_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom < 12 OR
     mz_building_min_zoom < 12 OR
     mz_earth_min_zoom < 12 OR
     mz_landuse_min_zoom < 12 OR
@@ -90,6 +92,7 @@ CREATE INDEX
   planet_osm_polygon_geom_min_zoom_15_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom < 15 OR
     mz_building_min_zoom < 15 OR
     mz_earth_min_zoom < 15 OR
     mz_landuse_min_zoom < 15 OR
@@ -101,6 +104,7 @@ CREATE INDEX
   planet_osm_polygon_geom_min_zoom_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom IS NOT NULL OR
     mz_building_min_zoom IS NOT NULL OR
     mz_earth_min_zoom IS NOT NULL OR
     mz_landuse_min_zoom IS NOT NULL OR

--- a/data/migrations/v1.5.0-planet_osm_polygon.sql
+++ b/data/migrations/v1.5.0-planet_osm_polygon.sql
@@ -22,6 +22,7 @@ CREATE INDEX IF NOT EXISTS
   planet_osm_polygon_geom_min_zoom_9_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom < 9 OR
     mz_building_min_zoom < 9 OR
     mz_earth_min_zoom < 9 OR
     mz_landuse_min_zoom < 9 OR
@@ -33,6 +34,7 @@ CREATE INDEX IF NOT EXISTS
   planet_osm_polygon_geom_min_zoom_12_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom < 12 OR
     mz_building_min_zoom < 12 OR
     mz_earth_min_zoom < 12 OR
     mz_landuse_min_zoom < 12 OR
@@ -44,6 +46,7 @@ CREATE INDEX IF NOT EXISTS
   planet_osm_polygon_geom_min_zoom_15_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom < 15 OR
     mz_building_min_zoom < 15 OR
     mz_earth_min_zoom < 15 OR
     mz_landuse_min_zoom < 15 OR
@@ -55,6 +58,7 @@ CREATE INDEX IF NOT EXISTS
   planet_osm_polygon_geom_min_zoom_index
   ON planet_osm_polygon USING gist(way)
   WHERE
+    mz_boundary_min_zoom IS NOT NULL OR
     mz_building_min_zoom IS NOT NULL OR
     mz_earth_min_zoom IS NOT NULL OR
     mz_landuse_min_zoom IS NOT NULL OR

--- a/queries/planet_osm_polygon.jinja2
+++ b/queries/planet_osm_polygon.jinja2
@@ -128,23 +128,37 @@ FROM (
 
 -- the logic for the filters is slightly different based on whether it's a boundary or not
 {% if zoom >= 16 %}
-    (mz_boundary_min_zoom IS NOT NULL AND {{ bounds['line']|bbox_overlaps('way', 3857) }}) OR
     ({{ bounds['polygon']|bbox_filter('way', 3857) }} AND
-      (mz_building_min_zoom IS NOT NULL OR
-       mz_earth_min_zoom IS NOT NULL OR
-       mz_landuse_min_zoom IS NOT NULL OR
-       mz_poi_min_zoom IS NOT NULL OR
-       mz_transit_level IS NOT NULL OR
-       mz_water_min_zoom IS NOT NULL))
+     (mz_boundary_min_zoom IS NOT NULL OR
+      mz_building_min_zoom IS NOT NULL OR
+      mz_earth_min_zoom IS NOT NULL OR
+      mz_landuse_min_zoom IS NOT NULL OR
+      mz_poi_min_zoom IS NOT NULL OR
+      mz_transit_level IS NOT NULL OR
+      mz_water_min_zoom IS NOT NULL)) AND
+    ((mz_boundary_min_zoom IS NOT NULL AND {{ bounds['line']|bbox_overlaps('way', 3857) }}) OR
+     (mz_building_min_zoom IS NOT NULL OR
+      mz_earth_min_zoom IS NOT NULL OR
+      mz_landuse_min_zoom IS NOT NULL OR
+      mz_poi_min_zoom IS NOT NULL OR
+      mz_transit_level IS NOT NULL OR
+      mz_water_min_zoom IS NOT NULL))
 {% elif zoom >= 8 %}
-    (mz_boundary_min_zoom < {{ zoom + 1 }} AND {{ bounds['line']|bbox_overlaps('way', 3857) }}) OR
     ({{ bounds['polygon']|bbox_filter('way', 3857) }} AND
-      (mz_building_min_zoom < {{ zoom + 1 }} OR
-       mz_earth_min_zoom < {{ zoom + 1 }} OR
-       mz_landuse_min_zoom < {{ zoom + 1 }} OR
-       mz_poi_min_zoom < {{ zoom + 1 }} OR
-       mz_transit_level < {{ zoom + 1 }} OR
-       mz_water_min_zoom < {{ zoom + 1 }}))
+     (mz_boundary_min_zoom < {{ zoom + 1 }} OR
+      mz_building_min_zoom < {{ zoom + 1 }} OR
+      mz_earth_min_zoom < {{ zoom + 1 }} OR
+      mz_landuse_min_zoom < {{ zoom + 1 }} OR
+      mz_poi_min_zoom < {{ zoom + 1 }} OR
+      mz_transit_level < {{ zoom + 1 }} OR
+      mz_water_min_zoom < {{ zoom + 1 }})) AND
+    ((mz_boundary_min_zoom < {{ zoom + 1 }} AND {{ bounds['line']|bbox_overlaps('way', 3857) }}) OR
+     (mz_building_min_zoom < {{ zoom + 1 }} OR
+      mz_earth_min_zoom < {{ zoom + 1 }} OR
+      mz_landuse_min_zoom < {{ zoom + 1 }} OR
+      mz_poi_min_zoom < {{ zoom + 1 }} OR
+      mz_transit_level < {{ zoom + 1 }} OR
+      mz_water_min_zoom < {{ zoom + 1 }}))
 {% elif zoom >= 7 %}
     ({{ bounds['polygon']|bbox_filter('way', 3857) }} AND
       (mz_earth_min_zoom < {{ zoom + 1 }} OR


### PR DESCRIPTION
Connects to #1380

The query planner was previously not able to use the index for zooms 8+ due to the boundary logic in the filter. This creates an index that represents the superset of the results, and updates the query to coerce the planner into using this index and then filtering out any extraneous results.