### PR TITLE
Fix root relation IDs for stations

### DIFF
--- a/integration-test/653-unify-building-part.py
+++ b/integration-test/653-unify-building-part.py
@@ -1,6 +1,12 @@
 from . import FixtureTest
 
 
+def _tile_centre(z, x, y):
+    from tilequeue.tile import num2deg
+    lat, lon = num2deg(x + 0.5, y + 0.5, z)
+    return (lon, lat)
+
+
 class UnifyBuildingPart(FixtureTest):
     def test_one_madison(self):
         # Way: One Madison
@@ -50,4 +56,28 @@ class UnifyBuildingPart(FixtureTest):
         self.assert_has_feature(
             16, 32747, 21793, 'pois',
             {'id': 3638795618, 'root_id': 1242762,
+             'root_relation_id': type(None)})
+
+    def test_generic_station_hierarchy(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.point(1, _tile_centre(z, x, y), {
+                'railway': 'station',
+                'name': 'Foo Station',
+            }),
+            dsl.relation(2, {
+                'type': 'site',
+                'site': 'public_transport',
+            }, nodes=[1]),
+        )
+
+        # NOTE: the check for 'root_relation_id' = None is because this
+        # property was renamed to 'root_id' and therefore the old key should
+        # not be used any more.
+        self.assert_has_feature(
+            z, x, y, 'pois',
+            {'id': 1, 'kind': 'station', 'root_id': 2,
              'root_relation_id': type(None)})

--- a/integration-test/653-unify-building-part.py
+++ b/integration-test/653-unify-building-part.py
@@ -35,22 +35,19 @@ class UnifyBuildingPart(FixtureTest):
             16, 10486, 25326, 'buildings',
             {'id': 404449724, 'kind': 'building_part', 'root_id': 24460886})
 
-    # TODO: fix this - it needs the relation-walking code to find the root
-    # relation ID, but that hasn't been implemented yet.
-    #
-    # def test_waterloo_station(self):
-    #     self.load_fixtures([
-    #         'http://www.openstreetmap.org/relation/1242762',  # tube and rail
-    #         'http://www.openstreetmap.org/relation/238793',   # tube station
-    #         'http://www.openstreetmap.org/relation/238792',   # building
-    #     ])
+    def test_waterloo_station(self):
+        self.load_fixtures([
+            'http://www.openstreetmap.org/relation/1242762',  # tube and rail
+            'http://www.openstreetmap.org/relation/238793',   # tube station
+            'http://www.openstreetmap.org/relation/238792',   # building
+        ])
 
-    #     self.assert_has_feature(
-    #         16, 32747, 21793, 'pois',
-    #         {'id': 3638795617, 'root_id': 1242762,
-    #          'root_relation_id': type(None)})
+        self.assert_has_feature(
+            16, 32747, 21793, 'pois',
+            {'id': 3638795617, 'root_id': 1242762,
+             'root_relation_id': type(None)})
 
-    #     self.assert_has_feature(
-    #         16, 32747, 21793, 'pois',
-    #         {'id': 3638795618, 'root_id': 1242762,
-    #          'root_relation_id': type(None)})
+        self.assert_has_feature(
+            16, 32747, 21793, 'pois',
+            {'id': 3638795618, 'root_id': 1242762,
+             'root_relation_id': type(None)})

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -957,7 +957,10 @@ def _load_fixture(fh):
         props = feature['properties']
         rel_ids = set(feature.get('relation_ids', []))
         if rel_ids:
-            rels = filter(lambda r: r['id'] in rel_ids, relations)
+            rels = []
+            for r in relations:
+                if r['id'] in rel_ids:
+                    rels.append(r)
             if rels:
                 props['__relations__'] = rels
         geom_lnglat = make_shape(feature['geometry'])
@@ -1239,8 +1242,13 @@ class RunTestInstance(object):
         # or tuples of (fid, shape, properties). the rels should be dicts with
         # keys for id, tags, way and rel offsets and "parts" array of IDs, as
         # if they had come from osm2pgsql's planet_osm_rels table.
-        rows = filter(lambda o: isinstance(o, tuple), objs)
-        rels = filter(lambda o: isinstance(o, dict), objs)
+        rows = []
+        rels = []
+        for o in objs:
+            if isinstance(o, tuple):
+                rows.append(o)
+            elif isinstance(o, dict):
+                rels.append(o)
 
         feature_fetcher = FixtureFeatureFetcher(rows, rels, self.env)
         self.assertions = Assertions(feature_fetcher, self.test)

--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -1,0 +1,27 @@
+from collections import namedtuple
+from shapely.geometry import Point
+from tilequeue.tile import reproject_lnglat_to_mercator
+
+
+Feature = namedtuple('Feature', 'fid shape properties')
+
+
+# simple utility wrapper to generate a Feature at a point. note that the
+# position is expected to be in (lon, lat) coordinates.
+def point(id, position, tags):
+    x, y = reproject_lnglat_to_mercator(*position)
+    return Feature(id, Point(x, y), tags)
+
+
+# the fixture code expects "raw" relations as if they come straight from
+# osm2pgsql. the structure is a little cumbersome, so this utility function
+# constructs it from a more readable function call.
+def relation(id, tags, nodes=None, ways=None, relations=None):
+    nodes = nodes or []
+    ways = ways or []
+    relations = relations or []
+    way_off = len(nodes)
+    rel_off = way_off + len(ways)
+    return dict(
+        id=id, tags=tags, way_off=way_off, rel_off=rel_off,
+        parts=(nodes + ways + relations))

--- a/tilejson/tilejson.json.erb
+++ b/tilejson/tilejson.json.erb
@@ -150,7 +150,7 @@
                 "is_subway" : "Boolean. Indicating whether this station has any routes of the given type as a convenience for styling. Optional value.",
                 "is_light_rail" : "Boolean. Indicating whether this station has any routes of the given type as a convenience for styling. Optional value.",
                 "is_tram" : "Boolean. Indicating whether this station has any routes of the given type as a convenience for styling. Optional value.",
-                "root_relation_id" : "Integer. The ID of the OpenStreetMap relation which can be used to link or group together features which are related by being part of a larger feature. A full explanation of [relations](http://wiki.openstreetmap.org/wiki/Relation) wouldn't fit here, but the general idea is that all the station features which are part of the same site. Optional value.",
+                "root_id" : "Integer. The ID of the OpenStreetMap relation which can be used to link or group together features which are related by being part of a larger feature. A full explanation of [relations](http://wiki.openstreetmap.org/wiki/Relation) wouldn't fit here, but the general idea is that all the station features which are part of the same site. Optional value.",
                 "capacity" : "Integer. Approximate number of total rental bicycles at the bike share station. Optional value.",
                 "network" : "String. The common (sometimes branded) name of the bike share network, eg: 'Citi Bike'. Optional value.",
                 "operator" : "String. Who actually runs the bike share station, eg: 'NYC Bike Share'. Optional value.",


### PR DESCRIPTION
Fetches recursive tree of relations rather than just relations directly including features in the fixture. This means the station relations can be walked to provide access to all the station points, lines and site relations. We use this to add a `root_id` property for grouping items related to the same station.

* Add a test option to always regenerate fixtures - useful for testing.
* Add (previously commented-out) test for root relation ID.
* Added a generative test for station root relations.
* We renamed root_relation_id to root_id some time ago, updating docs to match.

Fixes #1392.
