### PR TITLE
Include all name variants.

### DIFF
--- a/integration-test/1406-include-all-name-variants.py
+++ b/integration-test/1406-include-all-name-variants.py
@@ -1,0 +1,14 @@
+from . import FixtureTest
+
+
+class IncludeAllNameVariants(FixtureTest):
+
+    def test_duplicate_names(self):
+        self.load_fixtures([
+            'http://www.openstreetmap.org/node/206270454',
+        ])
+
+        self.assert_has_feature(
+            15, 18199, 11103, 'pois',
+            {'id': 206270454, 'kind': 'station',
+             'name': None, 'name:pl': None})

--- a/integration-test/418-wof-l10n_name.py
+++ b/integration-test/418-wof-l10n_name.py
@@ -26,7 +26,7 @@ class WofL10nName(FixtureTest):
             {'id': 85882641, 'kind': 'neighbourhood',
              'source': "whosonfirst.mapzen.com",
              'name': 'San Francisco',
-             'name:es': type(None)})
+             'name:es': 'San Francisco'})
 
     def test_san_francisco_osm(self):
         # San Francisco (osm city)

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -469,8 +469,6 @@ def tags_name_i18n(shape, properties, fid, zoom):
 
     langs = {}
     for k, v in tags.items():
-        if v == name:
-            continue
         for candidate in alt_name_prefix_candidates:
 
             if k.startswith(candidate):


### PR DESCRIPTION
Previous behaviour was to de-duplicate name variants with the same value as the main name tag. However, that breaks name fall-back logic when one doesn't want to fall back to the main name. For example, something tagged with `name=Foo, name:A=Foo, name:B=Bar` would remove the `name:A` tag, meaning that if the name preference display was `A` then `B` then local, it would display `Bar` instead of `Foo`.

Connects to #1406.
