### PR TITLE
Wrap geometry operation in a try-except block.

### DIFF
--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -1819,7 +1819,16 @@ def admin_boundaries(ctx):
                 cut_envelope = envelopes[j]
 
                 if envelope.intersects(cut_envelope):
-                    inside, boundary = _intersect_cut(boundary, cut_shape)
+                    try:
+                        inside, boundary = _intersect_cut(boundary, cut_shape)
+                    except (StandardError, shapely.errors.ShapelyError):
+                        # if the inside and remaining boundary can't be
+                        # calculated, then we can't continue to intersect
+                        # anything else with this shape. this means we might
+                        # end up with erroneous one-sided boundaries.
+
+                        # TODO: log warning!
+                        break
 
                     inside = _linemerge(inside)
                     if not inside.is_empty:


### PR DESCRIPTION
The admin boundaries transform was throwing a TopologicalError when encountering some degenerate geometry. There's no ideal way to deal with this that won't cause other weirdness, but it seems like the least worst thing is to catch it and cause the rest of the boundary to be output one-sided.

Related to #1471. Connects to https://github.com/tilezen/tilequeue/issues/332.