### PR TITLE
Remove unused wooded area tags + natural=park and add leaf_type to wooded areas

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -572,6 +572,9 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 
 The value of the OpenStreetMap `wetland` tag. Common values are `bog`, `fen`, `mangrove`, `marsh`, `reedbed`, `saltmarsh`, `string_bog`, `swamp`, `tidalflat`, and `wet_meadow`.
 
+#### Wood and forest `kind_detail` values
+* The value of the OpenStreetMap `leaf_type` tag. [Common values](https://taginfo.openstreetmap.org/keys/leaf_type#values) are `broadleaved`, `needleleaved`, or `mixed`.
+
 ## Places
 
 ![image](images/mapzen-vector-tile-docs-places.png)

--- a/integration-test/1425-osm-features.py
+++ b/integration-test/1425-osm-features.py
@@ -57,6 +57,32 @@ class FeatureTests(FixtureTest):
             '16/19318/24656', 'landuse',
             {'kind': 'wetland', 'kind_detail': 'tidalflat'})
 
+    def test_wood_leaf_type(self):
+        self._run_test(
+            'http://www.openstreetmap.org/way/19174535',
+            '16/19310/24600', 'landuse', {'kind': 'natural_wood'})
+        self._run_test(
+            'http://www.openstreetmap.org/way/429020668',
+            '16/19308/24610', 'landuse',
+            {'kind': 'natural_wood', 'kind_detail': 'broadleaved'})
+        self._run_test(
+            'http://www.openstreetmap.org/way/456466352',
+            '16/19372/24598', 'landuse',
+            {'kind': 'natural_wood', 'kind_detail': 'mixed'})
+
+    def test_forest_leaf_type(self):
+        self._run_test(
+            'http://www.openstreetmap.org/way/27106290',
+            '16/19289/24630', 'landuse', {'kind': 'forest'})
+        self._run_test(
+            'http://www.openstreetmap.org/way/337809950',
+            '16/19530/24590', 'landuse',
+            {'kind': 'forest', 'kind_detail': 'broadleaved'})
+        self._run_test(
+            'http://www.openstreetmap.org/way/443206773',
+            '16/19461/24578', 'landuse',
+            {'kind': 'forest', 'kind_detail': 'mixed'})
+
     def _run_test(self, url, zxy, layer, props):
         z, x, y = map(int, zxy.split('/'))
         self.load_fixtures([url])

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -132,6 +132,8 @@ global:
         - US National Park Service
         - U.S. National Park Service
         - US National Park service
+  - &leaftype_kind_detail
+    kind_detail: { col: leaf_type }
 filters:
   - filter: {meta.source: ne}
     min_zoom: 4
@@ -339,12 +341,14 @@ filters:
     output:
       <<: *output_properties
       kind: forest
+      <<: *leaftype_kind_detail
       tier: 2
   - filter: { landuse: forest }
     min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
+      <<: *leaftype_kind_detail
       tier: 2
 
   - filter: {leisure: nature_reserve}
@@ -365,12 +369,14 @@ filters:
     output:
       <<: *output_properties
       kind: wood
+      <<: *leaftype_kind_detail
       tier: 2
   - filter: { landuse: wood }
     min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: wood
+      <<: *leaftype_kind_detail
       tier: 2
 
   - filter: { natural: forest, operator: *us_forest_service }
@@ -378,12 +384,14 @@ filters:
     output:
       <<: *output_properties
       kind: natural_forest
+      <<: *leaftype_kind_detail
       tier: 2
   - filter: { natural: forest }
     min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: natural_forest
+      <<: *leaftype_kind_detail
       tier: 2
 
   - filter: { natural: wood, operator: *us_forest_service }
@@ -391,12 +399,14 @@ filters:
     output:
       <<: *output_properties
       kind: natural_wood
+      <<: *leaftype_kind_detail
       tier: 2
   - filter: { natural: wood }
     min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: natural_wood
+      <<: *leaftype_kind_detail
       tier: 2
 
   - filter: {landuse: urban}


### PR DESCRIPTION
- [x] Update tests
- [x] Update data migrations
- [x] Update docs

~~natural=forest, landuse=wood and natural=park are all mistakes with about 0.02% occurrence in the data.~~

~~This isn't a schema-breaking change because these objects aren't present except as mistakes anyways.~~

I did this change first because I had to modify all the wooded areas for the other change, leaf_type. This adds the leaf_type to kind_detail for wooded areas.