### PR TITLE
Add some basic performance recommendations

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,34 @@
+# Improving performance
+
+Performance doesn't matter much for creating tiles for an extract, but when handling production loads for the entire planet, some thought needs to be given to it
+
+## PostgreSQL
+
+Entire [books](https://www.packtpub.com/big-data-and-business-intelligence/postgresql-high-performance-second-edition) have been written on tuning PostgreSQL. In general, the Tilezen database load is most similar to a Data Warehouse usecase. Look for optimization advice for large databases and ETL workloads, not OLTP ones.
+
+General advice applicable to osm2pgsql rendering should be applicable here, including raster-based rendering. The queries are similar enough.
+
+### Tuning
+
+The following tunables are based on experience on dedicated SSD-based servers with at least 64GB of RAM, and RDS. They are framed as [`ALTER SYSTEM`](https://www.postgresql.org/docs/current/static/sql-altersystem.html) commands, but in production environments it is better to put the settings into your configuration management software.
+
+```sql
+-- For systems with <64GB of RAM, the memory values might need to be scaled down
+ALTER SYSTEM SET effective_cache_size = 56GB;
+ALTER SYSTEM SET shared_buffers = 16GB;
+
+-- The workload involves big queries, but not hundreds of them
+ALTER SYSTEM SET work_mem = 128MB;
+-- osm2pgsql builds big indexes and vector-datasource also has some custom ones
+ALTER SYSTEM SET maintenance_work_mem = 4GB;
+
+-- There can be autovacuum_max_workers running at once, parallel to everything else
+ALTER SYSTEM SET autovacuum_work_mem = 1GB;
+
+-- SSDs are fast on random.
+ALTER SYSTEM SET random_page_cost = 1.2;
+
+-- The default settings won't run autovacuum nearly enough, leading to months between runs
+ALTER SYSTEM SET autovacuum_vacuum_scale_factor = 0.05;
+ALTER SYSTEM SET autovacuum_analyze_scale_factor = 0.02;
+```


### PR DESCRIPTION
This starts a file with selected general performance recommendations and Tilezen specific ones.

There's a some changes from the current settings that are significant

- `work_mem` changed from ~2GB to 128MB. At 2GB I have real concerns about queries taking all the RAM, and I haven't seen much in performance gains past 128MB. 256 would also be reasonable.
- `autovacuum_work_mem` set explicitly. With `maintenance_work_mem` set so high for index builds, it's useful to turn it back down for autovacuum.
- `random_page_cost` reflects current recommendations
- The scale factors will cause autovacuum to run much more often. This is necessary, as otherwise it only runs every few months, trying to do a big giant cleanup.