### PR TITLE
Remove natural=park, natural=forest, and landuse=wood

### DIFF
--- a/data/migrations/v1.5.0-planet_osm_polygon.sql
+++ b/data/migrations/v1.5.0-planet_osm_polygon.sql
@@ -5,6 +5,11 @@ UPDATE planet_osm_polygon
     'newsagent', 'perfumery', 'shoes', 'stationery', 'tobacco', 'travel_agency',
     'variety_store');
 
+UPDATE planet_osm_polygon
+  SET mz_landuse_min_zoom = mz_calculate_min_zoom_landuse(planet_osm_polygon.*)
+  WHERE mz_landuse_min_zoom != mz_calculate_min_zoom_landuse(planet_osm_polygon.*)
+    AND (landuse = 'wood' OR "natural" IN ('forest', 'park'));
+
 -- polygon low zoom
 SET client_min_messages TO WARNING;
 CREATE INDEX IF NOT EXISTS

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -507,8 +507,6 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `military`
 * `national_park`
 * `nature_reserve`
-* `natural_forest` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
-* `natural_park` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
 * `natural_wood` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
 * `park`
 * `parking`

--- a/docs/migrate-to-vector-tiles-v1.md
+++ b/docs/migrate-to-vector-tiles-v1.md
@@ -215,17 +215,8 @@ Below is a summary of the major, breaking changes listed for the vector tiles 1.
 * **place** and **boundaries** layers: `region`
     * `kind: [state]` > `kind: [region]`
 
-* **landuse** layer: `forest`
-    * some values are now `natural_forest`
-    * but many values are still forest
-
-* **landuse** layer: `park`
-    * some values are now `natural_park`
-    * but many values are still park
-
 * **landuse** layer: `wood`
-    * some values are now `natural_wood`
-    * but many values are still wood
+    * values are now `natural_wood`
 
 * **earth** layer: `continent` labels
     * If you have not updated for several releases, continent labels moved to the earth layer (from places layer)

--- a/integration-test/1103-no-natural-pois.py
+++ b/integration-test/1103-no-natural-pois.py
@@ -35,19 +35,3 @@ class NoNaturalPois(FixtureTest):
         self.assert_no_matching_feature(
             15, 9327, 12418, 'pois',
             {'id': -6366946, 'kind': 'natural_wood'})
-
-    def test_named_forest(self):
-        # same, but for a forest
-        # Liebesinsel, nr. Berlin, Germany
-        self.load_fixtures([
-            'http://www.openstreetmap.org/way/316516905',
-        ])
-
-        self.assert_has_feature(
-            16, 35199, 21454, 'landuse',
-            {'id': 316516905, 'kind': 'natural_forest',
-             'label_placement': True})
-
-        self.assert_no_matching_feature(
-            16, 35199, 21454, 'pois',
-            {'id': 316516905, 'kind': 'natural_forest'})

--- a/integration-test/1186-the-pois-with-no-name.py
+++ b/integration-test/1186-the-pois-with-no-name.py
@@ -62,14 +62,6 @@ class ThePoisWithNoName(FixtureTest):
             10, 163, 392, 'pois',
             {'id': 64296322})
 
-    def test_natural_forest(self):
-        # Node:2148541212 natural: Forest in POIS
-        self.load_fixtures(['http://www.openstreetmap.org/node/2148541212'])
-
-        self.assert_no_matching_feature(
-            14, 3942, 5901, 'pois',
-            {'id': 2148541212})
-
     def test_park(self):
         # Node:4206408136 park in POIS
         self.load_fixtures(['http://www.openstreetmap.org/node/4206408136'])

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -91,32 +91,6 @@ class PredictableLayersPois(FixtureTest):
             8, 72, 94, 'pois',
             {'id': 432810821, 'kind': 'forest', 'protect_class': '6'})
 
-    def test_natural_forest_way(self):
-        # Way: natural: Forest in POIS
-        # note: since #1103, there should be no POIs for natural_forest,
-        # only label placements in the landuse layer.
-        self.load_fixtures(['http://www.openstreetmap.org/way/202680509'])
-
-        self.assert_no_matching_feature(
-            14, 4877, 6109, 'pois',
-            {'id': 202680509, 'kind': 'natural_forest'})
-
-        # Label placement forest in landuse
-        self.assert_has_feature(
-            15, 9755, 12218, 'landuse',
-            {'id': 202680509, 'kind': 'natural_forest',
-             'label_placement': True})
-
-    def test_natural_forest_node(self):
-        # natural: Forest in POIS
-        # note: since #1103, there should be no POIs for natural_forest,
-        # only label placements in the landuse layer.
-        self.load_fixtures(['http://www.openstreetmap.org/node/4633280957'])
-
-        self.assert_no_matching_feature(
-            14, 11852, 7770, 'pois',
-            {'id': 4633280957, 'kind': 'natural_forest', 'min_zoom': 14})
-
     def test_golf_course_way(self):
         # Way:30903221 Golf_course in POIS
         self.load_fixtures(['http://www.openstreetmap.org/way/30903221'])

--- a/integration-test/844-normalize-poi-kind.py
+++ b/integration-test/844-normalize-poi-kind.py
@@ -29,19 +29,6 @@ class NormalizePoiKind(FixtureTest):
             16, 13462, 24933, 'pois',
             {'id': 2122898936, 'kind': 'ski_rental'})
 
-    def test_wood(self):
-        self.load_fixtures(['http://www.openstreetmap.org/way/52497271'])
-
-        self.assert_has_feature(
-            16, 10566, 25429, 'landuse',
-            {'id': 52497271, 'kind': 'wood'})
-
-        self.load_fixtures(['http://www.openstreetmap.org/way/207859675'])
-
-        self.assert_has_feature(
-            16, 11306, 26199, 'landuse',
-            {'id': 207859675, 'kind': 'wood'})
-
     def test_natural_wood(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/417405367'])
 
@@ -56,13 +43,6 @@ class NormalizePoiKind(FixtureTest):
             16, 10476, 25324, 'landuse',
             {'id': 422270533, 'kind': 'forest'})
 
-    def test_natural_forest(self):
-        self.load_fixtures(['http://www.openstreetmap.org/way/95360670'])
-
-        self.assert_has_feature(
-            16, 17780, 27428, 'landuse',
-            {'id': 95360670, 'kind': 'natural_forest'})
-
     def test_park(self):
         # Way: Stables & Equestrian Area (393312618)
         self.load_fixtures(['http://www.openstreetmap.org/way/393312618'])
@@ -70,10 +50,3 @@ class NormalizePoiKind(FixtureTest):
         self.assert_has_feature(
             16, 10294, 25113, 'landuse',
             {'id': 393312618, 'kind': 'park'})
-
-    def test_natural_park(self):
-        self.load_fixtures(['http://www.openstreetmap.org/way/469494860'])
-
-        self.assert_has_feature(
-            16, 17612, 24209, 'landuse',
-            {'id': 469494860, 'kind': 'natural_park'})

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -360,32 +360,6 @@ filters:
       kind: protected_area
       tier: 2
 
-  - filter: { landuse: wood, operator: *us_forest_service }
-    min_zoom: { max: [ 6, *tier2_min_zoom ] }
-    output:
-      <<: *output_properties
-      kind: wood
-      tier: 2
-  - filter: { landuse: wood }
-    min_zoom: { max: [ 10, *tier2_min_zoom ] }
-    output:
-      <<: *output_properties
-      kind: wood
-      tier: 2
-
-  - filter: { natural: forest, operator: *us_forest_service }
-    min_zoom: { max: [ 6, *tier2_min_zoom ] }
-    output:
-      <<: *output_properties
-      kind: natural_forest
-      tier: 2
-  - filter: { natural: forest }
-    min_zoom: { max: [ 10, *tier2_min_zoom ] }
-    output:
-      <<: *output_properties
-      kind: natural_forest
-      tier: 2
-
   - filter: { natural: wood, operator: *us_forest_service }
     min_zoom: { max: [ 6, *tier2_min_zoom ] }
     output:
@@ -862,11 +836,6 @@ filters:
     output:
       <<: *output_properties
       kind: wetland
-  - filter: {natural: park}
-    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
-    output:
-      <<: *output_properties
-      kind: natural_park
   - filter:
       highway: footway
       geom_type: polygon


### PR DESCRIPTION
All three are tagging errors that occur very infrequently. The first occurs at a 0.022% rate and the latter two at a 0.017% rate in current OSM data.

- [x] Update tests
- [x] Update data migrations
- [x] Update docs