### PR TITLE
Guard against a TopologicalError

### DIFF
--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -1795,7 +1795,14 @@ def admin_boundaries(ctx):
                     continue
                 cut_envelope = envelopes[j]
                 if envelope.intersects(cut_envelope):
-                    boundary = boundary.difference(cut_shape)
+                    try:
+                        boundary = boundary.difference(cut_shape)
+                    except shapely.errors.TopologicalError:
+                        # NOTE: we have gotten errors Topological errors here
+                        # that look like:
+                        # TopologicalError: This operation could not be
+                        # performed. Reason: unknown"
+                        pass
 
                 if boundary.is_empty:
                     break


### PR DESCRIPTION
This error appears in processing logs for a recent run. I verified that
locally a tile with a problem generates successfully after the guard is
introduced.

There are several other places where also make the same shapely
`difference` call, but I only introduced the guard in this one specific
case.