### PR TITLE
Australian road shields

### DIFF
--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -35,8 +35,8 @@ class BusRouteRefs(FixtureTest):
             {'id': 225516711,
              'bus_network': type(None),
              'bus_shield_text': '3',
-             'all_bus_networks': [None, None],
-             'all_bus_shield_texts': ['3', '3']})
+             'all_bus_networks': [None],
+             'all_bus_shield_texts': ['3']})
 
     def test_full_lists_disappear_by_zoom_12(self):
         # make sure the all_* lists are gone by zoom 12 on major roads, but

--- a/integration-test/1491-australia-shields.py
+++ b/integration-test/1491-australia-shields.py
@@ -126,6 +126,32 @@ class AustraliaShieldTest(FixtureTest):
                 'all_shield_texts': ['9', '31'],
             })
 
+    def test_s_road_in_zero_relations(self):
+        import dsl
+
+        z, x, y = (16, 60644, 38056)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org'
+            }),
+            # https://www.openstreetmap.org/way/240922938
+            dsl.way(240922938, dsl.tile_diagonal(z, x, y), {
+                'source:name': 'survey', 'maxspeed': '60', 'lanes': '2',
+                'name': 'Beaudesert Beenleigh Road',
+                'source': 'openstreetmap.org', 'source:ref': 'survey',
+                'ref': '92;T8', 'highway': 'primary', 'network': 'S',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 240922938, 'shield_text': '92', 'network': 'AU:S-route',
+                'all_networks': ['AU:S-route', 'AU:T-drive'],
+                'all_shield_texts': ['92', '8'],
+            })
+
     # test not just a B-road, but one where the text ref has spaces between
     # the additional T-drive refs (i.e: "T 28" rather than "T28").
     def test_b_road_with_spaces(self):

--- a/integration-test/1491-australia-shields.py
+++ b/integration-test/1491-australia-shields.py
@@ -1,0 +1,127 @@
+from . import FixtureTest
+
+
+class AustraliaShieldTest(FixtureTest):
+    def test_a_road_in_relation(self):
+        import dsl
+
+        z, x, y = (16, 58007, 39547)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org'
+            }),
+            # https://www.openstreetmap.org/way/582052008
+            dsl.way(582052008, dsl.tile_diagonal(z, x, y), {
+                'maxspeed': '60', 'lanes': '2', 'name': 'North East Road',
+                'surface': 'paved', 'cycleway': 'lane',
+                'source': 'openstreetmap.org', 'oneway': 'yes', 'ref': 'A10',
+                'highway': 'primary'
+            }),
+            dsl.relation(1, {
+                'type': 'route', 'route': 'road', 'ref': 'A10',
+                'addr:country': 'AU', 'addr:state': 'SA',
+                'source': 'openstreetmap.org'
+            }, ways=[582052008]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 582052008, 'shield_text': '10', 'network': 'AU:A-road',
+             'all_networks': ['AU:A-road'], 'all_shield_texts': ['10']})
+
+    def test_s_road_in_both_relations(self):
+        import dsl
+
+        z, x, y = (16, 60644, 38056)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org'
+            }),
+            # https://www.openstreetmap.org/way/240922938
+            dsl.way(240922938, dsl.tile_diagonal(z, x, y), {
+                'source:name': 'survey', 'maxspeed': '60', 'lanes': '2',
+                'name': 'Beaudesert Beenleigh Road',
+                'source:maxspeed': 'sign', 'surface': 'asphalt',
+                'source': 'openstreetmap.org', 'source:ref': 'survey',
+                'ref': '92;T8', 'highway': 'primary', 'network': 'S',
+            }),
+            dsl.relation(1, {
+                'network': 'S', 'ref': '92', 'route': 'road',
+                'addr:state': 'QLD', 'source': 'openstreetmap.org',
+                'type': 'route', 'addr:country': 'AU',
+            }, ways=[240922938]),
+            dsl.relation(2, {
+                'type': 'route', 'route': 'road', 'ref': '8', 'network': 'T',
+                'source': 'openstreetmap.org'
+            }, ways=[240922938]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 240922938, 'shield_text': '92', 'network': 'AU:S-route',
+                'all_networks': ['AU:S-route', 'AU:T-drive'],
+                'all_shield_texts': ['92', '8'],
+            })
+
+    def test_s_road_not_in_t_relation(self):
+        import dsl
+
+        z, x, y = (16, 60607, 37966)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org'
+            }),
+            # https://www.openstreetmap.org/way/13851986
+            dsl.way(13851986, dsl.tile_diagonal(z, x, y), {
+                'source': 'openstreetmap.org', 'ref': '31;T8',
+                'name': 'Waterworks Road', 'highway': 'primary',
+                'surface': 'paved'
+            }),
+            dsl.relation(1, {
+                'network': 'S', 'ref': '31', 'route': 'road',
+                'addr:state': 'QLD', 'source': 'openstreetmap.org',
+                'type': 'route', 'addr:country': 'AU'
+            }, ways=[13851986]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 13851986, 'shield_text': '31', 'network': 'AU:S-route',
+                'all_networks': ['AU:S-route', 'AU:T-drive'],
+                'all_shield_texts': ['31', '8'],
+            })
+
+    def test_s_road_not_in_s_relation(self):
+        import dsl
+
+        z, x, y = (16, 60571, 37936)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org'
+            }),
+            # https://www.openstreetmap.org/way/16477624
+            dsl.way(16477624, dsl.tile_diagonal(z, x, y), {
+                'source': 'openstreetmap.org', 'ref': '31;T9',
+                'name': 'Mount Glorious Road', 'highway': 'secondary'
+            }),
+            dsl.relation(1, {
+                'network': 'T', 'ref': '9', 'route': 'road',
+                'addr:state': 'QLD', 'source': 'openstreetmap.org',
+                'type': 'route', 'addr:country': 'AU'
+            }, ways=[16477624]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 16477624, 'shield_text': '9', 'network': 'AU:T-drive',
+                'all_networks': ['AU:T-drive', None],
+                'all_shield_texts': ['9', '31'],
+            })

--- a/integration-test/1491-australia-shields.py
+++ b/integration-test/1491-australia-shields.py
@@ -125,3 +125,200 @@ class AustraliaShieldTest(FixtureTest):
                 'all_networks': ['AU:T-drive', None],
                 'all_shield_texts': ['9', '31'],
             })
+
+    # test not just a B-road, but one where the text ref has spaces between
+    # the additional T-drive refs (i.e: "T 28" rather than "T28").
+    def test_b_road_with_spaces(self):
+        import dsl
+
+        z, x, y = (16, 60720, 38212)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org',
+            }),
+            # https://www.openstreetmap.org/way/131293316
+            dsl.way(131293316, dsl.tile_diagonal(z, x, y), {
+                'source:name': 'NSW LPI Base Map', 'name': 'Myocum Road',
+                'source:name:date': '2016-02', 'surface': 'asphalt',
+                'source:date': '2016-07', 'source': 'openstreetmap.org',
+                'oneway': 'yes', 'ref': 'B62;T 28;T 30', 'highway': 'primary',
+            }),
+            dsl.relation(1, {
+                'ref': 'B62', 'route': 'road', 'addr:state': 'NSW',
+                'source': 'openstreetmap.org', 'type': 'route',
+                'addr:country': 'AU',
+            }, ways=[131293316]),
+            dsl.relation(2, {
+                'type': 'route', 'route': 'road', 'ref': '30', 'network': 'T',
+                'source': 'openstreetmap.org',
+            }, ways=[131293316]),
+            dsl.relation(3, {
+                'type': 'route', 'route': 'road', 'ref': '28', 'network': 'T',
+                'source': 'openstreetmap.org',
+            }, ways=[131293316]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 131293316, 'shield_text': '62', 'network': 'AU:B-road',
+                'all_networks': ['AU:B-road', 'AU:T-drive', 'AU:T-drive'],
+                'all_shield_texts': ['62', '28', '30'],
+            })
+
+    def test_c_road(self):
+        import dsl
+
+        z, x, y = (16, 59435, 40315)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org',
+            }),
+            # https://www.openstreetmap.org/way/7787334
+            dsl.way(7787334, dsl.tile_diagonal(z, x, y), {
+                'name': 'Churchill - Traralgon Road', 'surface': 'paved',
+                'source': 'openstreetmap.org', 'oneway': 'yes',
+                'ref': 'C475;C476', 'highway': 'secondary',
+            }),
+            dsl.relation(1, {
+                'name': 'Mattingley Hill Road', 'ref': 'C475', 'route': 'road',
+                'addr:state': 'VIC', 'source': 'openstreetmap.org',
+                'type': 'route', 'addr:country': 'AU',
+            }, ways=[7787334]),
+            dsl.relation(2, {
+                'ref': 'C476', 'route': 'road', 'addr:state': 'VIC',
+                'source': 'openstreetmap.org', 'type': 'route',
+                'addr:country': 'AU',
+            }, ways=[7787334]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 7787334, 'shield_text': '475', 'network': 'AU:C-road',
+                'all_shield_texts': ['475', '476'],
+                'all_networks': ['AU:C-road', 'AU:C-road'],
+            })
+
+    # this appears to be a typo - i can't find any reference to a "D83" road,
+    # and "The Outback Highway" (another name for Barndioota Road?) appears to
+    # be *B83* according to Wikipedia:
+    # https://en.wikipedia.org/wiki/Barndioota_Road
+    #
+    # so, given that this doesn't correspond to a known highway type in AU,
+    # we emit this with a network type of None, since we can't figure it out
+    # from the available information.
+    def test_d_road(self):
+        import dsl
+
+        z, x, y = (16, 57903, 38425)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org'
+            }),
+            # https://www.openstreetmap.org/way/229978585
+            dsl.way(229978585, dsl.tile_diagonal(z, x, y), {
+                'maxspeed': '80', 'lanes': '2', 'name': 'The Outback Highway',
+                'source': 'openstreetmap.org', 'surface': 'paved',
+                'name:source': 'data.sa.gov.au roads', 'ref': 'D83',
+                'highway': 'secondary',
+            }),
+            dsl.relation(1, {
+                'type': 'route', 'route': 'road', 'ref': 'D83',
+                'source': 'openstreetmap.org'
+            }, ways=[229978585]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 229978585, 'shield_text': '83', 'network': type(None),
+            })
+
+    def test_m_road(self):
+        import dsl
+
+        z, x, y = (16, 60296, 39327)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org'
+            }),
+            # https://www.openstreetmap.org/way/3188239
+            dsl.way(3188239, dsl.tile_diagonal(z, x, y), {
+                'old_ref': '1', 'maxspeed': '60', 'lanes': '2',
+                'name': 'Cahill Expressway', 'toll': 'yes',
+                'surface': 'asphalt', 'source': 'openstreetmap.org',
+                'ref:start_date': '2013-08', 'oneway': 'yes', 'ref': 'M1',
+                'highway': 'motorway', 'old_network': 'MR',
+            }),
+            dsl.relation(1, {
+                'ref': 'M1', 'route': 'road', 'addr:state': 'NSW',
+                'source': 'openstreetmap.org', 'type': 'route',
+                'addr:country': 'AU'
+            }, ways=[3188239]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 3188239, 'shield_text': '1', 'network': 'AU:M-road'})
+
+    # https://en.wikipedia.org/wiki/City_Ring_Route,_Adelaide
+    def test_ring_route(self):
+        import dsl
+
+        z, x, y = (16, 58001, 39557)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org',
+            }),
+            # https://www.openstreetmap.org/way/7795168
+            dsl.way(7795168, dsl.tile_diagonal(z, x, y), {
+                'maxspeed': '60', 'name': 'Hackney Road', 'surface': 'asphalt',
+                'cycleway': 'lane', 'source': 'openstreetmap.org',
+                'postal_code': '5069', 'oneway': 'yes', 'ref': 'R1',
+                'highway': 'primary',
+            }),
+            dsl.relation(1, {
+                'ref': 'R1', 'route': 'road', 'addr:state': 'SA',
+                'source': 'openstreetmap.org', 'type': 'route',
+                'addr:country': 'AU'
+            }, ways=[7795168]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 7795168, 'shield_text': '1', 'network': 'AU:R-route'})
+
+    def test_metroad(self):
+        import dsl
+
+        z, x, y = (16, 60622, 37990)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'AU',
+                'source': 'openstreetmap.org',
+            }),
+            # https://www.openstreetmap.org/way/463027243
+            dsl.way(463027243, dsl.tile_diagonal(z, x, y), {
+                'maxspeed': '60', 'lanes': '2', 'name': 'Granard Road',
+                'surface': 'asphalt', 'source': 'openstreetmap.org',
+                'oneway': 'yes', 'ref': 'MR2', 'highway': 'trunk',
+                'network': 'MR',
+            }),
+            dsl.relation(1, {
+                'type': 'route', 'route': 'road', 'ref': '2', 'network': 'MR',
+                'source': 'openstreetmap.org',
+            }, ways=[463027243]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads',
+            {'id': 463027243, 'shield_text': '2', 'network': 'AU:Metro-road'})

--- a/integration-test/192-shield-text-ref.py
+++ b/integration-test/192-shield-text-ref.py
@@ -15,14 +15,50 @@ class ShieldTextRef(FixtureTest):
              'shield_text': '101'})
 
     def test_multiple_shields(self):
+        import dsl
+
+        z, x, y = 16, 18022, 25522
+
         # I-77, I-81, US-11 & US-52 all in one road West Virginia.
-        self.load_fixtures([
-            'http://www.openstreetmap.org/way/51388984',
-            'http://www.openstreetmap.org/relation/2309416',
-            'http://www.openstreetmap.org/relation/2301037',
-            'http://www.openstreetmap.org/relation/2297359',
-            'http://www.openstreetmap.org/relation/1027748',
-        ], clip=self.tile_bbox(16, 18022, 25522))
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'kind': 'admin_area', 'iso_code': 'US',
+                'source': 'openstreetmap.org'
+            }),
+            # http://www.openstreetmap.org/way/51388984
+            dsl.way(51388984, dsl.tile_diagonal(z, x, y), {
+                'horse': 'no', 'maxspeed': '70 mph', 'bicycle': 'no',
+                'source': 'openstreetmap.org', 'hgv': 'designated',
+                'surface': 'asphalt', 'oneway': 'yes', 'foot': 'no',
+                'lanes': '3', 'sidewalk': 'none',
+                'ref': 'I 77;I 81;US 11;US 52', 'highway': 'motorway'
+            }),
+            dsl.relation(1, {
+                'name': 'US 11 (VA)', 'type': 'route', 'route': 'road',
+                'wikipedia': 'en:U.S. Route 11', 'is_in:state': 'VA',
+                'source': 'openstreetmap.org', 'wikidata': 'Q407534',
+                'ref': '11', 'network': 'US:US'
+            }, ways=[51388984]),
+            dsl.relation(2, {
+                'name': 'I 77 (VA) (North)', 'type': 'route', 'route': 'road',
+                'wikipedia': 'en:Interstate 77 in Virginia',
+                'is_in:state': 'VA', 'source': 'openstreetmap.org',
+                'wikidata': 'Q2447354', 'ref': '77', 'network': 'US:I'
+            }, ways=[51388984]),
+            dsl.relation(3, {
+                'direction': 'south', 'name': 'I 81 (VA southbound)',
+                'type': 'route', 'route': 'road',
+                'wikipedia': 'en:Interstate 81 in Virginia',
+                'is_in:state': 'VA', 'source': 'openstreetmap.org',
+                'wikidata': 'Q2447647', 'ref': '81', 'network': 'US:I'
+            }, ways=[51388984]),
+            dsl.relation(4, {
+                'name': 'US 52 (VA)', 'type': 'route', 'route': 'road',
+                'wikipedia': 'en:U.S. Route 52', 'is_in:state': 'VA',
+                'source': 'openstreetmap.org', 'ref': '52', 'network': 'US:US'
+            }, ways=[51388984]),
+        )
+
         self.assert_has_feature(
             16, 18022, 25522, 'roads',
             {'kind': 'highway', 'network': 'US:I', 'id': 51388984,

--- a/queries.yaml
+++ b/queries.yaml
@@ -458,7 +458,7 @@ post_process:
       target_attribute: country_code
       linear: true
 
-  - fn: vectordatasource.transform.backfill_road_networks
+  - fn: vectordatasource.transform.road_networks
     params:
       layer: roads
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4424,7 +4424,7 @@ def _choose_most_important_network(properties, prefix, importance_fn):
         def network_key(t):
             return importance_fn(*t)
 
-        tuples = sorted(zip(networks, shield_texts), key=network_key)
+        tuples = sorted(set(zip(networks, shield_texts)), key=network_key)
 
         # expose first network as network/shield_text
         network, ref = tuples[0]

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4193,9 +4193,9 @@ def _normalize_au_netref(network, ref):
 #
 # the different logic sections are:
 #
-# * backfill: this is called as fn(ref) when the `network` value is missing in
-#             the original object and may return a list of (network, ref)
-#             tuples to use instead.
+# * backfill: this is called as fn(ref) to unpack the ref tag into a list of
+#             (network, ref) tuples to use instead. For example, it's common
+#             to give ref=A1;B2;C3 to indicate multiple networks & shields.
 #
 # * fix: this is called as fn(network, ref) and should fix whatever problems it
 #        can and return the replacement (network, ref). remember! either


### PR DESCRIPTION
Added logic to do per-country road network processing. The first case for this, other than breaking out the logic for AR, GB and US which already existed, was Australia.

This adds the concept of a `CountryNetworkLogic`, which bundles logic for a particular country together (previously it was spread over several functions). The initial version contains up to three functions:

* `backfill`: this is called to expand the `ref`tag into a list of `(network, ref)` pairs . For example; in Australia, where network relations are less commonly used than in the US, a road might have `ref=S1;T2` to indicate it's part of both the S- and T-route networks. This function is where that splitting can happen.

* `fix`: this is called to try and fix whatever problems it can with the `network` and `ref`, returning replacements. For example, in Australia it's common to give the `network=A`, when we'd prefer a "fully-qualified" network name such as `network=AU:A-road`. Also, it's possible for the `network` to be `None` if there was no network tag, but the `ref` gives the network name (e.g: `ref=A1`).

* `sort`: this is called with a `network` and `ref` and should return a numeric value where lower numeric values mean _more_ important networks. This is used to sort the roads into order to pick the "most important" one to put in the `shield_text` and `network` properties on the output element. In Australia, as in the US, it's common for roads to be part of multiple networks and we might only have space to show one shield.

Connects to #1491.
