### PR TITLE
Back-fill building kind detail from POI kinds

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -356,6 +356,8 @@ Values for `kind_detail`  are sourced from OpenStreetMap's `building` tag for bu
 * `wayside_shrine`
 * `works`
 
+Additional `kind_detail` values are provided from POI `kind`s where one is not available from the building feature. This means that you could see any POI `kind` value as a building `kind_detail` value.
+
 #### Building part `kind_detail` values:
 
 * `arch`

--- a/integration-test/487-building-kind-detail.py
+++ b/integration-test/487-building-kind-detail.py
@@ -1,0 +1,23 @@
+from . import FixtureTest
+
+
+class BuildingKindDetail(FixtureTest):
+
+    def _assert_kind_detail(self, way_id, tile, kind_detail):
+        self.load_fixtures([
+            'https://www.openstreetmap.org/way/%d' % (way_id,),
+        ])
+
+        z, x, y = map(int, tile.split('/'))
+        self.assert_has_feature(
+            z, x, y, 'buildings',
+            {'id': way_id, 'kind': 'building', 'kind_detail': kind_detail})
+
+    def test_whole_foods(self):
+        self._assert_kind_detail(194906343, '16/10480/25336', 'supermarket')
+
+    def test_foods_co(self):
+        self._assert_kind_detail(25821952, '16/10482/25332', 'supermarket')
+
+    def test_costco(self):
+        self._assert_kind_detail(43100828, '16/10483/25332', 'supermarket')

--- a/queries.yaml
+++ b/queries.yaml
@@ -856,6 +856,15 @@ post_process:
       end_zoom: 16
       tolerance: 1.0
 
+  # NOTE: want to do this _before_ buildings_unify, as after that we might not
+  # have a feature ID to match buildings on!
+  - fn: vectordatasource.transform.backfill_from_other_layer
+    params:
+      layer: buildings
+      layer_key: kind_detail
+      other_layer: pois
+      other_key: kind
+
   - fn: vectordatasource.transform.buildings_unify
     params:
       source_layer: buildings

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4446,3 +4446,53 @@ def palettize_colours(ctx):
                 props[attr_name] = palette(rgb)
 
     return layer
+
+
+def backfill_from_other_layer(ctx):
+    """
+    Matches features from one layer with the other on the basis of the feature
+    ID and, if the configured layer property doesn't exist on the feature, but
+    the other layer property does exist on the matched feature, then copy it
+    across.
+
+    The initial use for this is to backfill POI kinds into building kind_detail
+    when the building doesn't already have a different kind_detail supplied.
+    """
+
+    layer_name = ctx.params.get('layer')
+    assert layer_name, \
+        'Parameter layer was missing from ' \
+        'backfill_from_other_layer config'
+    other_layer_name = ctx.params.get('other_layer')
+    assert other_layer_name, \
+        'Parameter other_layer_name was missing from ' \
+        'backfill_from_other_layer config'
+    layer_key = ctx.params.get('layer_key')
+    assert layer_key, \
+        'Parameter layer_key was missing from ' \
+        'backfill_from_other_layer config'
+    other_key = ctx.params.get('other_key')
+    assert other_key, \
+        'Parameter other_key was missing from ' \
+        'backfill_from_other_layer config'
+
+    layer = _find_layer(ctx.feature_layers, layer_name)
+    other_layer = _find_layer(ctx.feature_layers, other_layer_name)
+
+    # build an index of feature ID to property value in the other layer
+    other_values = {}
+    for (shape, props, fid) in other_layer['features']:
+        kind = props.get(other_key)
+        # make sure fid is truthy, as it can be set to None on features
+        # created by merging.
+        if kind and fid:
+            other_values[fid] = kind
+
+    # apply those to features which don't already have a value
+    for (shape, props, fid) in layer['features']:
+        if layer_key not in props:
+            value = other_values.get(fid)
+            if value:
+                props[layer_key] = value
+
+    return layer

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4482,6 +4482,8 @@ def backfill_from_other_layer(ctx):
     # build an index of feature ID to property value in the other layer
     other_values = {}
     for (shape, props, fid) in other_layer['features']:
+        # prefer to use the `id` property rather than the fid.
+        fid = props.get('id', fid)
         kind = props.get(other_key)
         # make sure fid is truthy, as it can be set to None on features
         # created by merging.
@@ -4491,6 +4493,7 @@ def backfill_from_other_layer(ctx):
     # apply those to features which don't already have a value
     for (shape, props, fid) in layer['features']:
         if layer_key not in props:
+            fid = props.get('id', fid)
             value = other_values.get(fid)
             if value:
                 props[layer_key] = value


### PR DESCRIPTION
This derives `kind_detail` on buildings from the POI feature with the same feature ID. This might not work if the building is visible when the POI isn't, or when we've done something to the building or POI to change the feature ID. But it should work in most, simple cases.

Connects to #487.
