### PR TITLE
Clip buildings to tiles.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -194,6 +194,8 @@ Label position points may also have `closed` or `historical` kind_detail values 
 
 Values for `kind_detail`  are sourced from OpenStreetMap's `building` tag for building footprints and from `building:part` tag for building parts.
 
+Note that building geometries, like most geometries in Tilezen tiles, are clipped to the bounds of the tile, even if the building extends beyond the tile. This means that it might be necessary to assemble geometry from several neighbouring tiles to recreate the full building. Some buildings are exceptionally large and span many tiles, so this can be tricky.
+
 #### Building properties (common):
 
 * `name`

--- a/integration-test/1226-landuse-kind-buildings.py
+++ b/integration-test/1226-landuse-kind-buildings.py
@@ -1,0 +1,73 @@
+from . import FixtureTest
+
+
+class LanduseKindBuildings(FixtureTest):
+    def test_lax_airport_terminals(self):
+        self.load_fixtures([
+            # Terminal 2, which had landuse_kind set correctly at z14
+            'https://www.openstreetmap.org/way/413226245',
+
+            # Tom Bradley International Terminal was missing landuse_kind
+            'https://www.openstreetmap.org/relation/6168071',
+
+            # the aerodrome landuse polygon
+            'https://www.openstreetmap.org/way/131190417',
+        ])
+
+        # the tile which contains Terminal 2 should set the landuse_kind
+        # correctly.
+        self.assert_has_feature(
+            14, 2803, 6547, 'buildings',
+            {'id': 413226245, 'kind': 'building', 'landuse_kind': 'aerodrome'})
+
+        # the four tiles containing bits of Tom Bradley International should
+        # do so also.
+        for x in (2802, 2803):
+            for y in (6547, 6548):
+                self.assert_has_feature(
+                    14, x, y, 'buildings',
+                    {'id': -6168071, 'kind': 'building',
+                     'landuse_kind': 'aerodrome'})
+
+    def test_lax_united_airlines_building(self):
+        self.load_fixtures([
+            # United Airlines building spans two tiles at z16, and neither(?)
+            # of them were getting a landuse_kind assigned.
+            'https://www.openstreetmap.org/relation/6168075',
+
+            # the aerodrome landuse polygon
+            'https://www.openstreetmap.org/way/131190417',
+        ])
+
+        for x in (11209, 11210):
+            self.assert_has_feature(
+                16, x, 26192, 'buildings',
+                {'id': -6168075, 'kind': 'building',
+                 'landuse_kind': 'aerodrome'})
+
+    def test_building_part(self):
+        import dsl
+        from tilequeue.tile import coord_to_bounds
+        from shapely.geometry import box
+        from ModestMaps.Core import Coordinate
+
+        z, x, y = (16, 0, 0)
+        bounds = coord_to_bounds(Coordinate(zoom=z, column=x, row=y))
+        shape = box(*bounds)
+
+        self.generate_fixtures(
+            dsl.way(1, shape,
+                    {'landuse': 'park', 'source': 'openstreetmap.org'}),
+            dsl.way(2, shape,
+                    {'building': 'yes', 'source': 'openstreetmap.org'}),
+            dsl.way(3, shape,
+                    {'building:part': 'yes', 'source': 'openstreetmap.org'}),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'buildings',
+            {'id': 2, 'kind': 'building', 'landuse_kind': 'park'})
+        import pdb; pdb.set_trace()
+        self.assert_has_feature(
+            z, x, y, 'buildings',
+            {'id': 3, 'kind': 'building_part', 'landuse_kind': 'park'})

--- a/integration-test/1226-landuse-kind-buildings.py
+++ b/integration-test/1226-landuse-kind-buildings.py
@@ -67,7 +67,6 @@ class LanduseKindBuildings(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'buildings',
             {'id': 2, 'kind': 'building', 'landuse_kind': 'park'})
-        import pdb; pdb.set_trace()
         self.assert_has_feature(
             z, x, y, 'buildings',
             {'id': 3, 'kind': 'building_part', 'landuse_kind': 'park'})

--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -13,6 +13,13 @@ def point(id, position, tags):
     return Feature(id, Point(x, y), tags)
 
 
+# utility wrapper to generate a Feature from a lat/lon shape.
+def way(id, shape, tags):
+    from shapely.ops import transform
+    merc_shape = transform(reproject_lnglat_to_mercator, shape)
+    return Feature(id, merc_shape, tags)
+
+
 # the fixture code expects "raw" relations as if they come straight from
 # osm2pgsql. the structure is a little cumbersome, so this utility function
 # constructs it from a more readable function call.


### PR DESCRIPTION
Looks like this was done already as part of #1352, so this PR just updates the test to have the behaviour that we want; that all building geometry is within the tile bounds.

Fixes #1142.
