### PR TITLE
Add country code to roads (update)

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1070,7 +1070,7 @@ Road names are **abbreviated** so directionals like `North` is replaced with `N`
 
 Tilezen calculates the `landuse_kind` value by intercutting `roads` with the `landuse` layer to determine if a road segment is over a parks, hospitals, universities or other landuse features. Use this property to modify the visual appearance of roads over these features. For instance, light grey minor roads look great in general, but aren't legible over most landuse colors unless they are darkened.
 
-Tilezen also calculates an ISO 3166-1 alpha2 `country_code` value by working out which country a road feature is in, using [Valhalla's](https://github.com/valhalla/valhalla/) [administrative areas](https://github.com/valhalla/valhalla/blob/master/docs/mjolnir/admins.md). If we can't tell that a road segment is unambiguously in a country, then the `country_code` parameter is omitted.
+Tilezen also calculates an ISO 3166-1 alpha2 `country_code` value by working out which country a `roads` layer feature is in, using [Valhalla's](https://github.com/valhalla/valhalla/) [administrative areas](https://github.com/valhalla/valhalla/blob/master/docs/mjolnir/admins.md). If we can't tell that a road segment is unambiguously in a country, then the `country_code` parameter is omitted.
 
 To improve performance, some road segments are merged at low and mid-zooms. To facilitate this, certain properties are dropped at those zooms. Examples include `is_bridge` and `is_tunnel`, `name`, `network`, `oneway`, and `ref`. The exact zoom varies per feature class (major roads keep this properties over a wider range, minor roads drop them starting at zoom 14). When roads are merged, the original OSM `id` values are dropped.
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -297,7 +297,11 @@ layers:
     area-inclusion-threshold: 1
   admin_areas:
     geometry_types: [Polygon, MultiPolygon]
+    # note: simplify_* settings shouldn't affect this layer, as it should be
+    # dropped before we get to that stage. but worth "documenting" that it
+    # shouldn't be simplified here to make it more explicit.
     simplify_before_intersect: false
+    simplify_start: 999
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.add_id_to_properties
@@ -852,6 +856,13 @@ post_process:
       source_layers: [landuse, water]
       pixel_area: 0.1
 
+  # drop this layer before simplify_and_clip - we don't want it in the output,
+  # so don't waste time simplifying and clipping it to the tile.
+  - fn: vectordatasource.transform.drop_layer
+    params:
+      layer: admin_areas
+      start_zoom: 0
+
   - fn: vectordatasource.transform.simplify_and_clip
     params: {simplify_before: 16}
 
@@ -950,8 +961,3 @@ post_process:
         white: [255, 255, 255]
         yellow: [255, 255, 0]
         yellowgreen: [154, 205, 50]
-
-  - fn: vectordatasource.transform.drop_layer
-    params:
-      layer: admin_areas
-      start_zoom: 0

--- a/queries.yaml
+++ b/queries.yaml
@@ -140,7 +140,7 @@ sources:
 
   admin_areas:
     - template: admin_areas.jinja2
-      # starts at the min zoom where we have OSM roads
+      # starts at the min zoom where we have road layer data
       start_zoom: 5
 
 layers:

--- a/queries.yaml
+++ b/queries.yaml
@@ -954,4 +954,4 @@ post_process:
   - fn: vectordatasource.transform.drop_layer
     params:
       layer: admin_areas
-      start_zoom: 15
+      start_zoom: 0

--- a/queries.yaml
+++ b/queries.yaml
@@ -298,7 +298,6 @@ layers:
   admin_areas:
     geometry_types: [Polygon, MultiPolygon]
     simplify_before_intersect: false
-    simplify_start: 9
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.add_id_to_properties


### PR DESCRIPTION
Fixes various problems pointed out by @nvkelso in https://github.com/tilezen/vector-datasource/pull/1499#pullrequestreview-120379360 and following:

1. Clarify documentation; country code is added to all features in the roads layer, not just roads.
2. Clarify comment; roads data starts at zoom 5, but isn't OSM data at that point.
3. Don't simplify admin areas (they're not output anyway).
4. Drop admin areas at all zooms.