### PR TITLE
Add direction property on mini roundabouts.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -906,7 +906,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `midwife`
 * `military`
 * `mineshaft`
-* `mini_roundabout`
+* `mini_roundabout` - has optional property `drives_on_left` to indicate whether the roundabout is in a country which drives on the left (`drives_on_left=true`) and therefore goes around the mini roundabout in  a clockwise direction as seen from above. The property is omitted when the country drives on the right and has counter-clockwise mini roundabouts (i.e: default `false`).
 * `mobile_phone`
 * `monument`
 * `motel`

--- a/integration-test/1498-mini-roundabout-direction.py
+++ b/integration-test/1498-mini-roundabout-direction.py
@@ -1,0 +1,52 @@
+from . import FixtureTest
+
+
+# mini roundabouts are modelled as points, which means they have no intrinsic
+# direction. this means we need additional information to tell whether to draw
+# the roundabout with clockwise arrows (drives on left) or counter-clockwise
+# (drives on right).
+#
+class MiniRoundaboutDirection(FixtureTest):
+    def test_mini_roundabout_drives_on_left(self):
+        import dsl
+
+        # randomly chosen tile with the M4 motorway west of London, GB
+        z, x, y = (16, 32680, 21796)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'GB',
+                'source': 'openstreetmap.org'
+            }),
+            dsl.point(1, dsl.tile_centre(z, x, y), {
+                'highway': 'mini_roundabout'
+            }),
+        )
+
+        # roundabout should now have a "drives_on_left" attribute
+        self.assert_has_feature(
+            z, x, y, 'pois',
+            {'id': 1, 'kind': 'mini_roundabout', 'drives_on_left': True})
+
+    def test_mini_roundabout_drives_on_right(self):
+        import dsl
+
+        # randomly chosen tile in Rouen, France (drives on right).
+        z, x, y = (16, 32959, 22386)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'FR',
+                'source': 'openstreetmap.org'
+            }),
+            dsl.point(1, dsl.tile_centre(z, x, y), {
+                'highway': 'mini_roundabout'
+            }),
+        )
+
+        # roundabout should _not_ have a "drives_on_left" attribute - the
+        # default for this would be false, and therefore omitted.
+        self.assert_has_feature(
+            z, x, y, 'pois',
+            {'id': 1, 'kind': 'mini_roundabout',
+             'drives_on_left': type(None)})

--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -67,3 +67,16 @@ def tile_box(z, x, y):
 
     bounds = coord_to_bounds(Coordinate(zoom=z, column=x, row=y))
     return box(*bounds)
+
+
+def tile_centre(z, x, y):
+    """
+    Returns the (lon, lat) tuple of the centre of the tile. Note that the
+    centre is calculated in mercator projection, so might not be the centre of
+    the tile in lat/lon projection.
+    """
+
+    from tilequeue.tile import num2deg
+
+    lat, lon = num2deg(x + 0.5, y + 0.5, z)
+    return (lon, lat)

--- a/queries.yaml
+++ b/queries.yaml
@@ -463,31 +463,47 @@ post_process:
       where: kind == 'mini_roundabout'
       # see https://en.wikipedia.org/wiki/List_of_countries_with_left-hand_traffic
       logic_table:
+        AG: true
+        AI: true
         AU: true
+        BB: true
         BD: true
+        BM: true
         BN: true
+        BS: true
         BT: true
         BW: true
         CC: true
         CK: true
         CX: true
         CY: true
+        DM: true
         FJ: true
+        FK: true
         GB: true
+        GD: true
         GG: true
+        GS: true
+        GY: true
         HK: true
         ID: true
         IE: true
         IM: true
         IN: true
         JE: true
+        JM: true
         JP: true
         KE: true
         KI: true
+        KN: true
+        KY: true
+        LC: true
         LK: true
         LS: true
         MO: true
+        MS: true
         MT: true
+        MU: true
         MV: true
         MW: true
         MY: true
@@ -502,15 +518,23 @@ post_process:
         PK: true
         PN: true
         SB: true
+        SC: true
         SG: true
+        SH: true
+        SR: true
         SZ: true
+        TC: true
         TH: true
         TK: true
         TL: true
         TO: true
+        TT: true
         TV: true
         TZ: true
         UG: true
+        VC: true
+        VG: true
+        VI: true
         WS: true
         ZA: true
         ZM: true

--- a/queries.yaml
+++ b/queries.yaml
@@ -454,6 +454,68 @@ post_process:
     params:
       layer: roads
 
+  - fn: vectordatasource.transform.point_in_country_logic
+    params:
+      layer: pois
+      country_layer: admin_areas
+      country_code_attr: iso_code
+      output_attr: drives_on_left
+      where: kind == 'mini_roundabout'
+      # see https://en.wikipedia.org/wiki/List_of_countries_with_left-hand_traffic
+      logic_table:
+        AU: true
+        BD: true
+        BN: true
+        BT: true
+        BW: true
+        CC: true
+        CK: true
+        CX: true
+        CY: true
+        FJ: true
+        GB: true
+        GG: true
+        HK: true
+        ID: true
+        IE: true
+        IM: true
+        IN: true
+        JE: true
+        JP: true
+        KE: true
+        KI: true
+        LK: true
+        LS: true
+        MO: true
+        MT: true
+        MV: true
+        MW: true
+        MY: true
+        MZ: true
+        NA: true
+        NF: true
+        NP: true
+        NR: true
+        NU: true
+        NZ: true
+        PG: true
+        PK: true
+        PN: true
+        SB: true
+        SG: true
+        SZ: true
+        TH: true
+        TK: true
+        TL: true
+        TO: true
+        TV: true
+        TZ: true
+        UG: true
+        WS: true
+        ZA: true
+        ZM: true
+        ZW: true
+
   - fn: vectordatasource.transform.overlap
     params:
       base_layer: buildings

--- a/queries.yaml
+++ b/queries.yaml
@@ -463,82 +463,82 @@ post_process:
       where: kind == 'mini_roundabout'
       # see https://en.wikipedia.org/wiki/List_of_countries_with_left-hand_traffic
       logic_table:
-        AG: true
-        AI: true
-        AU: true
-        BB: true
-        BD: true
-        BM: true
-        BN: true
-        BS: true
-        BT: true
-        BW: true
-        CC: true
-        CK: true
-        CX: true
-        CY: true
-        DM: true
-        FJ: true
-        FK: true
-        GB: true
-        GD: true
-        GG: true
-        GS: true
-        GY: true
-        HK: true
-        ID: true
-        IE: true
-        IM: true
-        IN: true
-        JE: true
-        JM: true
-        JP: true
-        KE: true
-        KI: true
-        KN: true
-        KY: true
-        LC: true
-        LK: true
-        LS: true
-        MO: true
-        MS: true
-        MT: true
-        MU: true
-        MV: true
-        MW: true
-        MY: true
-        MZ: true
-        NA: true
-        NF: true
-        NP: true
-        NR: true
-        NU: true
-        NZ: true
-        PG: true
-        PK: true
-        PN: true
-        SB: true
-        SC: true
-        SG: true
-        SH: true
-        SR: true
-        SZ: true
-        TC: true
-        TH: true
-        TK: true
-        TL: true
-        TO: true
-        TT: true
-        TV: true
-        TZ: true
-        UG: true
-        VC: true
-        VG: true
-        VI: true
-        WS: true
-        ZA: true
-        ZM: true
-        ZW: true
+        AG: true # Antigua and Barbuda
+        AI: true # Anguilla
+        AU: true # Australia
+        BB: true # Barbados
+        BD: true # Bangladesh
+        BM: true # Bermuda
+        BN: true # Brunei
+        BS: true # Bahamas
+        BT: true # Bhutan
+        BW: true # Botswana
+        CC: true # Cocos (Keeling) Islands
+        CK: true # Cook Islands
+        CX: true # Christmas Island
+        CY: true # Cyprus (note, also fake ISO code for Northern Cyprus)
+        DM: true # Dominica
+        FJ: true # Fiji
+        FK: true # Falkland Islands
+        GB: true # United Kingdom
+        GD: true # Grenada
+        GG: true # Guernsey
+        GS: true # South Georgia and the South Sandwich Islands
+        GY: true # Guyana
+        HK: true # Hong Kong
+        ID: true # Indonesia
+        IE: true # Ireland
+        IM: true # Isle of Man
+        IN: true # India
+        JE: true # Jersey
+        JM: true # Jamaica
+        JP: true # Japan
+        KE: true # Kenya
+        KI: true # Kiribati
+        KN: true # Saint Kitts and Nevis
+        KY: true # Cayman Islands
+        LC: true # Saint Lucia
+        LK: true # Sri Lanka
+        LS: true # Lesotho
+        MO: true # Macau (fake ISO code)
+        MS: true # Montserrat
+        MT: true # Malta
+        MU: true # Mauritius
+        MV: true # Maldives
+        MW: true # Malawi
+        MY: true # Malaysia
+        MZ: true # Mozambique
+        NA: true # Namibia
+        NF: true # Norfolk Island
+        NP: true # Nepal
+        NR: true # Nauru
+        NU: true # Niue
+        NZ: true # New Zealand
+        PG: true # Papua New Guinea
+        PK: true # Pakistan
+        PN: true # Pitcairn Islands
+        SB: true # Solomon Islands
+        SC: true # Seychelles
+        SG: true # Singapore
+        SH: true # Saint Helena, Ascension and Tristan da Cunha
+        SR: true # Suriname
+        SZ: true # Swaziland
+        TC: true # Turks and Caicos Islands
+        TH: true # Thailand
+        TK: true # Tokelau
+        TL: true # East Timor
+        TO: true # Tonga
+        TT: true # Trinidad and Tobago
+        TV: true # Tuvalu
+        TZ: true # Tanzania
+        UG: true # Uganda
+        VC: true # Saint Vincent and the Grenadines
+        VG: true # British Virgin Islands
+        VI: true # U.S. Virgin Islands
+        WS: true # Samoa
+        ZA: true # South Africa
+        ZM: true # Zambia
+        ZW: true # Zimbabwe
 
   - fn: vectordatasource.transform.overlap
     params:


### PR DESCRIPTION
Adds a `drives_on_left=true` property to mini roundabouts when they're in a country which drives on the left. The default is driving on the right, and the property is omitted in this case.

Connects to #1498.