### PR TITLE
Cache fixtures in S3 after a successful test.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ deployment:
       - pip install 'Circle-Beacon == 2.0.0'
       - alert-circle mapzen documentation master $CIRCLE_TOKEN
       - ./scripts/update-integration-test-coordinates.sh
+      - s3cmd --continue-put put ~/.cache/vector-datasource/*.geojson s3://mapzen-tiles-assets/integration-test-fixtures/
   release:
     tag: /.+/
     commands:

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -55,7 +55,9 @@ OVERPASS_SERVER = environ.get('OVERPASS_SERVER', 'overpass-api.de')
 # the fixture cache stores generated GeoJSON fixtures. these can be somewhat
 # expensive to generate (running `osm2pgsql` and so forth), so it seems worth
 # caching them for everyone to reuse.
-FIXTURE_CACHE = environ.get('FIXTURE_CACHE', 'http://localhost:8000')
+FIXTURE_CACHE = environ.get(
+    'FIXTURE_CACHE',
+    'http://s3.amazonaws.com/mapzen-tiles-assets/integration-test-fixtures/')
 
 
 def make_acceptable_module_name(path):

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -57,7 +57,7 @@ OVERPASS_SERVER = environ.get('OVERPASS_SERVER', 'overpass-api.de')
 # caching them for everyone to reuse.
 FIXTURE_CACHE = environ.get(
     'FIXTURE_CACHE',
-    'http://s3.amazonaws.com/mapzen-tiles-assets/integration-test-fixtures/')
+    'http://s3.amazonaws.com/mapzen-tiles-assets/integration-test-fixtures')
 
 
 def make_acceptable_module_name(path):


### PR DESCRIPTION
This should mean that anyone starting from a blank slate should be able to download fixtures from S3 rather than needing to regenerate them from scratch, and this should be much quicker.
