### PR TITLE
Add country code to roads

### DIFF
--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
 bucket: tilezen-assets
-datestamp: 20180313
+datestamp: 20180514
 
 shapefiles:
 
@@ -26,6 +26,11 @@ shapefiles:
     prj: 3857
     shapefile-name: buffered_land_05232017.shp
     tile: true
+
+  - name: admin_areas
+    url: http://s3.amazonaws.com/tilezen-assets/curated/admin_areas_20180409.zip
+    prj: 4326
+    shapefile-name: admin_areas_20180409.shp
 
   - name: ne_110m_lakes
     url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/physical/ne_110m_lakes.zip

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1068,7 +1068,9 @@ More than just roads, this OpenStreetMap and Natural Earth based transportation 
 
 Road names are **abbreviated** so directionals like `North` is replaced with `N`, `Northeast` is replaced with `NE`, and common street suffixes like `Avenue` to `Ave.` and `Street` to `St.`. Full details in the [StreetNames](https://github.com/nvkelso/map-label-style-manual/blob/master/tools/street_names/StreetNames/__init__.py) library.
 
-Mapzen calculates the `landuse_kind` value by intercutting `roads` with the `landuse` layer to determine if a road segment is over a parks, hospitals, universities or other landuse features. Use this property to modify the visual appearance of roads over these features. For instance, light grey minor roads look great in general, but aren't legible over most landuse colors unless they are darkened.
+Tilezen calculates the `landuse_kind` value by intercutting `roads` with the `landuse` layer to determine if a road segment is over a parks, hospitals, universities or other landuse features. Use this property to modify the visual appearance of roads over these features. For instance, light grey minor roads look great in general, but aren't legible over most landuse colors unless they are darkened.
+
+Tilezen also calculates an ISO 3166-1 alpha2 `country_code` value by working out which country a road feature is in, using [Valhalla's](https://github.com/valhalla/valhalla/) [administrative areas](https://github.com/valhalla/valhalla/blob/master/docs/mjolnir/admins.md). If we can't tell that a road segment is unambiguously in a country, then the `country_code` parameter is omitted.
 
 To improve performance, some road segments are merged at low and mid-zooms. To facilitate this, certain properties are dropped at those zooms. Examples include `is_bridge` and `is_tunnel`, `name`, `network`, `oneway`, and `ref`. The exact zoom varies per feature class (major roads keep this properties over a wider range, minor roads drop them starting at zoom 14). When roads are merged, the original OSM `id` values are dropped.
 
@@ -1118,6 +1120,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `bus_network`: Note that this is often not present for bus routes / networks. This may be replaced with `operator` in the future, see [issue 1194](https://github.com/tilezen/vector-datasource/issues/1194).
 * `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus or trolley-bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
 * `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`. `cobblestone:flattened`, `concrete:plates` and `concrete:lanes` values are transformed to `cobblestone_flattened`, `concrete_plates` and `concrete_lanes` respectively.
+* `country_code`: The ISO 3166-1 alpha2 code for the country that the road is in, if we can tell. Note that this means that this property is _optional_, and you should not assume that it is always present.
 
 #### Road properties (optional):
 

--- a/integration-test/135-add-country-codes-on-roads.py
+++ b/integration-test/135-add-country-codes-on-roads.py
@@ -1,0 +1,65 @@
+from . import FixtureTest
+
+
+class AddCountryCodesToRoads(FixtureTest):
+    def test_add_country_code_to_road(self):
+        import dsl
+
+        # randomly chosen tile with the M4 motorway west of London, GB
+        z, x, y = (16, 32680, 21796)
+
+        # although we model these both as "ways", this is really just a way to
+        # get geometry into the pipeline. in real usage, the admin_area comes
+        # from a static shapefile.
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y),
+                    {'kind': 'admin_area', 'iso_code': 'GB',
+                     'source': 'openstreetmap.org'}),
+            dsl.way(2, dsl.tile_diagonal(z, x, y),
+                    {'highway': 'motorway', 'ref': 'M4',
+                     'source': 'openstreetmap.org'}),
+        )
+
+        # should have deleted this layer before output.
+        with self.layers_in_tile(z, x, y) as layers:
+            self.assertNotIn('admin_areas', layers)
+
+        # but should have used it to add a "country_code" parameter to the
+        # road.
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 2, 'country_code': 'GB', 'network': 'GB:M-road'})
+
+    # the backfill national network in the UK should still be more important
+    # than the EU "e-road" desigation, as that isn't signed.
+    def test_backfill_more_important_than_eroad(self):
+        import dsl
+
+        # randomly chosen tile with the M4 motorway west of London, GB
+        z, x, y = (16, 32680, 21796)
+
+        # although we model these both as "ways", this is really just a way to
+        # get geometry into the pipeline. in real usage, the admin_area comes
+        # from a static shapefile.
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y),
+                    {'kind': 'admin_area', 'iso_code': 'GB',
+                     'source': 'openstreetmap.org'}),
+            dsl.way(2, dsl.tile_diagonal(z, x, y),
+                    {'highway': 'motorway', 'ref': 'M4',
+                     'source': 'openstreetmap.org'}),
+            dsl.relation(
+                1, {
+                    'network': 'e-road',
+                    'route': 'road',
+                    'ref': 'E 30',
+                    'type': 'route',
+                },
+                ways=[2],
+            ),
+        )
+
+        # the main network should be GB, not e-road
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 2, 'network': 'GB:M-road', 'shield_text': 'M4'})

--- a/integration-test/1491-argentina-shields.py
+++ b/integration-test/1491-argentina-shields.py
@@ -70,3 +70,31 @@ class ArgentinaShieldTest(FixtureTest):
             z, x, y, 'roads',
             {'id': 1, 'kind': 'major_road', 'network': 'AR:provincial',
              'ref': 'RP21', 'shield_text': '21'})
+
+    # same as the test above, but using the country backfill rather than
+    # the relation.
+    def test_ruta_provincial_backfill(self):
+        import dsl
+
+        z, x, y = 16, 22114, 39520
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': 'primary',
+                'ref': 'RP21',
+                'source': 'openstreetmap.org',
+            }),
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area',
+                'iso_code': 'AR',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        # note that the logic for backfilling currently pops the 'ref' off,
+        # so that's slightly different from when it's present on both the
+        # road _and_ the relation.
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 1, 'kind': 'major_road', 'network': 'AR:provincial',
+             'shield_text': '21'})

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -653,6 +653,13 @@ class FixtureShapeSource(object):
                         source="tilezen.org",
                         maritime_boundary=True,
                     )
+                elif obj.table in ("admin_areas"):
+                    # fix up column names here too!
+                    override_properties = dict(
+                        source='openstreetmap.org',
+                        kind='admin_area',
+                        admin_level=2,
+                    )
                 else:
                     override_properties = dict(source="openstreetmapdata.com")
                 _convert_shape_to_geojson(

--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -54,3 +54,16 @@ def tile_diagonal(z, x, y):
     ])
 
     return shape
+
+
+def tile_box(z, x, y):
+    """
+    Returns a Shapely Polygon which covers the tile.
+    """
+
+    from tilequeue.tile import coord_to_bounds
+    from shapely.geometry import box
+    from ModestMaps.Core import Coordinate
+
+    bounds = coord_to_bounds(Coordinate(zoom=z, column=x, row=y))
+    return box(*bounds)

--- a/queries.yaml
+++ b/queries.yaml
@@ -8,6 +8,7 @@ all:
   - pois
   - boundaries
   - transit
+  - admin_areas
 
 sources:
 
@@ -137,6 +138,11 @@ sources:
     - template: wof.jinja2
       start_zoom: 11
 
+  admin_areas:
+    - template: admin_areas.jinja2
+      # starts at the min zoom where we have OSM roads
+      start_zoom: 5
+
 layers:
   water:
     geometry_types: [Point, MultiPoint, Polygon, MultiPolygon, LineString, MultiLineString]
@@ -212,9 +218,6 @@ layers:
       - vectordatasource.transform.normalize_aerialways
       - vectordatasource.transform.normalize_cycleway
       - vectordatasource.transform.add_is_bicycle_related
-      - vectordatasource.transform.merge_networks_from_tags
-      - vectordatasource.transform.extract_network_information
-      - vectordatasource.transform.choose_most_important_network
       - vectordatasource.transform.road_trim_properties
       - vectordatasource.transform.remove_feature_id
       - vectordatasource.transform.tags_remove
@@ -291,6 +294,15 @@ layers:
       - vectordatasource.transform.remove_feature_id
       - vectordatasource.transform.truncate_min_zoom_to_2dp
     sort: vectordatasource.sort.transit
+    area-inclusion-threshold: 1
+  admin_areas:
+    geometry_types: [Polygon, MultiPolygon]
+    simplify_before_intersect: false
+    simplify_start: 9
+    transform:
+      - vectordatasource.transform.tags_create_dict
+      - vectordatasource.transform.add_id_to_properties
+      - vectordatasource.transform.remove_feature_id
     area-inclusion-threshold: 1
 post_process:
   - fn: vectordatasource.transform.numeric_min_filter
@@ -427,6 +439,21 @@ post_process:
     params:
       source_layer: roads
       properties: [layer]
+
+  # cut with admin_areas to put country_code attributes on roads
+  # which are mostly within a particular country.
+  - fn: vectordatasource.transform.overlap
+    params:
+      base_layer: roads
+      cutting_layer: admin_areas
+      attribute: iso_code
+      target_attribute: country_code
+      linear: true
+
+  - fn: vectordatasource.transform.backfill_road_networks
+    params:
+      layer: roads
+
   - fn: vectordatasource.transform.overlap
     params:
       base_layer: buildings
@@ -924,3 +951,8 @@ post_process:
         white: [255, 255, 255]
         yellow: [255, 255, 0]
         yellowgreen: [154, 205, 50]
+
+  - fn: vectordatasource.transform.drop_layer
+    params:
+      layer: admin_areas
+      start_zoom: 15

--- a/queries/admin_areas.jinja2
+++ b/queries/admin_areas.jinja2
@@ -1,0 +1,16 @@
+SELECT
+  gid AS __id__,
+  {% filter geometry %}{{ bounds['polygon']|bbox_intersection('the_geom') }}{% endfilter %} AS __geometry__,
+  jsonb_build_object(
+    'source', 'openstreetmap.org',
+    'kind', 'admin_area',
+    'admin_level', 2,
+    'iso_code', iso_code
+  ) AS __properties__,
+  '{}'::jsonb AS __admin_areas_properties__
+
+FROM
+  admin_areas
+
+WHERE
+    {{ bounds['polygon']|bbox_filter('the_geom', 3857) }}

--- a/vectordatasource/meta/python.py
+++ b/vectordatasource/meta/python.py
@@ -532,7 +532,7 @@ LayerParseResult = namedtuple(
 def parse_layers(yaml_path, output_fn, fn_name_fn):
     layer_data = []
     layers = ('landuse', 'pois', 'transit', 'water', 'places', 'boundaries',
-              'buildings', 'roads', 'earth')
+              'buildings', 'roads', 'earth', 'admin_areas')
 
     scope = {}
     import_asts = []

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -68,6 +68,9 @@ LAYER_TABLES = {
         'planet_osm_polygon',
         'water_polygons',
     ],
+    'admin_areas': [
+        'admin_areas',
+    ],
 }
 
 
@@ -89,6 +92,7 @@ POLYGON_TABLES = [
     'ne_50m_playas',
     'ne_50m_urban_areas',
     'water_polygons',
+    'admin_areas',
 ]
 
 

--- a/yaml/admin_areas.yaml
+++ b/yaml/admin_areas.yaml
@@ -1,0 +1,9 @@
+filters:
+  - filter:
+      kind: admin_area
+      iso_code: true
+    min_zoom: 5
+    output:
+      kind: admin_area
+      iso_code: {col: iso_code}
+      min_zoom: 5


### PR DESCRIPTION
* Added admin areas curated shapefile, converted from Valhalla's `admins.sqlite`, with data originally from OSM.
* Bumped assets bundle version.
* Added support for admin areas in all the places that we need to list new tables.
* Added admin areas as a new layer, which gets dropped before the tile is written out, so doesn't alter the layers in the output tile.
* Used the admin areas layer joined to roads to add a `country_code` property to output roads.
* Used the `country_code` property to back-fill road network values.
* Added tests for `country_code` and back-filling in GB & AR.

Connects to #135.
