### PR TITLE
Update call to format_mvt for new signature.

### DIFF
--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -1061,7 +1061,8 @@ class FixtureFeatureFetcher(object):
             io = StringIO()
 
             from tilequeue.format import format_mvt
-            format_mvt(io, pfl, z, bounds_merc, bounds_lnglat)
+            extent = 4096
+            format_mvt(io, pfl, z, bounds_merc, bounds_lnglat, extent)
 
             from mapbox_vector_tile import decode as mvt_decode
             msg = mvt_decode(io.getvalue())


### PR DESCRIPTION
Updated signature for `format_mvt` in https://github.com/tilezen/tilequeue/pull/304, but missed this use of it in the `vector-datasource` integration tests.