### PR TITLE
Make migrations quieter.

### DIFF
--- a/data/migrations/v1.5.0-planet_osm_line.sql
+++ b/data/migrations/v1.5.0-planet_osm_line.sql
@@ -1,6 +1,6 @@
 -- only these 2 columns are relevant in lower zoom queries
 SET client_min_messages TO WARNING;
-CREATE INDEX
+CREATE INDEX IF NOT EXISTS
   planet_osm_line_geom_min_zoom_8_index
   ON planet_osm_line USING gist(way)
   WHERE

--- a/data/migrations/v1.5.0-planet_osm_line.sql
+++ b/data/migrations/v1.5.0-planet_osm_line.sql
@@ -1,4 +1,5 @@
 -- only these 2 columns are relevant in lower zoom queries
+SET client_min_messages TO WARNING;
 CREATE INDEX
   planet_osm_line_geom_min_zoom_8_index
   ON planet_osm_line USING gist(way)
@@ -70,3 +71,4 @@ DROP INDEX IF EXISTS planet_osm_line_boundary_geom_index;
 DROP INDEX IF EXISTS planet_osm_line_boundary_geom_9_index;
 DROP INDEX IF EXISTS planet_osm_line_boundary_geom_12_index;
 DROP INDEX IF EXISTS planet_osm_line_boundary_geom_15_index;
+RESET client_min_messages;

--- a/data/migrations/v1.5.0-planet_osm_point.sql
+++ b/data/migrations/v1.5.0-planet_osm_point.sql
@@ -1,4 +1,5 @@
 -- ladder the point indexes
+SET client_min_messages TO WARNING;
 CREATE INDEX IF NOT EXISTS
   planet_osm_point_geom_min_zoom_6_index
   ON planet_osm_point USING gist(way)
@@ -68,3 +69,4 @@ DROP INDEX IF EXISTS planet_osm_point_min_zoom_places_index;
 DROP INDEX IF EXISTS planet_osm_point_min_zoom_places_9_index;
 DROP INDEX IF EXISTS planet_osm_point_min_zoom_places_12_index;
 DROP INDEX IF EXISTS planet_osm_point_min_zoom_places_15_index;
+RESET client_min_messages;

--- a/data/migrations/v1.5.0-planet_osm_polygon.sql
+++ b/data/migrations/v1.5.0-planet_osm_polygon.sql
@@ -1,4 +1,5 @@
 -- polygon low zoom
+SET client_min_messages TO WARNING;
 CREATE INDEX IF NOT EXISTS
   planet_osm_polygon_geom_min_zoom_7_index
   ON planet_osm_polygon USING gist(way)
@@ -97,3 +98,4 @@ DROP INDEX IF EXISTS planet_osm_polygon_pois_geom_6_index;
 DROP INDEX IF EXISTS planet_osm_polygon_pois_geom_9_index;
 DROP INDEX IF EXISTS planet_osm_polygon_pois_geom_12_index;
 DROP INDEX IF EXISTS planet_osm_polygon_pois_geom_15_index;
+RESET client_min_messages;


### PR DESCRIPTION
- [ ] ~~Update tests~~
- [x] Update data migrations
- [ ] ~~Update docs~~

The output from the script is now
```
(env) pnorman@pippin:~/osm/tilezen/vector-datasource$ data/migrations/run_migrations.sh -d osm
SKIPPING data/migrations/v1.5.0-ne.sql - this will be run after the functions.
SKIPPING data/migrations/v1.5.0-planet_osm_line.sql - this will be run after the functions.
SKIPPING data/migrations/v1.5.0-planet_osm_point.sql - this will be run after the functions.
SKIPPING data/migrations/v1.5.0-planet_osm_polygon.sql - this will be run after the functions.
SKIPPING data/migrations/v1.5.0-prefunction-schema.sql - this was already run before the functions.
```

This means if there's an error, it can be seen. The second commit fixes an error that was being hidden behind the wall of text.