### PR TITLE
add default value to landuse dam min_zoom

### DIFF
--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -935,16 +935,16 @@ filters:
       kind: water_park
   - filter:
       waterway: dam
-    min_zoom:
-      case:
-        - when: { geom_type: line }
-          then: 12
-        - when: { geom_type: polygon }
-          then:
-            clamp:
-              min: 9
-              max: 16
-              value: { col: zoom }
+      geom_type: line
+    min_zoom: 12
+    output:
+      <<: *output_properties
+      kind: dam
+    extra_columns: [way]
+  - filter:
+      waterway: dam
+      geom_type: polygon
+    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
     output:
       <<: *output_properties
       kind: dam


### PR DESCRIPTION
I would like to propose this change so that all min_zoom expression are guaranteed to return a number. In this case, if a point geometry has `waterway: dam` the expression would eval to null.

As far as I know, this is the only place where the min_zoom expression does not always eval to a number.