### PR TITLE
Maritime boundaries fix

### DIFF
--- a/integration-test/1482-maritime_boundary-buffered_land.py
+++ b/integration-test/1482-maritime_boundary-buffered_land.py
@@ -51,3 +51,51 @@ class MaritimeBoundary(FixtureTest):
         self.assert_no_matching_feature(
             8, 44, 88, "boundaries",
             {"kind": "region", "maritime_boundary": 1})
+
+    # this test is to state the properties explicitly, so that we can make sure
+    # they don't get changed unintentionally.
+    def test_generative_non_maritime(self):
+        import dsl
+
+        z, x, y = (8, 44, 88)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'source': 'tilezen.org',
+                'maritime_boundary': True,
+                'min_zoom': 0,
+                'kind': 'maritime',
+            }),
+            dsl.way(2, dsl.tile_diagonal(z, x, y), {
+                'source': 'openstreetmap.org',
+                'boundary': 'administrative',
+                'admin_level': '2',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 2,
+                'kind': 'country',
+                'maritime_boundary': type(None),
+            })
+
+    def test_generative_maritime(self):
+        import dsl
+
+        z, x, y = (8, 44, 88)
+
+        self.generate_fixtures(
+            dsl.way(2, dsl.tile_diagonal(z, x, y), {
+                'source': 'openstreetmap.org',
+                'boundary': 'administrative',
+                'admin_level': '2',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 2,
+                'kind': 'country',
+                'maritime_boundary': True,
+            })

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -1408,6 +1408,12 @@ class FixtureTest(unittest.TestCase):
         self.test_instance.load_fixtures(urls, clip, simplify)
 
     def generate_fixtures(self, *objs):
+        # check for common programming mistake, given that this takes variadic
+        # args, but could easily take a list.
+        if objs:
+            self.assertFalse(
+                isinstance(objs[0], list),
+                msg='generate_fixtures is variadic, do not pass it a list')
         self.test_instance.generate_fixtures(objs)
 
     def assert_has_feature(self, z, x, y, layer, props):

--- a/queries.yaml
+++ b/queries.yaml
@@ -143,6 +143,11 @@ sources:
       # starts at the min zoom where we have OSM roads
       start_zoom: 5
 
+  # note: this goes into the _boundaries_ layer.
+  buffered_land:
+    - template: buffered_land.jinja2
+      start_zoom: 0
+
 layers:
   water:
     geometry_types: [Point, MultiPoint, Polygon, MultiPolygon, LineString, MultiLineString]

--- a/queries/buffered_land.jinja2
+++ b/queries/buffered_land.jinja2
@@ -16,7 +16,7 @@ FROM (
     -- extract only polygons. we might get linestring and point fragments when
     -- the box and geometry touch but don't overlap. we don't want these, so
     -- want to throw them away.
-    fiahdlfauisdhluhST_CollectionExtract({% filter geometry %}the_geom{% endfilter %}, 3) AS geom
+    ST_CollectionExtract({% filter geometry %}the_geom{% endfilter %}, 3) AS geom
 
   FROM buffered_land
 

--- a/queries/buffered_land.jinja2
+++ b/queries/buffered_land.jinja2
@@ -1,0 +1,28 @@
+SELECT
+    gid AS __id__,
+    ST_AsBinary(geom) AS __geometry__,
+    jsonb_build_object(
+      'source', 'tilezen.org',
+      'min_zoom', 0,
+      'kind', 'maritime',
+      'maritime_boundary', TRUE
+    ) AS __properties__,
+
+    '{}'::jsonb AS __boundaries_properties__
+
+FROM (
+  SELECT
+    gid,
+    -- extract only polygons. we might get linestring and point fragments when
+    -- the box and geometry touch but don't overlap. we don't want these, so
+    -- want to throw them away.
+    fiahdlfauisdhluhST_CollectionExtract({% filter geometry %}the_geom{% endfilter %}, 3) AS geom
+
+  FROM buffered_land
+
+  WHERE
+    {{ bounds['point']|bbox_filter('the_geom', 3857) }}
+) maybe_empty_intersections
+
+WHERE
+  NOT ST_IsEmpty(geom)


### PR DESCRIPTION
This fixes buffered land for SQL queries (`zoom < 10`), taking the query from https://github.com/tilezen/raw_tiles/commit/93f0b7d1bbeacc62d2939a65be5abda520f4604d.

Added extra tests to be sure of the tags we need to pass in.

Added a small check to `generate_fixtures` to validate the type of its arguments, as I've made the mistake of passing in a `list` a few times now.

I've run a test tile through both the SQL and RAWR paths, and it seems to work:

![image](https://user-images.githubusercontent.com/271360/40131825-ea521042-5932-11e8-8f1d-0b5e167c54ee.png)

Which shows the boundaries on `10/158/380` (tile from OpenStreetMap):

![Tile 10/158/380 from OpenStreetMap, data available under the ODbL](https://user-images.githubusercontent.com/271360/40131918-35559136-5933-11e8-8f39-102b20f9fe79.png)

Connects to #1482.
