### PR TITLE
Fix scripts to upload tile coordinates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,14 +187,14 @@ Create a new test for the issue in `integration-test` dir. Sometimes it's helpfu
 
 #### Example test
 
-The unit tests are written using the `unittest` framework, which has been subclassed in `OsmFixtureTest` to provide some useful methods. This means that each test starts with the import of `OsmFixtureTest`, and defines a test class. These make it slightly harder to see what's going on, but are necessary to fit into the way `unittest` structures tests.
+The unit tests are written using the `unittest` framework, which has been subclassed in `FixtureTest` to provide some useful methods. This means that each test starts with the import of `OsmFixtureTest`, and defines a test class. These make it slightly harder to see what's going on, but are necessary to fit into the way `unittest` structures tests.
 
 
 ```python
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class CampGroundZoom(OsmFixtureTest):
+class CampGroundZoom(FixtureTest):
 
     def test_camp_ground_in_landuse_layer(self):
         self.load_fixtures([
@@ -288,7 +288,7 @@ But the tests require this to be formatted like:
 
 #### Common test types
 
-The `OsmFixtureTest` class provides several useful tests (called using `self.`):
+The `FixtureTest` class provides several useful tests (called using `self.`):
 
 - `assert_has_feature`
 - `assert_no_matching_feature`

--- a/TESTS.md
+++ b/TESTS.md
@@ -54,7 +54,7 @@ Unit tests go in the `tests/` subdirectory. Each should be a Python file, and us
 
 Integration tests go in the `integration-tests/` subdirectory. Each should be a Python file, but uses a custom test harness which can be found in the `integration-test/__init__.py` file. Tests are generally named starting with the issue number of any issue which led to the test being written and a short description of the issue. It can he helpful if the description is the same as the git branch on which the issue is being addressed.
 
-The integration test defines a `unittest` compatible class called `OsmFixtureTest` which provides useful tile-related test functions such as:
+The integration test defines a `unittest` compatible class called `FixtureTest` which provides useful tile-related test functions such as:
 
 * `assert_has_feature(z, x, y, layer, properties)` fails the test if the tile with coordinate `z/x/y` doesn't contain a feature matching `properties` in layer `layer`.
 * `assert_at_least_n_features(z, x, y, layer, properties, n)` fails the test if the tile layer doesn't contain at least `n` matching features.

--- a/integration-test/1012-sort_key-boundary.py
+++ b/integration-test/1012-sort_key-boundary.py
@@ -1,8 +1,8 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 # Adds tests for OSM features (but not NE features)
-class SortKeyBoundary(OsmFixtureTest):
+class SortKeyBoundary(FixtureTest):
 
     def test_usa_country_boundary(self):
         # country boundary of USA

--- a/integration-test/1016-missing-localized-names.py
+++ b/integration-test/1016-missing-localized-names.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MissingLocalizedNames(OsmFixtureTest):
+class MissingLocalizedNames(FixtureTest):
     def test_nj_ny_state_boundary(self):
         # New Jersey - New York state boundary
         self.load_fixtures([

--- a/integration-test/1020-roads-surface.py
+++ b/integration-test/1020-roads-surface.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadsSurface(OsmFixtureTest):
+class RoadsSurface(FixtureTest):
 
     def test_road_surface(self):
         # Add surface properties to roads layer (at max zooms)

--- a/integration-test/1030-invalid-wkb-polygons.py
+++ b/integration-test/1030-invalid-wkb-polygons.py
@@ -1,4 +1,4 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 from mapbox_vector_tile.decoder import POLYGON
 
 
@@ -25,7 +25,7 @@ def area_of(polygons):
     return area
 
 
-class InvalidWkbPolygons(OsmFixtureTest):
+class InvalidWkbPolygons(FixtureTest):
 
     def test_caspian_sea_exists(self):
         # Caspian Sea

--- a/integration-test/1091-missing-name-short.py
+++ b/integration-test/1091-missing-name-short.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MissingNameShort(OsmFixtureTest):
+class MissingNameShort(FixtureTest):
     def test_missouri(self):
         self.load_fixtures([
             'http://www.openstreetmap.org/node/473849775',

--- a/integration-test/1103-no-natural-pois.py
+++ b/integration-test/1103-no-natural-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NoNaturalPois(OsmFixtureTest):
+class NoNaturalPois(FixtureTest):
 
     def test_unnamed_natural_wood_hyde_park_london(self):
         # example from ticket: an unnamed natural=wood in Hyde Park, London

--- a/integration-test/1106-merge-ocean-earth.py
+++ b/integration-test/1106-merge-ocean-earth.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MergeOceanEarth(OsmFixtureTest):
+class MergeOceanEarth(FixtureTest):
     def test_ne_water(self):
         # There should be a single, merged feature in each of these tiles
         # Natural Earth

--- a/integration-test/1140-fix-city-names.py
+++ b/integration-test/1140-fix-city-names.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class FixCityNames(OsmFixtureTest):
+class FixCityNames(FixtureTest):
 
     def setUp(self):
         # need to call this to make sure the environment exists.

--- a/integration-test/1147-bicycle-ramps.py
+++ b/integration-test/1147-bicycle-ramps.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BicycleRamps(OsmFixtureTest):
+class BicycleRamps(FixtureTest):
 
     def test_ramp_properties_on_path(self):
         # Add ramp properties to paths in roads layer

--- a/integration-test/1170-very-early-paths-and-bike-routes.py
+++ b/integration-test/1170-very-early-paths-and-bike-routes.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class VeryEarlyPathsAndBikeRoutes(OsmFixtureTest):
+class VeryEarlyPathsAndBikeRoutes(FixtureTest):
 
     def test_path_with_international_route(self):
         # highway=path, with route inter-national

--- a/integration-test/1171-bicycle-yes-designated-roads.py
+++ b/integration-test/1171-bicycle-yes-designated-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BicycleYesDesignatedRoads(OsmFixtureTest):
+class BicycleYesDesignatedRoads(FixtureTest):
 
     def test_bicycle_yes(self):
         # Add bicycle properties to roads

--- a/integration-test/1175-bicycle-route-refs.py
+++ b/integration-test/1175-bicycle-route-refs.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BicycleRouteRefs(OsmFixtureTest):
+class BicycleRouteRefs(FixtureTest):
 
     def test_lcn45(self):
         # https://www.openstreetmap.org/way/417389551

--- a/integration-test/1178-earlier-piers.py
+++ b/integration-test/1178-earlier-piers.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class EarlierPiers(OsmFixtureTest):
+class EarlierPiers(FixtureTest):
 
     def test_very_large_pier(self):
         # a very, very large pier which alters the coastline visually, so

--- a/integration-test/1185-garden-min-zoom.py
+++ b/integration-test/1185-garden-min-zoom.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class GardenMinZoom(OsmFixtureTest):
+class GardenMinZoom(FixtureTest):
     def test_very_small_garden(self):
         # this garden previously had a min_zoom of 12, but based on its size
         # should be z16 instead.

--- a/integration-test/1186-the-pois-with-no-name.py
+++ b/integration-test/1186-the-pois-with-no-name.py
@@ -1,9 +1,9 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 # this is a collection of features which have no name and therefore should be
 # excluded from being POIs.
-class ThePoisWithNoName(OsmFixtureTest):
+class ThePoisWithNoName(FixtureTest):
 
     def test_trail_riding_station(self):
         # originally from 440-zoos-and-other-attractions-tourism.py

--- a/integration-test/1190-mz-colours.py
+++ b/integration-test/1190-mz-colours.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MzColours(OsmFixtureTest):
+class MzColours(FixtureTest):
     def test_colour_property(self):
         self.load_fixtures(['http://www.openstreetmap.org/relation/366773'])
 

--- a/integration-test/1191-improve-road-line-merging.py
+++ b/integration-test/1191-improve-road-line-merging.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ImproveRoadLineMerging(OsmFixtureTest):
+class ImproveRoadLineMerging(FixtureTest):
 
     def _assert_is_linestring(self, z, x, y, layer, name,
                               max_coords, max_count):

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BusRouteRefs(OsmFixtureTest):
+class BusRouteRefs(FixtureTest):
     def test_one_bus_route(self):
         # Sloat Blvd, part of:
         #   type=route, route=bus, network="", ref=23

--- a/integration-test/1211-fix-null-network.py
+++ b/integration-test/1211-fix-null-network.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class FixNullNetwork(OsmFixtureTest):
+class FixNullNetwork(FixtureTest):
     def test_routes_with_no_network(self):
         # ref="N 4", route=road, but no network=*
         # so we should get something that has no network, but a shield text of

--- a/integration-test/1215-fix-bad-unicode-shield-text.py
+++ b/integration-test/1215-fix-bad-unicode-shield-text.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class FixBadUnicodeShieldText(OsmFixtureTest):
+class FixBadUnicodeShieldText(FixtureTest):
 
     def test_cyrillic(self):
         # route relation with a cyrillic capital letter Ka at the end.

--- a/integration-test/1218-poni-whitelist.py
+++ b/integration-test/1218-poni-whitelist.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class PoniWhitelist(OsmFixtureTest):
+class PoniWhitelist(FixtureTest):
 
     def test_aeroway_helipad(self):
         # aeroway=helipad

--- a/integration-test/1224-earlier-bike-properties.py
+++ b/integration-test/1224-earlier-bike-properties.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class EarlierBikeProperties(OsmFixtureTest):
+class EarlierBikeProperties(FixtureTest):
     def test_bobcat_trail(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/12188550'])
 

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadsSurface(OsmFixtureTest):
+class RoadsSurface(FixtureTest):
     def test_cobblestones(self):
         # Add surface properties to roads layer (at max zooms)
         # Prince St with cobblestones in Alexandria, VA

--- a/integration-test/1273-roads-access.py
+++ b/integration-test/1273-roads-access.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadsAccess(OsmFixtureTest):
+class RoadsAccess(FixtureTest):
 
     def test_restricted_access(self):
         # Add surface properties to roads layer (at max zooms)

--- a/integration-test/1298-missing-road.py
+++ b/integration-test/1298-missing-road.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MissingRoad(OsmFixtureTest):
+class MissingRoad(FixtureTest):
     def test_route_611(self):
         # Relation: route 611 (975266)
         self.load_fixtures(

--- a/integration-test/1337-roads-surface-cobblestone-value-transformed.py
+++ b/integration-test/1337-roads-surface-cobblestone-value-transformed.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadsSurfaceCobblestoneValueTransformed(OsmFixtureTest):
+class RoadsSurfaceCobblestoneValueTransformed(FixtureTest):
     def test_transform(self):
         # transform cobblestone:flattened to cobblestone_flattened
         # Illicha Avenue in Donetsk, Ukraine

--- a/integration-test/1353-ne-min-zoom-roads.py
+++ b/integration-test/1353-ne-min-zoom-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NeMinZoomRoads(OsmFixtureTest):
+class NeMinZoomRoads(FixtureTest):
     def setUp(self):
         super(NeMinZoomRoads, self).setUp()
 

--- a/integration-test/1354-osm-ne-transition.py
+++ b/integration-test/1354-osm-ne-transition.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class OsmNeTransition(OsmFixtureTest):
+class OsmNeTransition(FixtureTest):
 
     def _assert_osm_ne_transition(self, z, x, y, layer):
         # checks that the OSM->NE transition happens for the given layer

--- a/integration-test/148-sea-ocean-labels-water-layer.py
+++ b/integration-test/148-sea-ocean-labels-water-layer.py
@@ -1,9 +1,9 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 # ocean and sea labels should be in the water layer rather than the places
 # layer.
-class SeaOceanLabelsWaterLayer(OsmFixtureTest):
+class SeaOceanLabelsWaterLayer(FixtureTest):
 
     def test_gulf_of_california(self):
         # Gulf of California: http://www.openstreetmap.org/node/305639734

--- a/integration-test/160-motorway-junctions.py
+++ b/integration-test/160-motorway-junctions.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MotorwayJunctions(OsmFixtureTest):
+class MotorwayJunctions(FixtureTest):
 
     def test_motorway_junctions(self):
         self.load_fixtures([

--- a/integration-test/192-shield-text-ref.py
+++ b/integration-test/192-shield-text-ref.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ShieldTextRef(OsmFixtureTest):
+class ShieldTextRef(FixtureTest):
 
     def test_james_lick_freeway(self):
         # US 101, "James Lick Freeway"

--- a/integration-test/197-clip-buildings.py
+++ b/integration-test/197-clip-buildings.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ClipBuildings(OsmFixtureTest):
+class ClipBuildings(FixtureTest):
 
     def test_high_line(self):
         from shapely.geometry import shape

--- a/integration-test/230-place-population-integer.py
+++ b/integration-test/230-place-population-integer.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class PlacePopulationInteger(OsmFixtureTest):
+class PlacePopulationInteger(FixtureTest):
 
     def test_south_bay(self):
         # all these places are in the south bay, near SF, CA.

--- a/integration-test/244-railway-plaforms.py
+++ b/integration-test/244-railway-plaforms.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RailwayPlatforms(OsmFixtureTest):
+class RailwayPlatforms(FixtureTest):
 
     def test_hunterspoint_avenue_lirr(self):
         # Hunterspoint Avenue LIRR

--- a/integration-test/291-483-suppress-historical-closed.py
+++ b/integration-test/291-483-suppress-historical-closed.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class SuppressHistoricalClosed(OsmFixtureTest):
+class SuppressHistoricalClosed(FixtureTest):
 
     def test_cartoon_museum(self):
         # Cartoon Art Museum (closed)

--- a/integration-test/333-mz_is_building.py
+++ b/integration-test/333-mz_is_building.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MzIsBuilding(OsmFixtureTest):
+class MzIsBuilding(FixtureTest):
 
     def test_buildings_around_san_francisco_state_university(self):
         # Buildings around San Francisco State University

--- a/integration-test/342-winter-sports-pistes.py
+++ b/integration-test/342-winter-sports-pistes.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WinterSportsPistes(OsmFixtureTest):
+class WinterSportsPistes(FixtureTest):
     def test_piste_easy(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/313466665'])
 

--- a/integration-test/343-winter-sports-resorts.py
+++ b/integration-test/343-winter-sports-resorts.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WinterSportsResorts(OsmFixtureTest):
+class WinterSportsResorts(FixtureTest):
     def test_heavenly_mountain_resort(self):
         # Heavenly Mountain Resort NV/CA
         self.load_fixtures(['https://www.openstreetmap.org/way/317721523'])

--- a/integration-test/344-winter-sports-pois.py
+++ b/integration-test/344-winter-sports-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WinterSportsPois(OsmFixtureTest):
+class WinterSportsPois(FixtureTest):
 
     def test_ski_shop(self):
         # ski shop in Big Bear Lake, CA

--- a/integration-test/358-merge-same-roads.py
+++ b/integration-test/358-merge-same-roads.py
@@ -1,4 +1,4 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 def _freeze(thing):
@@ -19,7 +19,7 @@ def _query_highway(highway):
     return overpass + 'way(' + bbox + ')[highway=' + highway + '];>;'
 
 
-class MergeSameRoads(OsmFixtureTest):
+class MergeSameRoads(FixtureTest):
 
     def test_roads_merged(self):
         # count the unique parameters - there should only be one, indicating

--- a/integration-test/366-beaches.py
+++ b/integration-test/366-beaches.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Beaches(OsmFixtureTest):
+class Beaches(FixtureTest):
     def test_baker_beach(self):
         # Baker beach, SF
         self.load_fixtures(['https://www.openstreetmap.org/relation/6260732'])

--- a/integration-test/367-military-landuse.py
+++ b/integration-test/367-military-landuse.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MilitaryLanduse(OsmFixtureTest):
+class MilitaryLanduse(FixtureTest):
     def test_naval_station(self):
         # Naval Weapons Station Concord, CA
         self.load_fixtures(['https://www.openstreetmap.org/way/154836419'])

--- a/integration-test/368-disused-railway-stations.py
+++ b/integration-test/368-disused-railway-stations.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class DisusedRailwayStations(OsmFixtureTest):
+class DisusedRailwayStations(FixtureTest):
 
     def test_old_south_ferry(self):
         # Old South Ferry (1) (disused=yes)

--- a/integration-test/369-subway-stations-z12.py
+++ b/integration-test/369-subway-stations-z12.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class SubwayStationsZ12(OsmFixtureTest):
+class SubwayStationsZ12(FixtureTest):
     def test_subway_stations_appear_at_z12(self):
         # 23rd St Station, New York, NY
         self.load_fixtures(['https://www.openstreetmap.org/node/597928317'])

--- a/integration-test/370-prisons.py
+++ b/integration-test/370-prisons.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Prisons(OsmFixtureTest):
+class Prisons(FixtureTest):
     def test_rikers_island(self):
         self.load_fixtures(['https://www.openstreetmap.org/relation/3955540'])
 

--- a/integration-test/374-electronics-shops.py
+++ b/integration-test/374-electronics-shops.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ElectronicsShops(OsmFixtureTest):
+class ElectronicsShops(FixtureTest):
 
     def test_best_buy(self):
         self._run_test(

--- a/integration-test/382-pier-lines.py
+++ b/integration-test/382-pier-lines.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class PierLines(OsmFixtureTest):
+class PierLines(FixtureTest):
     def test_pier_in_roads_layer(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/23783924'])
 

--- a/integration-test/398-airport-iata-codes.py
+++ b/integration-test/398-airport-iata-codes.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AirportIataCodes(OsmFixtureTest):
+class AirportIataCodes(FixtureTest):
     def test_sfo(self):
         # San Francisco International
         self.load_fixtures(['https://www.openstreetmap.org/way/23718192'])

--- a/integration-test/399-add-island-labels.py
+++ b/integration-test/399-add-island-labels.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddIslandLabels(OsmFixtureTest):
+class AddIslandLabels(FixtureTest):
     def test_ne_land_110m(self):
         # Natural Earth 110m
         self.load_fixtures([

--- a/integration-test/400-bay-water.py
+++ b/integration-test/400-bay-water.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BayWater(OsmFixtureTest):
+class BayWater(FixtureTest):
     def test_san_pablo_bay(self):
         # San Pablo Bay
         self.load_fixtures(['https://www.openstreetmap.org/way/43950409'])

--- a/integration-test/404-toys-not-found.py
+++ b/integration-test/404-toys-not-found.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ToysNotFound(OsmFixtureTest):
+class ToysNotFound(FixtureTest):
 
     def test_01(self):
         self._run_test(16, 10473, 25339,

--- a/integration-test/418-wof-l10n_name.py
+++ b/integration-test/418-wof-l10n_name.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WofL10nName(OsmFixtureTest):
+class WofL10nName(FixtureTest):
     def test_hollywood(self):
         # Hollywood (wof neighbourhood)
         self.load_fixtures([

--- a/integration-test/421-zoos-z13.py
+++ b/integration-test/421-zoos-z13.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ZoosZ13(OsmFixtureTest):
+class ZoosZ13(FixtureTest):
     def test_zoo_appears_at_z13(self):
         # Zoo Montana, Billings, MT
         self.load_fixtures(['https://www.openstreetmap.org/node/2274329294'])

--- a/integration-test/440-zoos-and-other-attractions-attraction.py
+++ b/integration-test/440-zoos-and-other-attractions-attraction.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ZoosAndOtherAttractionsAttraction(OsmFixtureTest):
+class ZoosAndOtherAttractionsAttraction(FixtureTest):
     def test_attractions(self):
         # Sable Island Horse
         self._run_test(16, 21228, 23551, 342984911, 'animal')

--- a/integration-test/440-zoos-and-other-attractions-barrier.py
+++ b/integration-test/440-zoos-and-other-attractions-barrier.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ZoosAndOtherAttractionsBarrier(OsmFixtureTest):
+class ZoosAndOtherAttractionsBarrier(FixtureTest):
     def test_fences_around_enclosures(self):
         # barrier=fence around enclosures
         self.load_fixtures(['https://www.openstreetmap.org/way/316623706'])

--- a/integration-test/440-zoos-and-other-attractions-tourism.py
+++ b/integration-test/440-zoos-and-other-attractions-tourism.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ZoosAndOtherAttractionsTourism(OsmFixtureTest):
+class ZoosAndOtherAttractionsTourism(FixtureTest):
     def test_tourism(self):
         # City Sculpture, Detroit
         self._run_test(16, 17645, 24242, 358445798, 'artwork')

--- a/integration-test/440-zoos-and-other-attractions-zoo.py
+++ b/integration-test/440-zoos-and-other-attractions-zoo.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ZoosAndOtherAttractionsZoo(OsmFixtureTest):
+class ZoosAndOtherAttractionsZoo(FixtureTest):
     def test_zoos(self):
         # Bear Enclosure (presumably + woods=yes?)
         self._run_test(16, 11458, 21855, 316623706, 'enclosure')

--- a/integration-test/440-zoos-and-other-attractions.py
+++ b/integration-test/440-zoos-and-other-attractions.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ZoosAndOtherAttractions(OsmFixtureTest):
+class ZoosAndOtherAttractions(FixtureTest):
 
     # So the question here is if kind should be set to attraction or enclosure.
     # There are other attraction areas (like rides at amusement parks), so I

--- a/integration-test/443-swimming-pools.py
+++ b/integration-test/443-swimming-pools.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class SwimmingPools(OsmFixtureTest):
+class SwimmingPools(FixtureTest):
 
     def test_amenity_swimming_pool(self):
         # Bayonne Municipal Pool, amenity=swimming_pool

--- a/integration-test/447-ice-cream-shops.py
+++ b/integration-test/447-ice-cream-shops.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class IceCreamShops(OsmFixtureTest):
+class IceCreamShops(FixtureTest):
     def test_amenity_ice_cream(self):
         # New York, NY (amenity=ice_cream)
         self.load_fixtures(['https://www.openstreetmap.org/node/2782000317'])

--- a/integration-test/448-wine-and-alcohol-shops.py
+++ b/integration-test/448-wine-and-alcohol-shops.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WineAndAlcoholShops(OsmFixtureTest):
+class WineAndAlcoholShops(FixtureTest):
 
     def test_shop_wine(self):
         # Wine, New York, NY (shop=wine)

--- a/integration-test/454-aeroway-gates.py
+++ b/integration-test/454-aeroway-gates.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AerowayGates(OsmFixtureTest):
+class AerowayGates(FixtureTest):
     def test_aeroway_gate(self):
         # Gate A5, SFO
         self.load_fixtures(['https://www.openstreetmap.org/node/656398641'])

--- a/integration-test/465-fitness-pois.py
+++ b/integration-test/465-fitness-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class FitnessPois(OsmFixtureTest):
+class FitnessPois(FixtureTest):
     def test_leisure_fitness_centre(self):
         # Fitness SF SOMA, leisure=fitness_centre
         self._run_test(16, 10484, 25332, 'way/25371830')

--- a/integration-test/469-transit-features.py
+++ b/integration-test/469-transit-features.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class TransitFeatures(OsmFixtureTest):
+class TransitFeatures(FixtureTest):
     def test_bus_stop_way(self):
         # way 91806504
         self.load_fixtures(['https://www.openstreetmap.org/way/91806504'])

--- a/integration-test/471-categorize-trains.py
+++ b/integration-test/471-categorize-trains.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class CategorizeTrains(OsmFixtureTest):
+class CategorizeTrains(FixtureTest):
     def test_long_distance(self):
         self.load_fixtures(
             ['https://www.openstreetmap.org/relation/2812900'],

--- a/integration-test/472-adjust-transit-zoom-ranges.py
+++ b/integration-test/472-adjust-transit-zoom-ranges.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AdjustTransitZoomRanges(OsmFixtureTest):
+class AdjustTransitZoomRanges(FixtureTest):
     def test_bart(self):
         # SFO-Pittsburg/Bay Point BART
         self.load_fixtures(['https://www.openstreetmap.org/relation/2827684'])

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class LanduseTier(OsmFixtureTest):
+class LanduseTier(FixtureTest):
     def test_large_national_park(self):
         # area 1.75564e+10
         self.load_fixtures(['http://www.openstreetmap.org/relation/1453306'])

--- a/integration-test/479-barrier-toll_booth.py
+++ b/integration-test/479-barrier-toll_booth.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BarrierTollBooth(OsmFixtureTest):
+class BarrierTollBooth(FixtureTest):
     def test_01(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/52529616'])
 

--- a/integration-test/480-rest_area-services.py
+++ b/integration-test/480-rest_area-services.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RestAreaServices(OsmFixtureTest):
+class RestAreaServices(FixtureTest):
     def test_rest_area_node(self):
         self.load_fixtures(['http://www.openstreetmap.org/node/159773030'])
 

--- a/integration-test/484-include-state-pois.py
+++ b/integration-test/484-include-state-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class IncludeStatePois(OsmFixtureTest):
+class IncludeStatePois(FixtureTest):
     def test_proposed_stations(self):
         # Antioch Station
         self.load_fixtures(['https://www.openstreetmap.org/node/3353451464'])

--- a/integration-test/488-motorway_link-z11.py
+++ b/integration-test/488-motorway_link-z11.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MotorwayLinkZ11(OsmFixtureTest):
+class MotorwayLinkZ11(FixtureTest):
     def test_motorway_link_until_zoom_11(self):
         z, x, y = 11, 327, 791
 

--- a/integration-test/489-keep-ref-for-major-roads.py
+++ b/integration-test/489-keep-ref-for-major-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class KeepRefForMajorRoads(OsmFixtureTest):
+class KeepRefForMajorRoads(FixtureTest):
     def test_I495(self):
         # just checks that there is at least one major_road with a ref set.
         self.load_fixtures(['https://www.openstreetmap.org/relation/1876662'])

--- a/integration-test/501-drop-physical-railways-from-transit.py
+++ b/integration-test/501-drop-physical-railways-from-transit.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class DropPhysicalRailwaysFromTransit(OsmFixtureTest):
+class DropPhysicalRailwaysFromTransit(FixtureTest):
 
     def test_drop_physical_railways(self):
         import urllib

--- a/integration-test/502-water-boundaries-slow.py
+++ b/integration-test/502-water-boundaries-slow.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WaterBoundariesSlow(OsmFixtureTest):
+class WaterBoundariesSlow(FixtureTest):
 
     def test_boundaries(self):
         from shapely.ops import unary_union

--- a/integration-test/507-routes-via-stop-positions.py
+++ b/integration-test/507-routes-via-stop-positions.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoutesViaStopPositions(OsmFixtureTest):
+class RoutesViaStopPositions(FixtureTest):
 
     def _load(self, z, x, y, nodes=[], ways=[], relations=[]):
         fixtures = []

--- a/integration-test/510-funicular.py
+++ b/integration-test/510-funicular.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Funicular(OsmFixtureTest):
+class Funicular(FixtureTest):
     def test_funicular(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/393550019'])
 

--- a/integration-test/520-big-box-stores.py
+++ b/integration-test/520-big-box-stores.py
@@ -1,4 +1,4 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 def _url_for(osm_id):
@@ -6,7 +6,7 @@ def _url_for(osm_id):
     return 'https://www.openstreetmap.org/%s/%d' % (typ, abs(osm_id))
 
 
-class BigBoxStores(OsmFixtureTest):
+class BigBoxStores(FixtureTest):
 
     def test_big_box_stores(self):
         tests = [

--- a/integration-test/522-hotels.py
+++ b/integration-test/522-hotels.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Hotels(OsmFixtureTest):
+class Hotels(FixtureTest):
     def test_ritz_carlton(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/32947245'])
 

--- a/integration-test/523-add-elevation-to-peaks.py
+++ b/integration-test/523-add-elevation-to-peaks.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddElevationToPeaks(OsmFixtureTest):
+class AddElevationToPeaks(FixtureTest):
     def test_mt_elbert(self):
         ##
         # A selection of very tall peaks which should be visible at zoom 9.

--- a/integration-test/524-peak-kind-tile-rank.py
+++ b/integration-test/524-peak-kind-tile-rank.py
@@ -1,4 +1,4 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 def count_matching(features, props):
@@ -19,7 +19,7 @@ def count_matching(features, props):
     return num_matches
 
 
-class PeakKindTileRank(OsmFixtureTest):
+class PeakKindTileRank(FixtureTest):
 
     def test_01(self):
         # the tile 11/420/779 contains all the peaks below. so many, it

--- a/integration-test/526-inclusive-pois.py
+++ b/integration-test/526-inclusive-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class InclusivePois(OsmFixtureTest):
+class InclusivePois(FixtureTest):
 
     def test_healthcare_midwife(self):
         self._run_test(

--- a/integration-test/546-road-sort-keys-aerialway.py
+++ b/integration-test/546-road-sort-keys-aerialway.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadSortKeysAerialway(OsmFixtureTest):
+class RoadSortKeysAerialway(FixtureTest):
     def test_gondola(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/32051122'])
 

--- a/integration-test/546-road-sort-keys-aeroway.py
+++ b/integration-test/546-road-sort-keys-aeroway.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadSortKeysAeroway(OsmFixtureTest):
+class RoadSortKeysAeroway(FixtureTest):
     def test_runway(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/214484985'])
 

--- a/integration-test/546-road-sort-keys-bridges.py
+++ b/integration-test/546-road-sort-keys-bridges.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadSortKeysBridges(OsmFixtureTest):
+class RoadSortKeysBridges(FixtureTest):
     def test_motorway_bridge(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/28412298'])
 

--- a/integration-test/546-road-sort-keys-layers.py
+++ b/integration-test/546-road-sort-keys-layers.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadSortKeysLayers(OsmFixtureTest):
+class RoadSortKeysLayers(FixtureTest):
     def test_layer_5(self):
         # layer 5
         self.load_fixtures(['https://www.openstreetmap.org/way/48474682'])

--- a/integration-test/546-road-sort-keys-railways.py
+++ b/integration-test/546-road-sort-keys-railways.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadSortKeysRailways(OsmFixtureTest):
+class RoadSortKeysRailways(FixtureTest):
     def test_rail(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/8920472'])
 

--- a/integration-test/546-road-sort-keys-roads.py
+++ b/integration-test/546-road-sort-keys-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadSortKeysRoads(OsmFixtureTest):
+class RoadSortKeysRoads(FixtureTest):
     def test_motorway(self):
         # regular roads
         self.load_fixtures(['https://www.openstreetmap.org/way/26765956'])

--- a/integration-test/546-road-sort-keys-tunnel.py
+++ b/integration-test/546-road-sort-keys-tunnel.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RoadSortKeysTunnel(OsmFixtureTest):
+class RoadSortKeysTunnel(FixtureTest):
     def test_motorway_level_0(self):
         # tunnels at level = 0
         self.load_fixtures(['https://www.openstreetmap.org/way/167952621'])

--- a/integration-test/549-subways.py
+++ b/integration-test/549-subways.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Subways(OsmFixtureTest):
+class Subways(FixtureTest):
     def test_subway(self):
         self.load_fixtures(
             ['https://www.openstreetmap.org/way/101647480'])

--- a/integration-test/552-water-boundary-sort-key.py
+++ b/integration-test/552-water-boundary-sort-key.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WaterBoundarySortKey(OsmFixtureTest):
+class WaterBoundarySortKey(FixtureTest):
     def test_water_boundary_sort_key(self):
         # from https://github.com/mapzen/vector-datasource/issues/552
         self.load_fixtures([

--- a/integration-test/557-missing-buildings.py
+++ b/integration-test/557-missing-buildings.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MissingBuildings(OsmFixtureTest):
+class MissingBuildings(FixtureTest):
     def test_best_tile(self):
         # Best Tile
         self.load_fixtures(['https://www.openstreetmap.org/way/103383621'])

--- a/integration-test/558-default-brunnel-sort-keys.py
+++ b/integration-test/558-default-brunnel-sort-keys.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class DefaultBrunnelSortKeys(OsmFixtureTest):
+class DefaultBrunnelSortKeys(FixtureTest):
     def test_footway(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/70656344'])
 

--- a/integration-test/566-landuse-line.py
+++ b/integration-test/566-landuse-line.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class LanduseLine(OsmFixtureTest):
+class LanduseLine(FixtureTest):
     def test_tree_row(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/207142223'])
 

--- a/integration-test/569-duplicate-points.py
+++ b/integration-test/569-duplicate-points.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class DuplicatePoints(OsmFixtureTest):
+class DuplicatePoints(FixtureTest):
 
     def _assert_no_repeated_points(self, coords):
         last_coord = coords[0]

--- a/integration-test/580-kind-csv.py
+++ b/integration-test/580-kind-csv.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class KindCsv(OsmFixtureTest):
+class KindCsv(FixtureTest):
     def test_post_office(self):
         self.load_fixtures(['https://www.openstreetmap.org/node/1223019595'])
 

--- a/integration-test/583-merge-landuse.py
+++ b/integration-test/583-merge-landuse.py
@@ -1,4 +1,4 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 def _freeze(thing):
@@ -11,7 +11,7 @@ def _freeze(thing):
     return thing
 
 
-class MergeLanduse(OsmFixtureTest):
+class MergeLanduse(FixtureTest):
 
     def test_merge_landuse(self):
         self.load_fixtures([

--- a/integration-test/588-funicular-monorail.py
+++ b/integration-test/588-funicular-monorail.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class FunicularMonorail(OsmFixtureTest):
+class FunicularMonorail(FixtureTest):
     def test_monorail(self):
         self.load_fixtures(['https://www.openstreetmap.org/relation/6043603'])
 

--- a/integration-test/592-add-adjust-bicycle-pois.py
+++ b/integration-test/592-add-adjust-bicycle-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddAdjustBicyclePois(OsmFixtureTest):
+class AddAdjustBicyclePois(FixtureTest):
     def test_bicycle_shop(self):
         # Valencia Cyclery in SF
         self.load_fixtures(['http://www.openstreetmap.org/node/414269441'])

--- a/integration-test/593-early-cycleway.py
+++ b/integration-test/593-early-cycleway.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class EarlyCycleway(OsmFixtureTest):
+class EarlyCycleway(FixtureTest):
     def test_cycleway(self):
         z, x, y = 12, 655, 1586
         self.load_fixtures(

--- a/integration-test/593-early-footway.py
+++ b/integration-test/593-early-footway.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class EarlyFootway(OsmFixtureTest):
+class EarlyFootway(FixtureTest):
 
     def test_footway_unnamed_national(self):
         # highway=footway, no name, route national (Pacific Crest Trail)

--- a/integration-test/593-early-path.py
+++ b/integration-test/593-early-path.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class EarlyPath(OsmFixtureTest):
+class EarlyPath(FixtureTest):
     def test_pacific_crest_trail(self):
         # highway=path, with route national (Pacific Crest Trail)
         self.load_fixtures(

--- a/integration-test/593-early-step.py
+++ b/integration-test/593-early-step.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class EarlyStep(OsmFixtureTest):
+class EarlyStep(FixtureTest):
     def test_steps_with_regional_route(self):
         self.load_fixtures([
             'https://www.openstreetmap.org/way/24655593',

--- a/integration-test/593-early-track.py
+++ b/integration-test/593-early-track.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class EarlyTrack(OsmFixtureTest):
+class EarlyTrack(FixtureTest):
     def test_track(self):
         # track example in Marin Headlands, a member of Bay Area Ridge Trail,
         # a regional network

--- a/integration-test/594-trailhead.py
+++ b/integration-test/594-trailhead.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Trailhead(OsmFixtureTest):
+class Trailhead(FixtureTest):
     def test_trailhead(self):
         self.load_fixtures(['https://www.openstreetmap.org/node/3447700493'])
 

--- a/integration-test/596-add-hiking-routes.py
+++ b/integration-test/596-add-hiking-routes.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddHikingRoutes(OsmFixtureTest):
+class AddHikingRoutes(FixtureTest):
     def test_track(self):
         self.load_fixtures([
             'https://www.openstreetmap.org/way/12188550',

--- a/integration-test/599-whitewater.py
+++ b/integration-test/599-whitewater.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Whitewater(OsmFixtureTest):
+class Whitewater(FixtureTest):
     def test_put_in_egress(self):
         self.load_fixtures(['https://www.openstreetmap.org/node/3134398100'])
 

--- a/integration-test/601-cliff-arete-ridge-valley.py
+++ b/integration-test/601-cliff-arete-ridge-valley.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class CliffAreteRidgeValley(OsmFixtureTest):
+class CliffAreteRidgeValley(FixtureTest):
     def test_cliff(self):
         # cliff in Yosemite
         self.load_fixtures(['https://www.openstreetmap.org/way/291684864'])

--- a/integration-test/602-add-boat-rental.py
+++ b/integration-test/602-add-boat-rental.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddBoatRental(OsmFixtureTest):
+class AddBoatRental(FixtureTest):
     def test_shop_boat_rental(self):
         # shop=boat_rental
         self.load_fixtures(['https://www.openstreetmap.org/node/1306277961'])

--- a/integration-test/605-corridor.py
+++ b/integration-test/605-corridor.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Corridor(OsmFixtureTest):
+class Corridor(FixtureTest):
     def test_corridor(self):
         # Way: The Nave (205644309)
         self.load_fixtures(['http://www.openstreetmap.org/way/205644309'])

--- a/integration-test/605-crosswalk-sidewalk.py
+++ b/integration-test/605-crosswalk-sidewalk.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class CrosswalkSidewalk(OsmFixtureTest):
+class CrosswalkSidewalk(FixtureTest):
     def test_crossing_traffic_signals(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/444491374'])
 

--- a/integration-test/611-add-bus-to-roads.py
+++ b/integration-test/611-add-bus-to-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddBusToRoads(OsmFixtureTest):
+class AddBusToRoads(FixtureTest):
     def test_is_bus_route(self):
         # block between mission & 6th and howard & 5th in SF.
         # appears to have lots of buses.

--- a/integration-test/628-standardize-water-kinds.py
+++ b/integration-test/628-standardize-water-kinds.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class StandardizeWaterKinds(OsmFixtureTest):
+class StandardizeWaterKinds(FixtureTest):
     def test_great_salt_lake_ne(self):
         # ne_10m_lakes gid 1298: Great Salt Lake, UT
         self.load_fixtures([

--- a/integration-test/629-trolleybus-is-a-bus.py
+++ b/integration-test/629-trolleybus-is-a-bus.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class TrolleybusIsABus(OsmFixtureTest):
+class TrolleybusIsABus(FixtureTest):
     def test_industrial_street(self):
         self.load_fixtures([
             'http://www.openstreetmap.org/way/397268717',

--- a/integration-test/630-bus-routes-z12.py
+++ b/integration-test/630-bus-routes-z12.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BusRoutesZ12(OsmFixtureTest):
+class BusRoutesZ12(FixtureTest):
     def test_bus_routes_exist_at_z12(self):
         z, x, y = (16, 10484, 25329)
 

--- a/integration-test/647-cycle-route.py
+++ b/integration-test/647-cycle-route.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class CycleRoute(OsmFixtureTest):
+class CycleRoute(FixtureTest):
     def test_embarcadero(self):
         #  Way: The Embarcadero (24335490)
         self.load_fixtures([

--- a/integration-test/653-unify-building-part.py
+++ b/integration-test/653-unify-building-part.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class UnifyBuildingPart(OsmFixtureTest):
+class UnifyBuildingPart(FixtureTest):
     def test_one_madison(self):
         # Way: One Madison
         self.load_fixtures([

--- a/integration-test/655-landuse-scree.py
+++ b/integration-test/655-landuse-scree.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class LanduseScree(OsmFixtureTest):
+class LanduseScree(FixtureTest):
     def test_scree(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/59621863'])
 

--- a/integration-test/657-natural-man_made.py
+++ b/integration-test/657-natural-man_made.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NaturalManMade(OsmFixtureTest):
+class NaturalManMade(FixtureTest):
     def test_mineshaft(self):
         self.load_fixtures(['http://www.openstreetmap.org/node/4305375025'])
 

--- a/integration-test/661-historic-transit-stops.py
+++ b/integration-test/661-historic-transit-stops.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class HistoricTransitStops(OsmFixtureTest):
+class HistoricTransitStops(FixtureTest):
     def test_historic_railway_stop(self):
         # Check if historic stops are shown in pois and in transit layers.
         # Historic railway stop

--- a/integration-test/662-basic-outdoor-pois.py
+++ b/integration-test/662-basic-outdoor-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BasicOutdoorPois(OsmFixtureTest):
+class BasicOutdoorPois(FixtureTest):
     def test_bbq(self):
         self.load_fixtures(['http://www.openstreetmap.org/node/1387024181'])
 

--- a/integration-test/663-combo-outdoor-landuse-pois.py
+++ b/integration-test/663-combo-outdoor-landuse-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ComboOutdoorLandusePois(OsmFixtureTest):
+class ComboOutdoorLandusePois(FixtureTest):
     def test_water_park_way(self):
         # Waterworld in Concord
         self.load_fixtures(['http://www.openstreetmap.org/way/31198945'])

--- a/integration-test/664-raceway.py
+++ b/integration-test/664-raceway.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Raceway(OsmFixtureTest):
+class Raceway(FixtureTest):
     def test_raceway_1(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/28825404'])
 

--- a/integration-test/668-intermittent-water.py
+++ b/integration-test/668-intermittent-water.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class IntermittentWater(OsmFixtureTest):
+class IntermittentWater(FixtureTest):
     def test_river(self):
         # Arizona Canal Diversion Channel (ACDC)
         self.load_fixtures(['http://www.openstreetmap.org/way/107817218'])

--- a/integration-test/671-ranger-station.py
+++ b/integration-test/671-ranger-station.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RangerStation(OsmFixtureTest):
+class RangerStation(FixtureTest):
     def test_ranger_station_supersedes_tourism(self):
         # Big Basin Redwoods State Park Headquarters
         # Node with amenity=ranger_station, but also has tourism=information

--- a/integration-test/674-outdoor-shops.py
+++ b/integration-test/674-outdoor-shops.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class OutdoorShops(OsmFixtureTest):
+class OutdoorShops(FixtureTest):
     def test_fishing(self):
         self.load_fixtures(['http://www.openstreetmap.org/node/3056897308'])
 

--- a/integration-test/675-man_made-outdoor-landmarks.py
+++ b/integration-test/675-man_made-outdoor-landmarks.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ManMadeOutdoorLandmarks(OsmFixtureTest):
+class ManMadeOutdoorLandmarks(FixtureTest):
     def test_communications_tower(self):
         self.load_fixtures(['http://www.openstreetmap.org/node/1230069003'])
 

--- a/integration-test/677-waterfall.py
+++ b/integration-test/677-waterfall.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Waterfall(OsmFixtureTest):
+class Waterfall(FixtureTest):
     def test_more_than_300m(self):
         # Upper Yosemite Falls, because it's so tall at 550 meters, more than
         # 300 meters

--- a/integration-test/679-less-landuse-building-label-placements.py
+++ b/integration-test/679-less-landuse-building-label-placements.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class LessLanduseBuildingLabelPlacements(OsmFixtureTest):
+class LessLanduseBuildingLabelPlacements(FixtureTest):
     def test_pier(self):
         # The landuse for a pier
         self.load_fixtures(['http://www.openstreetmap.org/way/82206919'])

--- a/integration-test/704-exclude-null-values-for-buildings.py
+++ b/integration-test/704-exclude-null-values-for-buildings.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ExcludeNullValuesForBuildings(OsmFixtureTest):
+class ExcludeNullValuesForBuildings(FixtureTest):
 
     def test_alcatraz(self):
         # way 128245373 - alcatraz prison main building

--- a/integration-test/713-urban-areas.py
+++ b/integration-test/713-urban-areas.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class UrbanAreas(OsmFixtureTest):
+class UrbanAreas(FixtureTest):
     def test_urban_area_zooms(self):
         # update kind to read urban_areas instead of urban areas.
         # This is not an OSM feature it comes from Natural Earth

--- a/integration-test/719-add-kind-detail-for-pois.py
+++ b/integration-test/719-add-kind-detail-for-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddKindDetailForPois(OsmFixtureTest):
+class AddKindDetailForPois(FixtureTest):
     def test_seafood_restaurant(self):
         self.load_fixtures(['https://www.openstreetmap.org/node/1426311638'])
 

--- a/integration-test/729-route-name.py
+++ b/integration-test/729-route-name.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RouteName(OsmFixtureTest):
+class RouteName(FixtureTest):
     def test_route_name(self):
         # Relation: M-Ocean View: Inbound to Downtown (91022)
         self.load_fixtures([

--- a/integration-test/731-return-of-the-zombie-buildings.py
+++ b/integration-test/731-return-of-the-zombie-buildings.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ReturnOfTheZombieBuildings(OsmFixtureTest):
+class ReturnOfTheZombieBuildings(FixtureTest):
 
     def _load_query(self, z, x, y, tag):
         from ModestMaps.Core import Coordinate

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class PredictableLayersPois(OsmFixtureTest):
+class PredictableLayersPois(FixtureTest):
     def test_grave_yard_node(self):
         # Node:358830410 Grave_yard in POIs
         self.load_fixtures(['http://www.openstreetmap.org/node/358830410'])

--- a/integration-test/744-remove-osm-neighbourhoods.py
+++ b/integration-test/744-remove-osm-neighbourhoods.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RemoveOsmNeighbourhoods(OsmFixtureTest):
+class RemoveOsmNeighbourhoods(FixtureTest):
     def test_no_borough(self):
         # Node: Mount Pocono (158473043)
         self.load_fixtures(['http://www.openstreetmap.org/node/158473043'])

--- a/integration-test/766-dont-merge-z16-roads.py
+++ b/integration-test/766-dont-merge-z16-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class DontMergeZ16Roads(OsmFixtureTest):
+class DontMergeZ16Roads(FixtureTest):
     def test_roads_not_merged(self):
         # if we're merging, then only one of these will be in tiles. if
         # both exist then it's more likely that no merging is happening.

--- a/integration-test/768-multiline-encoded.py
+++ b/integration-test/768-multiline-encoded.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MultilineEncoded(OsmFixtureTest):
+class MultilineEncoded(FixtureTest):
     def test_multiline_encoded(self):
         # Way: Big Bear Boulevard (325846175)
         self.load_fixtures(['http://www.openstreetmap.org/way/325846175'])

--- a/integration-test/774-cycleway-no.py
+++ b/integration-test/774-cycleway-no.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class CyclewayEqualsNo(OsmFixtureTest):
+class CyclewayEqualsNo(FixtureTest):
     def test_centre(self):
         # Way: Grant Avenue (184956229)
         self.load_fixtures(['http://www.openstreetmap.org/way/184956229'])

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WalkingRouteRefs(OsmFixtureTest):
+class WalkingRouteRefs(FixtureTest):
     def test_single_route(self):
         # walking route constituent ways should have the walking route
         # properties projected onto them.

--- a/integration-test/776-duplicate-footway.py
+++ b/integration-test/776-duplicate-footway.py
@@ -1,10 +1,10 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 # we used to duplicate footway features between the roads and landuse layers.
 # this test exists to make sure we don't backslide.
 # see https://github.com/tilezen/vector-datasource/issues/776 for more info.
-class DuplicateFootway(OsmFixtureTest):
+class DuplicateFootway(FixtureTest):
 
     def test_pedestrian(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/128534087'])

--- a/integration-test/797-add-missing-boundaries.py
+++ b/integration-test/797-add-missing-boundaries.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddMissingBoundaries(OsmFixtureTest):
+class AddMissingBoundaries(FixtureTest):
     def test_statistical(self):
         # NE data - no OSM elements
         # boundary between NV and CA is _also_ a "statistical" boundary

--- a/integration-test/806-building-height.py
+++ b/integration-test/806-building-height.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BuildingHeight(OsmFixtureTest):
+class BuildingHeight(FixtureTest):
     def test_from_building_levels(self):
         # check that we synthesize a height value from building:levels
         # Way: R5 Tower A (431358377)

--- a/integration-test/820-gate-min-zoom.py
+++ b/integration-test/820-gate-min-zoom.py
@@ -1,8 +1,8 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 # Set gate min zoom based on highway type
-class GateMinZoom(OsmFixtureTest):
+class GateMinZoom(FixtureTest):
 
     def test_gate_on_secondary(self):
         # Gate on secondary road

--- a/integration-test/829-garden-pois.py
+++ b/integration-test/829-garden-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class GardenPois(OsmFixtureTest):
+class GardenPois(FixtureTest):
     def test_garden_with_area(self):
         # update gardens in pois
         # garden with area in pois

--- a/integration-test/830-windmill-zoom.py
+++ b/integration-test/830-windmill-zoom.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class WindmillZoom(OsmFixtureTest):
+class WindmillZoom(FixtureTest):
     def test_windmill_with_attraction(self):
         # update windmill zoom to 15 and if attraction zoom to 14
         # windmill with tourism = attraction

--- a/integration-test/832-pedestrian-paths-bicycle.py
+++ b/integration-test/832-pedestrian-paths-bicycle.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class PedestrianPathsBicycle(OsmFixtureTest):
+class PedestrianPathsBicycle(FixtureTest):
     def test_path(self):
         # Add footway properties to pedestrian paths and piers
         # Pedestrian path

--- a/integration-test/834-park-building.py
+++ b/integration-test/834-park-building.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ParkBuilding(OsmFixtureTest):
+class ParkBuilding(FixtureTest):
     def test_park_with_building_tags_should_appear_in_landuse(self):
         # This test make sure park polygons with addresses still end up in
         # the landuse layer

--- a/integration-test/837-no-country-label-low-zoom.py
+++ b/integration-test/837-no-country-label-low-zoom.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NoCountryLabelLowZoom(OsmFixtureTest):
+class NoCountryLabelLowZoom(FixtureTest):
     def test_no_country_label_at_low_zoom(self):
         # United States
         self.load_fixtures(['http://www.openstreetmap.org/node/424317935'])

--- a/integration-test/840-normalize-place-kind.py
+++ b/integration-test/840-normalize-place-kind.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NormalizePlaceKind(OsmFixtureTest):
+class NormalizePlaceKind(FixtureTest):
     def test_state(self):
         # Node: California (671022)
         self.load_fixtures(['http://www.openstreetmap.org/node/671022'])
@@ -76,7 +76,7 @@ class NormalizePlaceKind(OsmFixtureTest):
             {'id': 3219761323, 'kind': 'locality', 'kind_detail': 'farm'})
 
 
-class NormalizePlaceKindNaturalEarth(OsmFixtureTest):
+class NormalizePlaceKindNaturalEarth(FixtureTest):
 
     def setUp(self):
         super(NormalizePlaceKindNaturalEarth, self).setUp()

--- a/integration-test/841-normalize-boundaries-kind.py
+++ b/integration-test/841-normalize-boundaries-kind.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NormalizeBoundariesKind(OsmFixtureTest):
+class NormalizeBoundariesKind(FixtureTest):
     def test_aboriginal_lands_protected_area(self):
         # Relation: Hoopa Valley Tribe
         #
@@ -85,7 +85,7 @@ class NormalizeBoundariesKind(OsmFixtureTest):
             {'id': -2834528, 'kind': 'locality', 'kind_detail': '8'})
 
 
-class NormalizeBoundariesKindNaturalEarth(OsmFixtureTest):
+class NormalizeBoundariesKindNaturalEarth(FixtureTest):
 
     def setUp(self):
         super(NormalizeBoundariesKindNaturalEarth, self).setUp()

--- a/integration-test/842-normalize-building-kind.py
+++ b/integration-test/842-normalize-building-kind.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NormalizeBuildingKind(OsmFixtureTest):
+class NormalizeBuildingKind(FixtureTest):
     def test_office(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/431358377'])
 

--- a/integration-test/843-normalize-underscore.py
+++ b/integration-test/843-normalize-underscore.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NormalizeUnderscore(OsmFixtureTest):
+class NormalizeUnderscore(FixtureTest):
     def test_drive_through(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/219071307'])
 

--- a/integration-test/844-normalize-poi-kind.py
+++ b/integration-test/844-normalize-poi-kind.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NormalizePoiKind(OsmFixtureTest):
+class NormalizePoiKind(FixtureTest):
     def test_aeroway_gate(self):
         # Node: Gate G102 (1096088604)
         self.load_fixtures(['http://www.openstreetmap.org/node/1096088604'])

--- a/integration-test/845-buildings-z13.py
+++ b/integration-test/845-buildings-z13.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BuildingsZ13(OsmFixtureTest):
+class BuildingsZ13(FixtureTest):
     def test_buildings_exist_at_zoom_13(self):
         # Earlier work in 845 dropped buildings from zoom 13
         self.load_fixtures(['http://www.openstreetmap.org/way/23654700',

--- a/integration-test/852-remove-landuse_labels.py
+++ b/integration-test/852-remove-landuse_labels.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RemoveLanduseLabels(OsmFixtureTest):
+class RemoveLanduseLabels(FixtureTest):
 
     def test_landuse_labels_layer_no_longer_exists(self):
         # Label placement Cemetery in landuse - note that we test the

--- a/integration-test/857-move_barriers_to_landuse.py
+++ b/integration-test/857-move_barriers_to_landuse.py
@@ -1,8 +1,8 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 # update landuse to include barriers features and delete from boundaries
-class MoveBarriersToLanduse(OsmFixtureTest):
+class MoveBarriersToLanduse(FixtureTest):
 
     def test_city_wall(self):
         # city_wall in landuse

--- a/integration-test/859-add-bridleway.py
+++ b/integration-test/859-add-bridleway.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddBridleway(OsmFixtureTest):
+class AddBridleway(FixtureTest):
     def test_bridleway(self):
         # Add bridleway from osm
         self.load_fixtures(['http://www.openstreetmap.org/way/387216146'])

--- a/integration-test/860-lighthouse.py
+++ b/integration-test/860-lighthouse.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class Lighthouse(OsmFixtureTest):
+class Lighthouse(FixtureTest):
     def test_with_attraction(self):
         # update lighthouse zoom to 15 and if attraction zoom to 14
         # lighthouse with tourism = attraction

--- a/integration-test/875-camp-grounds-zoom.py
+++ b/integration-test/875-camp-grounds-zoom.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class CampGroundsZoom(OsmFixtureTest):
+class CampGroundsZoom(FixtureTest):
     def test_large(self):
         # update landuse to include campground features and fix label zoom
         # large campground in landuse zoom 16

--- a/integration-test/890-normalize-ne-roads.py
+++ b/integration-test/890-normalize-ne-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NormalizeNeRoads(OsmFixtureTest):
+class NormalizeNeRoads(FixtureTest):
 
     def setUp(self):
         super(NormalizeNeRoads, self).setUp()

--- a/integration-test/895-extract-airport-lines-minor_road.py
+++ b/integration-test/895-extract-airport-lines-minor_road.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class ExtractAirportLinesMinorRoad(OsmFixtureTest):
+class ExtractAirportLinesMinorRoad(FixtureTest):
     def test_runway(self):
         # Way: 10L/28R (22567191)
         self.load_fixtures(['http://www.openstreetmap.org/way/22567191'])

--- a/integration-test/896-ne-shield-enums-2.py
+++ b/integration-test/896-ne-shield-enums-2.py
@@ -1,4 +1,4 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
 # I think we should remove for v1 (and never should be been included at zoom
@@ -8,7 +8,7 @@ from . import OsmFixtureTest
 #  * level
 #  * namealt
 #  * namealtt
-class NeShieldEnums2(OsmFixtureTest):
+class NeShieldEnums2(FixtureTest):
 
     def setUp(self):
         super(NeShieldEnums2, self).setUp()

--- a/integration-test/896-ne-shield-enums.py
+++ b/integration-test/896-ne-shield-enums.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NeShieldEnums(OsmFixtureTest):
+class NeShieldEnums(FixtureTest):
 
     def setUp(self):
         super(NeShieldEnums, self).setUp()

--- a/integration-test/912-missing-building-part.py
+++ b/integration-test/912-missing-building-part.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class MissingBuildingPart(OsmFixtureTest):
+class MissingBuildingPart(FixtureTest):
     def test_building_part_exists(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/287494678'])
 

--- a/integration-test/919-gates-line-geometry.py
+++ b/integration-test/919-gates-line-geometry.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class GatesLineGeometry(OsmFixtureTest):
+class GatesLineGeometry(FixtureTest):
     def test_linear_gate(self):
         # Add barrier:gates with line geometries in landuse
         # Line barrier:ghate feature

--- a/integration-test/922-source-in-POI.py
+++ b/integration-test/922-source-in-POI.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class SourceInPoi(OsmFixtureTest):
+class SourceInPoi(FixtureTest):
     def test_poi_has_source(self):
         # Add source info in POIs
         self.load_fixtures(['https://www.openstreetmap.org/way/423023928'])

--- a/integration-test/927-normalize-operator-values.py
+++ b/integration-test/927-normalize-operator-values.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NormalizeOperatorValues(OsmFixtureTest):
+class NormalizeOperatorValues(FixtureTest):
     def test_us_national_park_service(self):
         # Standardize operator values
         # US National Park Service in POIS

--- a/integration-test/931-locality-changes-places.py
+++ b/integration-test/931-locality-changes-places.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class LocalityChangesPlacesNe(OsmFixtureTest):
+class LocalityChangesPlacesNe(FixtureTest):
 
     def setUp(self):
         super(LocalityChangesPlacesNe, self).setUp()
@@ -48,7 +48,7 @@ class LocalityChangesPlacesNe(OsmFixtureTest):
              'kind_detail': 'scientific_station'})
 
 
-class LocalityChangesPlacesOsm(OsmFixtureTest):
+class LocalityChangesPlacesOsm(FixtureTest):
     def test_no_region_capital_false(self):
         # Washington (158368533)
         # no region_capital false

--- a/integration-test/935-source-in-transit.py
+++ b/integration-test/935-source-in-transit.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class SourceInTransit(OsmFixtureTest):
+class SourceInTransit(FixtureTest):
     def test_source_in_transit(self):
         # Add source info in transit
         # Way: 189011731

--- a/integration-test/951-remove-sea.py
+++ b/integration-test/951-remove-sea.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RemoveSea(OsmFixtureTest):
+class RemoveSea(FixtureTest):
     def test_drop_sea_polygon_but_keep_label(self):
         # Drop sea polygon but keep the label
         self.load_fixtures([

--- a/integration-test/970-kind-detail-for-all-roads.py
+++ b/integration-test/970-kind-detail-for-all-roads.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class KindDetailForAllRoads(OsmFixtureTest):
+class KindDetailForAllRoads(FixtureTest):
     def test_ferry(self):
         # Alameda <-> SF Ferry bldg
         self.load_fixtures(['http://www.openstreetmap.org/way/98752535'])

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class FractionalPois(OsmFixtureTest):
+class FractionalPois(FixtureTest):
     def test_apple_store(self):
         # Apple Store, SF
         self.load_fixtures(['https://www.openstreetmap.org/way/332223480'])
@@ -46,7 +46,7 @@ class FractionalPois(OsmFixtureTest):
              'name': 'Vermonter'})
 
 
-class FractionalPoisNe(OsmFixtureTest):
+class FractionalPoisNe(FixtureTest):
 
     def setUp(self):
         super(FractionalPoisNe, self).setUp()

--- a/integration-test/981-remove-unstyled-ne-places.py
+++ b/integration-test/981-remove-unstyled-ne-places.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RemoveUnstyledNePlaces(OsmFixtureTest):
+class RemoveUnstyledNePlaces(FixtureTest):
 
     def setUp(self):
         super(RemoveUnstyledNePlaces, self).setUp()

--- a/integration-test/982-remove-unstyled-localities.py
+++ b/integration-test/982-remove-unstyled-localities.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RemoveUnstyledLocalities(OsmFixtureTest):
+class RemoveUnstyledLocalities(FixtureTest):
     def test_zoom_8(self):
         # zoom 8:
         # include only those localities with name and population and

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class NationalForests(OsmFixtureTest):
+class NationalForests(FixtureTest):
     def test_boundary_national_park(self):
         # Example Stanislaus National Forest in California near Yosemite
         # should be kind:forest.

--- a/integration-test/990-add-art-galleries.py
+++ b/integration-test/990-add-art-galleries.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class AddArtGalleries(OsmFixtureTest):
+class AddArtGalleries(FixtureTest):
     def test_node(self):
         self.load_fixtures(['http://www.openstreetmap.org/node/2026996113'])
 

--- a/integration-test/992-boundaries-min_zoom-and-name.py
+++ b/integration-test/992-boundaries-min_zoom-and-name.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class BoundariesMinZoomAndNameNe(OsmFixtureTest):
+class BoundariesMinZoomAndNameNe(FixtureTest):
     # global:
     #   # NOTE: Natural Earth 1:50 million used zooms 0,1,2,3,4
     #   #       and only has USA, Canada, Brazil, and Australia
@@ -124,7 +124,7 @@ class BoundariesMinZoomAndNameNe(OsmFixtureTest):
             {'kind': 'region', 'min_zoom': 7})
 
 
-class BoundariesMinZoomAndNameOsm(OsmFixtureTest):
+class BoundariesMinZoomAndNameOsm(FixtureTest):
     def test_region_boundary_zug_luzern(self):
         # Switzerland region HAS name, OpenStreetMap
         self.load_fixtures([

--- a/integration-test/993-remove-props-road-merge.py
+++ b/integration-test/993-remove-props-road-merge.py
@@ -1,7 +1,7 @@
-from . import OsmFixtureTest
+from . import FixtureTest
 
 
-class RemovePropsRoadMerge(OsmFixtureTest):
+class RemovePropsRoadMerge(FixtureTest):
     # NOTE: fixtures load up a single element, so this doesn't actually test
     # merging itself, only that we drop the properties (which can lead to
     # more merges).

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -226,7 +226,7 @@ def load_tests(loader, standard_tests, pattern=None, download_only=False):
             while True:
                 line = f.readline()
                 if not line.startswith('#'):
-                    new_test = (line == 'from . import OsmFixtureTest\n')
+                    new_test = (line == 'from . import FixtureTest\n')
                     break
             if not new_test:
                 continue
@@ -236,7 +236,7 @@ def load_tests(loader, standard_tests, pattern=None, download_only=False):
 
         mod = import_module(test_dir + '.' + path.rsplit('.', 1)[0])
 
-        # pass a parameter to OsmFixtureTest telling it whether or not to
+        # pass a parameter to FixtureTest telling it whether or not to
         # actually run the tests. setting download_only=True means it only
         # downloads the fixtures and stubs out all the test methods to pass.
         #
@@ -249,7 +249,7 @@ def load_tests(loader, standard_tests, pattern=None, download_only=False):
                issubclass(klass, unittest.TestCase):
                 names = loader.getTestCaseNames(klass)
                 for name in names:
-                    # TODO: when not instanceof OsmFixtureTest, don't add the
+                    # TODO: when not instanceof FixtureTest, don't add the
                     # download_only parameter.
                     standard_tests.addTest(klass(name, download_only))
 
@@ -1185,10 +1185,10 @@ class EmptyContext(object):
         pass
 
 
-class OsmFixtureTest(unittest.TestCase):
+class FixtureTest(unittest.TestCase):
 
     def __init__(self, methodName='runTest', download_only=False):
-        super(OsmFixtureTest, self).__init__(methodName)
+        super(FixtureTest, self).__init__(methodName)
         self.download_only = download_only
 
     def setUp(self):
@@ -1247,11 +1247,11 @@ class OsmFixtureTest(unittest.TestCase):
 
     def assertTrue(self, *args, **kwargs):
         if not self.download_only:
-            super(OsmFixtureTest, self).assertTrue(*args, **kwargs)
+            super(FixtureTest, self).assertTrue(*args, **kwargs)
 
     def assertFalse(self, *args, **kwargs):
         if not self.download_only:
-            super(OsmFixtureTest, self).assertFalse(*args, **kwargs)
+            super(FixtureTest, self).assertFalse(*args, **kwargs)
 
     def tile_bbox(self, z, x, y, padding=0.0):
         coord = Coordinate(zoom=z, column=x, row=y)

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -216,24 +216,6 @@ def load_tests(loader, standard_tests, pattern=None, download_only=False):
         if path.startswith('.'):
             continue
 
-        pathname = path_join(test_dir, path)
-
-        try:
-            f = open(pathname, 'U')
-
-            # TODO: take this out after all the tests have been converted!
-            new_test = False
-            while True:
-                line = f.readline()
-                if not line.startswith('#'):
-                    new_test = (line == 'from . import FixtureTest\n')
-                    break
-            if not new_test:
-                continue
-        finally:
-            if f:
-                f.close()
-
         mod = import_module(test_dir + '.' + path.rsplit('.', 1)[0])
 
         # pass a parameter to FixtureTest telling it whether or not to

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -199,8 +199,12 @@ def closest_matching(features, properties):
     return (min_feature, min_misses)
 
 
-def load_tests(loader, standard_tests, pattern=None, download_only=False):
+def load_tests(loader, standard_tests, test_instance, pattern=None):
     test_dir = dirname(__file__)
+
+    # can't load modules if there's a ".." in the path to them
+    assert ".." not in test_dir
+
     if pattern is None:
         pattern = '*.py'
 
@@ -226,6 +230,10 @@ def load_tests(loader, standard_tests, pattern=None, download_only=False):
         # to do with CircleCI, as the cache is only saved after the
         # dependencies step, not after the test step itself.
         for name in dir(mod):
+            # skip any "special" names, as these won't contain any tests.
+            if name.startswith('__'):
+                continue
+
             klass = getattr(mod, name)
             if isinstance(klass, type) and \
                issubclass(klass, unittest.TestCase):
@@ -233,7 +241,7 @@ def load_tests(loader, standard_tests, pattern=None, download_only=False):
                 for name in names:
                     # TODO: when not instanceof FixtureTest, don't add the
                     # download_only parameter.
-                    standard_tests.addTest(klass(name, download_only))
+                    standard_tests.addTest(klass(name, test_instance))
 
     return standard_tests
 
@@ -1167,16 +1175,13 @@ class EmptyContext(object):
         pass
 
 
-class FixtureTest(unittest.TestCase):
+class RunTestInstance(object):
 
-    def __init__(self, methodName='runTest', download_only=False):
-        super(FixtureTest, self).__init__(methodName)
-        self.download_only = download_only
-
-    def setUp(self):
+    def setUp(self, test):
         self.env = make_fixture_environment()
+        self.test = test
 
-    def load_fixtures(self, urls, clip=None, simplify=None):
+    def load_fixtures(self, urls, clip, simplify):
         geojson_file = self.env.ensure_fixture_file(urls, clip, simplify)
 
         if environ.get('VERBOSE'):
@@ -1188,52 +1193,165 @@ class FixtureTest(unittest.TestCase):
                     % (self.id(), geojson_size)
 
         feature_fetcher = FixtureFeatureFetcher([geojson_file], self.env)
-        self.assertions = Assertions(feature_fetcher, self)
+        self.assertions = Assertions(feature_fetcher, self.test)
 
     def assert_has_feature(self, z, x, y, layer, props):
-        if not self.download_only:
-            self.assertions.assert_has_feature(z, x, y, layer, props)
+        self.assertions.assert_has_feature(z, x, y, layer, props)
 
     def assert_no_matching_feature(self, z, x, y, layer, props):
-        if not self.download_only:
-            self.assertions.assert_no_matching_feature(z, x, y, layer, props)
+        self.assertions.assert_no_matching_feature(z, x, y, layer, props)
 
     def assert_feature_geom_type(self, z, x, y, layer, feature_id,
                                  exp_geom_type):
-        if not self.download_only:
-            self.assertions.assert_feature_geom_type(
-                z, x, y, layer, feature_id, exp_geom_type)
+        self.assertions.assert_feature_geom_type(
+            z, x, y, layer, feature_id, exp_geom_type)
 
     def assert_less_than_n_features(self, z, x, y, layer, properties, n):
-        if not self.download_only:
-            self.assertions.assert_less_than_n_features(
-                z, x, y, layer, properties, n)
+        self.assertions.assert_less_than_n_features(
+            z, x, y, layer, properties, n)
 
     def features_in_tile_layer(self, z, x, y, layer):
-        if not self.download_only:
-            return self.assertions.ff.features_in_tile_layer(z, x, y, layer)
-        else:
-            return EmptyContext()
+        return self.assertions.ff.features_in_tile_layer(z, x, y, layer)
 
     def layers_in_tile(self, z, x, y):
-        if not self.download_only:
-            return self.assertions.ff.layers_in_tile(z, x, y)
-        else:
-            return EmptyContext()
+        return self.assertions.ff.layers_in_tile(z, x, y)
 
     def features_in_mvt_layer(self, z, x, y, layer):
-        if not self.download_only:
-            return self.assertions.ff.features_in_mvt_layer(z, x, y, layer)
-        else:
-            return EmptyContext()
+        return self.assertions.ff.features_in_mvt_layer(z, x, y, layer)
 
     def assertTrue(self, *args, **kwargs):
-        if not self.download_only:
-            super(FixtureTest, self).assertTrue(*args, **kwargs)
+        self.test.assertTrue(*args, **kwargs)
 
     def assertFalse(self, *args, **kwargs):
-        if not self.download_only:
-            super(FixtureTest, self).assertFalse(*args, **kwargs)
+        self.test.assertFalse(*args, **kwargs)
+
+
+class DownloadOnlyInstance(object):
+
+    def setUp(self, test):
+        self.env = make_fixture_environment()
+        self.test = test
+
+    def load_fixtures(self, urls, clip, simplify):
+        self.env.ensure_fixture_file(urls, clip, simplify)
+
+    def assert_has_feature(self, z, x, y, layer, props):
+        pass
+
+    def assert_no_matching_feature(self, z, x, y, layer, props):
+        pass
+
+    def assert_feature_geom_type(self, z, x, y, layer, feature_id,
+                                 exp_geom_type):
+        pass
+
+    def assert_less_than_n_features(self, z, x, y, layer, properties, n):
+        pass
+
+    def features_in_tile_layer(self, z, x, y, layer):
+        return EmptyContext()
+
+    def layers_in_tile(self, z, x, y):
+        return EmptyContext()
+
+    def features_in_mvt_layer(self, z, x, y, layer):
+        return EmptyContext()
+
+    def assertTrue(self, *args, **kwargs):
+        pass
+
+    def assertFalse(self, *args, **kwargs):
+        pass
+
+
+class CollectTilesInstance(object):
+
+    def __init__(self):
+        self.tiles = set()
+
+    def _add_tile(self, z, x, y):
+        self.tiles.add((z, x, y))
+
+    def setUp(self, test):
+        self.test = test
+
+    def load_fixtures(self, urls, clip, simplify):
+        pass
+
+    def assert_has_feature(self, z, x, y, layer, props):
+        self._add_tile(z, x, y)
+
+    def assert_no_matching_feature(self, z, x, y, layer, props):
+        self._add_tile(z, x, y)
+
+    def assert_feature_geom_type(self, z, x, y, layer, feature_id,
+                                 exp_geom_type):
+        self._add_tile(z, x, y)
+
+    def assert_less_than_n_features(self, z, x, y, layer, properties, n):
+        self._add_tile(z, x, y)
+
+    def features_in_tile_layer(self, z, x, y, layer):
+        self._add_tile(z, x, y)
+        return EmptyContext()
+
+    def layers_in_tile(self, z, x, y):
+        self._add_tile(z, x, y)
+        return EmptyContext()
+
+    def features_in_mvt_layer(self, z, x, y, layer):
+        self._add_tile(z, x, y)
+        return EmptyContext()
+
+    def assertTrue(self, *args, **kwargs):
+        pass
+
+    def assertFalse(self, *args, **kwargs):
+        pass
+
+
+class FixtureTest(unittest.TestCase):
+
+    def __init__(self, methodName='runTest', test_instance=None):
+        super(FixtureTest, self).__init__(methodName)
+        self.test_instance = test_instance
+
+    def setUp(self):
+        test = super(FixtureTest, self)
+        self.test_instance.setUp(test)
+
+    def load_fixtures(self, urls, clip=None, simplify=None):
+        self.test_instance.load_fixtures(urls, clip, simplify)
+
+    def assert_has_feature(self, z, x, y, layer, props):
+        self.test_instance.assert_has_feature(z, x, y, layer, props)
+
+    def assert_no_matching_feature(self, z, x, y, layer, props):
+        self.test_instance.assert_no_matching_feature(z, x, y, layer, props)
+
+    def assert_feature_geom_type(self, z, x, y, layer, feature_id,
+                                 exp_geom_type):
+        self.test_instance.assert_feature_geom_type(
+            z, x, y, layer, feature_id, exp_geom_type)
+
+    def assert_less_than_n_features(self, z, x, y, layer, properties, n):
+        self.test_instance.assert_less_than_n_features(
+            z, x, y, layer, properties, n)
+
+    def features_in_tile_layer(self, z, x, y, layer):
+        return self.test_instance.features_in_tile_layer(z, x, y, layer)
+
+    def layers_in_tile(self, z, x, y):
+        return self.test_instance.layers_in_tile(z, x, y)
+
+    def features_in_mvt_layer(self, z, x, y, layer):
+        return self.test_instance.features_in_mvt_layer(z, x, y, layer)
+
+    def assertTrue(self, *args, **kwargs):
+        self.test_instance.assertTrue(*args, **kwargs)
+
+    def assertFalse(self, *args, **kwargs):
+        self.test_instance.assertFalse(*args, **kwargs)
 
     def tile_bbox(self, z, x, y, padding=0.0):
         coord = Coordinate(zoom=z, column=x, row=y)
@@ -1398,6 +1516,7 @@ if __name__ == '__main__':
     from unittest.util import strclass
     import sys
     import argparse
+    import os
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -1407,11 +1526,24 @@ if __name__ == '__main__':
         '--download-only', dest='download_only', action='store_const',
         const=True, default=False, help='Only download the fixtures, do not '
         'actually run the tests.')
+    parser.add_argument(
+        '--print-coords', dest='print_coords', action='store_const',
+        const=True, default=False, help='Print out the coordinates used by '
+        'the tests.')
     args = parser.parse_args()
+
+    test_stdout = sys.stderr
+    if args.download_only:
+        test_instance = DownloadOnlyInstance()
+    elif args.print_coords:
+        test_instance = CollectTilesInstance()
+        test_stdout = open(os.devnull, 'w')
+    else:
+        test_instance = RunTestInstance()
 
     loader = unittest.TestLoader()
     suite = load_tests(loader, unittest.TestSuite(),
-                       download_only=args.download_only)
+                       test_instance=test_instance)
 
     # convert filenames such as 'integration-test/1234-my-test.py' to the
     # equivalent module name. this can be helpful on the command line, when
@@ -1439,8 +1571,12 @@ if __name__ == '__main__':
     suite = unittest.TestSuite()
     suite.addTests(tests)
 
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(stream=test_stdout)
     result = runner.run(suite)
 
     if not result.wasSuccessful():
         sys.exit(1)
+
+    if isinstance(test_instance, CollectTilesInstance):
+        for z, x, y in test_instance.tiles:
+            print "%d/%d/%d" % (z, x, y)

--- a/scripts/update-integration-test-coordinates.sh
+++ b/scripts/update-integration-test-coordinates.sh
@@ -2,4 +2,6 @@
 
 basedir="$(dirname ${BASH_SOURCE[0]})/.."
 
-python ${basedir}/integration-test.py -printcoords | python ${basedir}/scripts/update-integration-test-coordinates.py
+cd $basedir
+
+python integration-test/__init__.py --print-coords | python scripts/update-integration-test-coordinates.py


### PR DESCRIPTION
As part of changing the test cases, I broke the uploading of the tile coordinates used in the tests. This adds that back in, along with a confusing rename of `OsmFixtureTest` to `FixtureTest` (since it actually handles all kinds of data sources, not just OSM).