### PR TITLE
Update curated shapefiles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,10 @@ data/*.cpg
 data/*.dbf
 data/*.prj
 data/*.shx
+data/*.qpj
 data/wof_neighbourhoods.pgdump
+data/*.README.html
+data/*.VERSION.txt
 
 # python compiled bytecode and development files
 *.pyc

--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
 bucket: mapzen-tiles-assets
-datestamp: 20161110
+datestamp: 20171201
 
 shapefiles:
 
@@ -22,9 +22,9 @@ shapefiles:
     shapefile-name: land-polygons-split-3857/land_polygons.shp
 
   - name: buffered_land
-    url: http://s3.amazonaws.com/mapzen-tiles-assets/curated/buffered_land_10272016.zip
+    url: http://s3.amazonaws.com/mapzen-tiles-assets/curated/buffered_land_05232017.zip
     prj: 3857
-    shapefile-name: buffered_land_10272016.shp
+    shapefile-name: buffered_land_05232017.shp
     tile: true
 
   - name: ne_110m_lakes
@@ -103,7 +103,7 @@ shapefiles:
   - name: ne_50m_admin_1_states_provinces_lines
     url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_1_states_provinces_lines.zip
     prj: 4326
-    shapefile-name: ne_50m_admin_1_states_provinces_lines_shp.shp
+    shapefile-name: ne_50m_admin_1_states_provinces_lines.shp
 
   - name: ne_10m_admin_1_states_provinces_lines
     url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_1_states_provinces_lines.zip


### PR DESCRIPTION
When deployed, will fix #1257.

Note: Not sure why the shapefile name changed for `ne_50m_admin_1_states_provinces_lines`. I assume it was just a one-off idiosyncrasy before and it's more consistent with the other shapefiles now.