### PR TITLE
Fix shield text for Argentinian roads.

### DIFF
--- a/integration-test/1491-argentina-shields.py
+++ b/integration-test/1491-argentina-shields.py
@@ -1,0 +1,72 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class ArgentinaShieldTest(FixtureTest):
+    def test_ruta_nacional_shield_text(self):
+        import dsl
+
+        # Argentina roads are generally prefixed with 2 characters and then
+        # a third [A-Z] character can prefix the number part of the ref,
+        # and should be included in the generated shield_text
+
+        # we could just use a coordinate like 16/0/0, but we might later
+        # start adding processing based on what country a road is in, so it
+        # probably makes sense to use a tile actually in Argentina.
+        z, x, y = 16, 22114, 39520
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': 'motorway',
+                'ref': 'RNA002',
+                'source': 'openstreetmap.org',
+            }),
+            dsl.relation(
+                1, {
+                    'network': 'AR:national',
+                    'route': 'road',
+                    'ref': 'RNA002',
+                    'type': 'route',
+                },
+                ways=[1],
+            ),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 1, 'kind': 'highway', 'network': 'AR:national',
+             'ref': 'RNA002', 'shield_text': 'A002'})
+
+    def test_ruta_provincial_shield_text(self):
+        import dsl
+
+        # Argentina provincial routes often aren't in relations with proper
+        # network value (expected to be AR:provincial), but they do have a
+        # RP prefix in he ref.
+
+        # we could just use a coordinate like 16/0/0, but we might later
+        # start adding processing based on what country a road is in, so it
+        # probably makes sense to use a tile actually in Argentina.
+        z, x, y = 16, 22114, 39520
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': 'primary',
+                'ref': 'RP21',
+                'source': 'openstreetmap.org',
+            }),
+            dsl.relation(
+                1, {
+                    'network': 'AR:provincial',
+                    'route': 'road',
+                    'ref': 'RP21',
+                    'type': 'route',
+                },
+                ways=[1],
+            ),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 1, 'kind': 'major_road', 'network': 'AR:provincial',
+             'ref': 'RP21', 'shield_text': '21'})

--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -29,6 +29,28 @@ def relation(id, tags, nodes=None, ways=None, relations=None):
     relations = relations or []
     way_off = len(nodes)
     rel_off = way_off + len(ways)
+    tags_as_list = []
+    for k, v in tags.items():
+        tags_as_list.extend((k, v))
     return dict(
-        id=id, tags=tags, way_off=way_off, rel_off=rel_off,
+        id=id, tags=tags_as_list, way_off=way_off, rel_off=rel_off,
         parts=(nodes + ways + relations))
+
+
+def tile_diagonal(z, x, y):
+    """
+    Returns a Shapely LineString which goes from the lower left of the tile
+    to the upper right.
+    """
+
+    from tilequeue.tile import coord_to_bounds
+    from shapely.geometry import LineString
+    from ModestMaps.Core import Coordinate
+
+    bounds = coord_to_bounds(Coordinate(zoom=z, column=x, row=y))
+    shape = LineString([
+        [bounds[0], bounds[1]],
+        [bounds[2], bounds[3]],
+    ])
+
+    return shape

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4176,6 +4176,15 @@ def _road_shield_text(network, ref):
     if network and (network.startswith('GR:') or network.startswith('gr:')):
         return ref
 
+    # Argentinian national routes start with "RN" (ruta nacional), which
+    # should be stripped, but other letters shouldn't be!
+    if network == 'AR:national' and ref.startswith('RN'):
+        return ref[2:]
+
+    # Argentinian provinicial routes start with "RP" (ruta provincial)
+    if network == 'AR:provincial' and ref.startswith('RP'):
+        return ref[2:]
+
     # If there's a number at the front (optionally with letters following),
     # then that's the ref.
     m = _NUMBER_AT_FRONT.match(ref)


### PR DESCRIPTION
Argentinian road refs can start with either "RP" or "RN", which shouldn't appear as part of the shield text. If we can detect that they're part of the right network, then we can strip this out.

Connects to #1491.