### PR TITLE
Use label placement point for representative point, if available.

### DIFF
--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -2757,7 +2757,11 @@ def make_representative_point(shape, properties, fid, zoom):
     polygons.
     """
 
-    shape = shape.representative_point()
+    label_placement_wkb = properties.get('mz_label_placement', None)
+    if label_placement_wkb:
+        shape = shapely.wkb.loads(label_placement_wkb)
+    else:
+        shape = shape.representative_point()
 
     return shape, properties, fid
 


### PR DESCRIPTION
We generate and store a representative point for the whole geometry in the `__label__` and, later, `mz_label_placement` properties. The geometry is clipped at an earlier point in the processing pipeline, so calculating the representative point again results in some duplicate labels. If the original label placement point is available, we can use that instead.
