### PR TITLE
South Korean road shields

### DIFF
--- a/integration-test/1491-south-korean-shields.py
+++ b/integration-test/1491-south-korean-shields.py
@@ -162,3 +162,110 @@ class SouthKoreanShields(FixtureTest):
                 'shield_text': '92',
                 'network': 'KR:national',
             })
+
+    def test_kr_national_no_rel(self):
+        import dsl
+
+        z, x, y = (16, 56158, 25837)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/542451694
+            dsl.way(542451694, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Upo 1-daero', 'name': u'\uc6b0\ud3ec1\ub300\ub85c',
+                'name:ko': u'\uc6b0\ud3ec1\ub300\ub85c', 'review': 'no',
+                'source': 'openstreetmap.org', 'highway': 'primary',
+                'ref': '20;24', 'ncat': u'\uad6d\ub3c4',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 542451694,
+                'shield_text': '20', 'network': 'KR:national',
+                'all_shield_texts': ['20', '24'],
+                'all_networks': ['KR:national', 'KR:national'],
+            })
+
+    def test_kr_expressway_no_rel(self):
+        import dsl
+
+        z, x, y = (16, 55923, 25876)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/574671133
+            dsl.way(574671133, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Gwangjudaegu Expressway',
+                'name': u'\uad11\uc8fc\ub300\uad6c\uace0\uc18d\ub3c4\ub85c',
+                'name:ko': u'\uad11\uc8fc\ub300\uad6c\uace0\uc18d\ub3c4\ub85c',
+                'review': 'no', 'name:ko_rm': 'Gwangjudaegugosokdoro',
+                'source': 'openstreetmap.org', 'maxspeed': '80',
+                'ncat': u'\uace0\uc18d\ub3c4\ub85c', 'oneway': 'yes',
+                'ref': '12', 'highway': 'motorway',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 574671133,
+                'shield_text': '12',
+                'network': 'KR:expressway',
+            })
+
+    def test_kr_expressway_no_name_en(self):
+        import dsl
+
+        z, x, y = (16, 56165, 25760)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/43543281
+            dsl.way(43543281, dsl.tile_diagonal(z, x, y), {
+                'lanes': '2', 'name': u'\uc911\ubd80\ub0b4\ub959\uace0'
+                u'\uc18d\ub3c4\ub85c\uc9c0\uc120', 'review': 'no',
+                'source': 'openstreetmap.org', 'highway': 'motorway',
+                'oneway': 'yes', 'ref': '451',
+                'ncat': u'\uace0\uc18d\ub3c4\ub85c',
+            }),
+            dsl.relation(1, {
+                'type': 'route', 'route': 'road', 'ref': '451',
+                'source': 'openstreetmap.org',
+            }, ways=[43543281]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 43543281,
+                'shield_text': '451',
+                'network': 'KR:expressway',
+            })
+
+    def test_kr_expressway_no_name_en_no_ncat(self):
+        # same as the test above, but without the "ncat" to test that it
+        # backfills from the name.
+        import dsl
+
+        z, x, y = (16, 56165, 25760)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/43543281
+            dsl.way(43543281, dsl.tile_diagonal(z, x, y), {
+                'lanes': '2', 'name': u'\uc911\ubd80\ub0b4\ub959\uace0'
+                u'\uc18d\ub3c4\ub85c\uc9c0\uc120', 'review': 'no',
+                'source': 'openstreetmap.org', 'highway': 'motorway',
+                'oneway': 'yes', 'ref': '451',
+            }),
+            dsl.relation(1, {
+                'type': 'route', 'route': 'road', 'ref': '451',
+                'source': 'openstreetmap.org',
+            }, ways=[43543281]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 43543281,
+                'shield_text': '451',
+                'network': 'KR:expressway',
+            })

--- a/integration-test/1491-south-korean-shields.py
+++ b/integration-test/1491-south-korean-shields.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 from . import FixtureTest
 
 
@@ -11,19 +12,16 @@ class SouthKoreanShields(FixtureTest):
             dsl.is_in('KR', z, x, y),
             # https://www.openstreetmap.org/way/547188348
             dsl.way(547188348, dsl.tile_diagonal(z, x, y), {
-                'name:en': 'Tongil-ro', 'name': u'\ud1b5\uc77c\ub85c',
-                'review': 'no', 'source': 'openstreetmap.org',
-                'highway': 'primary',
+                'name:en': 'Tongil-ro', 'name': u'통일로', 'review': 'no',
+                'source': 'openstreetmap.org', 'highway': 'primary',
             }),
             dsl.relation(1, {
-                'alt_name': u'\uc544\uc8fc\uacf5\ub85c 1\ud638\uc120',
-                'int_ref': 'AH1', 'layer': '1', 'section': 'Korea',
-                'int_name': 'Asian Highway AH1', 'network': 'AH',
-                'name': u'\uc544\uc2dc\uc548 \ud558\uc774\uc6e8\uc774 1'
-                u'\ud638\uc120', 'name:en': 'Asian Highway AH1', 'ref': 'AH1',
-                'route': 'road', 'source': 'openstreetmap.org',
-                'state': 'connection', 'type': 'route',
-                'wikidata': 'Q494205', 'wikipedia': 'en:AH1',
+                'alt_name': u'아주공로 1호선', 'int_ref': 'AH1', 'layer': '1',
+                'section': 'Korea', 'int_name': 'Asian Highway AH1',
+                'network': 'AH', 'name': u'아시안 하이웨이 1호선',
+                'name:en': 'Asian Highway AH1', 'ref': 'AH1', 'route': 'road',
+                'source': 'openstreetmap.org', 'state': 'connection',
+                'type': 'route', 'wikidata': 'Q494205', 'wikipedia': 'en:AH1',
             }, ways=[547188348]),
         )
 
@@ -44,17 +42,13 @@ class SouthKoreanShields(FixtureTest):
             # https://www.openstreetmap.org/way/37399710
             dsl.way(37399710, dsl.tile_diagonal(z, x, y), {
                 'tunnel:name:ko_rm': 'Namsan il ho teoneol', 'tunnel': 'yes',
-                'layer': '-2', 'name:en': 'Samil-daero',
-                'name': u'\uc0bc\uc77c\ub300\ub85c',
-                'tunnel:name:ko': u'\ub0a8\uc0b01\ud638\ud130\ub110',
-                'name:ko': u'\uc0bc\uc77c\ub300\ub85c', 'review': 'no',
-                'name:ko_rm': 'Samil-daero',
+                'layer': '-2', 'name:en': 'Samil-daero', 'name': u'삼일대로',
+                'tunnel:name:ko': u'남산1호터널', 'name:ko': u'삼일대로',
+                'review': 'no', 'name:ko_rm': 'Samil-daero',
                 'tunnel:name:en': 'Namsan 1 Ho Tunnel',
-                'source': 'openstreetmap.org',
-                'ncat': u'\uad11\uc5ed\uc2dc\ub3c4\ub85c', 'oneway': 'yes',
-                'tunnel:name': u'\ub0a8\uc0b01\ud638\ud130\ub110',
-                'ref': 'AH1', 'toll': 'yes', 'highway': 'primary',
-                'name:ja': u'\u4e09\u4e00\u5927\u8def',
+                'source': 'openstreetmap.org', 'ncat': u'광역시도로',
+                'oneway': 'yes', 'tunnel:name': u'남산1호터널', 'ref': 'AH1',
+                'toll': 'yes', 'highway': 'primary', 'name:ja': u'三一大路',
             }),
         )
 
@@ -74,17 +68,15 @@ class SouthKoreanShields(FixtureTest):
             dsl.is_in('KR', z, x, y),
             # https://www.openstreetmap.org/way/90611594
             dsl.way(90611594, dsl.tile_diagonal(z, x, y), {
-                'name:en': u'Tongyeong\u2013Daejeon Expressway', 'lanes': '2',
-                'name': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
-                'name:ko': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
+                'name:en': u'Tongyeong–Daejeon Expressway', 'lanes': '2',
+                'name': u'통영대전고속도로', 'name:ko': u'통영대전고속도로',
                 'name:ko_rm': 'Tongyeong-daejeon-gosokdoro',
                 'source': 'openstreetmap.org', 'maxspeed': '100',
                 'oneway': 'yes', 'ref': '35', 'highway': 'motorway',
             }),
             dsl.relation(1, {
-                'layer': '1', 'name:en': u'Tongyeong\u2013Daejeon Expressway',
-                'name': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
-                'name:ko': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
+                'layer': '1', 'name:en': u'Tongyeong–Daejeon Expressway',
+                'name': u'통영대전고속도로', 'name:ko': u'통영대전고속도로',
                 'type': 'route', 'route': 'road',
                 'source': 'openstreetmap.org', 'ref': '35',
             }, ways=[90611594]),
@@ -107,22 +99,18 @@ class SouthKoreanShields(FixtureTest):
             # https://www.openstreetmap.org/way/59242897
             dsl.way(59242897, dsl.tile_diagonal(z, x, y), {
                 'name:en': 'Seoul Ring Expressway', 'lanes': '4',
-                'name': u'\uc11c\uc6b8\uc678\uacfd\uc21c\ud658\uace0'
-                u'\uc18d\ub3c4\ub85c', 'name:ko': u'\uc11c\uc6b8\uc678'
-                u'\uacfd\uc21c\ud658\uace0\uc18d\ub3c4\ub85c',
+                'name': u'서울외곽순환고속도로',
+                'name:ko': u'서울외곽순환고속도로',
                 'name:ko_rm': 'Seouloegwaksunhwangosokdoro',
                 'source': 'openstreetmap.org', 'oneway': 'yes', 'ref': '100',
                 'highway': 'motorway',
             }),
             dsl.relation(1, {
                 'name:en': 'Seoul Ring Expressway(KEC), bound for '
-                'Pangyo(Ilsan)', 'name': u'\uc11c\uc6b8\uc678\uacfd\uc21c'
-                u'\ud658\uace0\uc18d\ub3c4\ub85c(\ub3c4\ub85c\uacf5\uc0ac)'
-                u' \ud310\uad50(\uc77c\uc0b0)\ubc29\ud5a5',
-                'name:ko': u'\uc11c\uc6b8\uc678\uacfd\uc21c\ud658\uace0'
-                u'\uc18d\ub3c4\ub85c(\ub3c4\ub85c\uacf5\uc0ac) \ud310'
-                u'\uad50(\uc77c\uc0b0)\ubc29\ud5a5', 'route': 'road',
-                'source': 'openstreetmap.org',
+                'Pangyo(Ilsan)',
+                'name': u'서울외곽순환고속도로(도로공사) 판교(일산)방향',
+                'name:ko': u'서울외곽순환고속도로(도로공사) 판교(일산)방향',
+                'route': 'road', 'source': 'openstreetmap.org',
                 'operator': 'Korea Expressway Corporation', 'type': 'route',
                 'road': 'kr:expressway', 'network': 'KR:expressway',
             }, ways=[59242897]),
@@ -144,11 +132,10 @@ class SouthKoreanShields(FixtureTest):
             dsl.is_in('KR', z, x, y),
             # https://www.openstreetmap.org/way/71503022
             dsl.way(71503022, dsl.tile_diagonal(z, x, y), {
-                'name:en': 'Nambusunhwan-ro', 'name': u'\ub0a8\ubd80'
-                u'\uc21c\ud658\ub85c', 'name:ko': u'\ub0a8\ubd80\uc21c'
-                u'\ud658\ub85c', 'source': 'openstreetmap.org',
+                'name:en': 'Nambusunhwan-ro', 'name': u'남부순환로',
+                'name:ko': u'남부순환로', 'source': 'openstreetmap.org',
                 'oneway': 'yes', 'ref': '92', 'highway': 'primary',
-                'name:ja': u'\u5357\u90e8\u5faa\u74b0\u8def',
+                'name:ja': u'南部循環路',
             }),
             dsl.relation(1, {
                 'type': 'route', 'route': 'road', 'ref': '92',
@@ -172,10 +159,10 @@ class SouthKoreanShields(FixtureTest):
             dsl.is_in('KR', z, x, y),
             # https://www.openstreetmap.org/way/542451694
             dsl.way(542451694, dsl.tile_diagonal(z, x, y), {
-                'name:en': 'Upo 1-daero', 'name': u'\uc6b0\ud3ec1\ub300\ub85c',
-                'name:ko': u'\uc6b0\ud3ec1\ub300\ub85c', 'review': 'no',
+                'name:en': 'Upo 1-daero', 'name': u'우포1대로',
+                'name:ko': u'우포1대로', 'review': 'no',
                 'source': 'openstreetmap.org', 'highway': 'primary',
-                'ref': '20;24', 'ncat': u'\uad6d\ub3c4',
+                'ref': '20;24', 'ncat': u'국도',
             }),
         )
 
@@ -197,12 +184,11 @@ class SouthKoreanShields(FixtureTest):
             # https://www.openstreetmap.org/way/574671133
             dsl.way(574671133, dsl.tile_diagonal(z, x, y), {
                 'name:en': 'Gwangjudaegu Expressway',
-                'name': u'\uad11\uc8fc\ub300\uad6c\uace0\uc18d\ub3c4\ub85c',
-                'name:ko': u'\uad11\uc8fc\ub300\uad6c\uace0\uc18d\ub3c4\ub85c',
+                'name': u'광주대구고속도로', 'name:ko': u'광주대구고속도로',
                 'review': 'no', 'name:ko_rm': 'Gwangjudaegugosokdoro',
                 'source': 'openstreetmap.org', 'maxspeed': '80',
-                'ncat': u'\uace0\uc18d\ub3c4\ub85c', 'oneway': 'yes',
-                'ref': '12', 'highway': 'motorway',
+                'ncat': u'고속도로', 'oneway': 'yes', 'ref': '12',
+                'highway': 'motorway',
             }),
         )
 
@@ -222,11 +208,9 @@ class SouthKoreanShields(FixtureTest):
             dsl.is_in('KR', z, x, y),
             # https://www.openstreetmap.org/way/43543281
             dsl.way(43543281, dsl.tile_diagonal(z, x, y), {
-                'lanes': '2', 'name': u'\uc911\ubd80\ub0b4\ub959\uace0'
-                u'\uc18d\ub3c4\ub85c\uc9c0\uc120', 'review': 'no',
+                'lanes': '2', 'name': u'중부내륙고속도로지선', 'review': 'no',
                 'source': 'openstreetmap.org', 'highway': 'motorway',
-                'oneway': 'yes', 'ref': '451',
-                'ncat': u'\uace0\uc18d\ub3c4\ub85c',
+                'oneway': 'yes', 'ref': '451', 'ncat': u'고속도로',
             }),
             dsl.relation(1, {
                 'type': 'route', 'route': 'road', 'ref': '451',
@@ -252,8 +236,7 @@ class SouthKoreanShields(FixtureTest):
             dsl.is_in('KR', z, x, y),
             # https://www.openstreetmap.org/way/43543281
             dsl.way(43543281, dsl.tile_diagonal(z, x, y), {
-                'lanes': '2', 'name': u'\uc911\ubd80\ub0b4\ub959\uace0'
-                u'\uc18d\ub3c4\ub85c\uc9c0\uc120', 'review': 'no',
+                'lanes': '2', 'name': u'중부내륙고속도로지선', 'review': 'no',
                 'source': 'openstreetmap.org', 'highway': 'motorway',
                 'oneway': 'yes', 'ref': '451',
             }),
@@ -280,17 +263,15 @@ class SouthKoreanShields(FixtureTest):
             # https://www.openstreetmap.org/way/562319872
             dsl.way(562319872, dsl.tile_diagonal(z, x, y), {
                 'name:en': 'Jungbunaeryuk Expressway', 'lanes': '2',
-                'name': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
-                'name:ko': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
+                'name': u'중부내륙고속도로', 'name:ko': u'중부내륙고속도로',
                 'review': 'no', 'name:ko_rm': 'Jungbunaeryukgosokdoro',
-                'source': 'openstreetmap.org',
-                'ncat': u'\uace0\uc18d\ub3c4\ub85c', 'oneway': 'yes',
-                'ref': '45', 'toll': 'yes', 'highway': 'motorway',
+                'source': 'openstreetmap.org', 'ncat': u'고속도로',
+                'oneway': 'yes', 'ref': '45', 'toll': 'yes',
+                'highway': 'motorway',
             }),
             dsl.relation(1, {
                 'name:en': 'Jungbunaeryuk Expressway',
-                'name': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
-                'name:ko': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
+                'name': u'중부내륙고속도로', 'name:ko': u'중부내륙고속도로',
                 'ref': '45', 'route': 'road', 'source': 'openstreetmap.org',
                 'type': 'route',
             }, ways=[562319872]),
@@ -312,10 +293,9 @@ class SouthKoreanShields(FixtureTest):
             dsl.is_in('KR', z, x, y),
             # https://www.openstreetmap.org/way/179815107
             dsl.way(179815107, dsl.tile_diagonal(z, x, y), {
-                'name:en': 'Upo 2-ro', 'name': u'\uc6b0\ud3ec2\ub85c',
-                'name:ko': u'\uc6b0\ud3ec2\ub85c', 'review': 'no',
-                'source': 'openstreetmap.org', 'highway': 'secondary',
-                'ref': '1080', 'ncat': u'\uc9c0\ubc29\ub3c4',
+                'name:en': 'Upo 2-ro', 'name': u'우포2로', 'name:ko': u'우포2로',
+                'review': 'no', 'source': 'openstreetmap.org',
+                'highway': 'secondary', 'ref': '1080', 'ncat': u'지방도',
             }),
         )
 
@@ -337,12 +317,10 @@ class SouthKoreanShields(FixtureTest):
             dsl.way(37395768, dsl.tile_diagonal(z, x, y), {
                 'bridge': 'viaduct', 'layer': '2',
                 'name:en': 'Naebusunhwan-ro', 'bicycle': 'no',
-                'name': u'\ub0b4\ubd80\uc21c\ud658\ub85c',
-                'name:ko': u'\ub0b4\ubd80\uc21c\ud658\ub85c', 'review': 'no',
-                'source': 'openstreetmap.org',
-                'ncat': u'\ud2b9\ubcc4\uc2dc\ub3c4', 'oneway': 'yes',
-                'ref': '30', 'highway': 'trunk',
-                'name:ja': u'\u5185\u90e8\u5faa\u74b0\u8def',
+                'name': u'내부순환로', 'name:ko': u'내부순환로', 'review': 'no',
+                'source': 'openstreetmap.org', 'ncat': u'특별시도',
+                'oneway': 'yes', 'ref': '30', 'highway': 'trunk',
+                'name:ja': u'内部循環路',
             }),
         )
 
@@ -363,11 +341,9 @@ class SouthKoreanShields(FixtureTest):
             # https://www.openstreetmap.org/way/577716125
             dsl.way(577716125, dsl.tile_diagonal(z, x, y), {
                 'name:en': 'Jungang-daero',
-                'name': u'\uc911\uc559\ub300\ub85c',
-                'name:ko': u'\uc911\uc559\ub300\ub85c', 'review': 'no',
+                'name': u'중앙대로', 'name:ko': u'중앙대로', 'review': 'no',
                 'name:ko_rm': 'Jungangdaero', 'source': 'openstreetmap.org',
-                'highway': 'primary', 'ref': '61',
-                'ncat': u'\uad11\uc5ed\uc2dc\ub3c4\ub85c',
+                'highway': 'primary', 'ref': '61', 'ncat': u'광역시도로',
             }),
         )
 

--- a/integration-test/1491-south-korean-shields.py
+++ b/integration-test/1491-south-korean-shields.py
@@ -269,3 +269,111 @@ class SouthKoreanShields(FixtureTest):
                 'shield_text': '451',
                 'network': 'KR:expressway',
             })
+
+    def test_kr_jungbunaeryukgosokdoro(self):
+        import dsl
+
+        z, x, y = (16, 56156, 25839)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/562319872
+            dsl.way(562319872, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Jungbunaeryuk Expressway', 'lanes': '2',
+                'name': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
+                'name:ko': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
+                'review': 'no', 'name:ko_rm': 'Jungbunaeryukgosokdoro',
+                'source': 'openstreetmap.org',
+                'ncat': u'\uace0\uc18d\ub3c4\ub85c', 'oneway': 'yes',
+                'ref': '45', 'toll': 'yes', 'highway': 'motorway',
+            }),
+            dsl.relation(1, {
+                'name:en': 'Jungbunaeryuk Expressway',
+                'name': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
+                'name:ko': u'\uc911\ubd80\ub0b4\ub959\uace0\uc18d\ub3c4\ub85c',
+                'ref': '45', 'route': 'road', 'source': 'openstreetmap.org',
+                'type': 'route',
+            }, ways=[562319872]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 562319872,
+                'shield_text': '45',
+                'network': 'KR:expressway',
+            })
+
+    def test_kr_upo_2_ro(self):
+        import dsl
+
+        z, x, y = (16, 56158, 25837)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/179815107
+            dsl.way(179815107, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Upo 2-ro', 'name': u'\uc6b0\ud3ec2\ub85c',
+                'name:ko': u'\uc6b0\ud3ec2\ub85c', 'review': 'no',
+                'source': 'openstreetmap.org', 'highway': 'secondary',
+                'ref': '1080', 'ncat': u'\uc9c0\ubc29\ub3c4',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 179815107,
+                'shield_text': '1080',
+                'network': 'KR:local',
+            })
+
+    def test_kr_special_city(self):
+        import dsl
+
+        z, x, y = (16, 55879, 25372)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/37395768
+            dsl.way(37395768, dsl.tile_diagonal(z, x, y), {
+                'bridge': 'viaduct', 'layer': '2',
+                'name:en': 'Naebusunhwan-ro', 'bicycle': 'no',
+                'name': u'\ub0b4\ubd80\uc21c\ud658\ub85c',
+                'name:ko': u'\ub0b4\ubd80\uc21c\ud658\ub85c', 'review': 'no',
+                'source': 'openstreetmap.org',
+                'ncat': u'\ud2b9\ubcc4\uc2dc\ub3c4', 'oneway': 'yes',
+                'ref': '30', 'highway': 'trunk',
+                'name:ja': u'\u5185\u90e8\u5faa\u74b0\u8def',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 37395768,
+                'shield_text': '30',
+                'network': 'KR:metropolitan',
+            })
+
+    def test_kr_metropolitan(self):
+        import dsl
+
+        z, x, y = (16, 56178, 25761)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/577716125
+            dsl.way(577716125, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Jungang-daero',
+                'name': u'\uc911\uc559\ub300\ub85c',
+                'name:ko': u'\uc911\uc559\ub300\ub85c', 'review': 'no',
+                'name:ko_rm': 'Jungangdaero', 'source': 'openstreetmap.org',
+                'highway': 'primary', 'ref': '61',
+                'ncat': u'\uad11\uc5ed\uc2dc\ub3c4\ub85c',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 577716125,
+                'shield_text': '61',
+                'network': 'KR:metropolitan',
+            })

--- a/integration-test/1491-south-korean-shields.py
+++ b/integration-test/1491-south-korean-shields.py
@@ -1,0 +1,164 @@
+from . import FixtureTest
+
+
+class SouthKoreanShields(FixtureTest):
+    def test_asianhighway(self):
+        import dsl
+
+        z, x, y = (16, 55875, 25370)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/547188348
+            dsl.way(547188348, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Tongil-ro', 'name': u'\ud1b5\uc77c\ub85c',
+                'review': 'no', 'source': 'openstreetmap.org',
+                'highway': 'primary',
+            }),
+            dsl.relation(1, {
+                'alt_name': u'\uc544\uc8fc\uacf5\ub85c 1\ud638\uc120',
+                'int_ref': 'AH1', 'layer': '1', 'section': 'Korea',
+                'int_name': 'Asian Highway AH1', 'network': 'AH',
+                'name': u'\uc544\uc2dc\uc548 \ud558\uc774\uc6e8\uc774 1'
+                u'\ud638\uc120', 'name:en': 'Asian Highway AH1', 'ref': 'AH1',
+                'route': 'road', 'source': 'openstreetmap.org',
+                'state': 'connection', 'type': 'route',
+                'wikidata': 'Q494205', 'wikipedia': 'en:AH1',
+            }, ways=[547188348]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 547188348,
+                'shield_text': '1',
+                'network': 'AsianHighway',
+            })
+
+    def test_asianhighway_no_relation(self):
+        import dsl
+
+        z, x, y = (16, 55886, 25381)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/37399710
+            dsl.way(37399710, dsl.tile_diagonal(z, x, y), {
+                'tunnel:name:ko_rm': 'Namsan il ho teoneol', 'tunnel': 'yes',
+                'layer': '-2', 'name:en': 'Samil-daero',
+                'name': u'\uc0bc\uc77c\ub300\ub85c',
+                'tunnel:name:ko': u'\ub0a8\uc0b01\ud638\ud130\ub110',
+                'name:ko': u'\uc0bc\uc77c\ub300\ub85c', 'review': 'no',
+                'name:ko_rm': 'Samil-daero',
+                'tunnel:name:en': 'Namsan 1 Ho Tunnel',
+                'source': 'openstreetmap.org',
+                'ncat': u'\uad11\uc5ed\uc2dc\ub3c4\ub85c', 'oneway': 'yes',
+                'tunnel:name': u'\ub0a8\uc0b01\ud638\ud130\ub110',
+                'ref': 'AH1', 'toll': 'yes', 'highway': 'primary',
+                'name:ja': u'\u4e09\u4e00\u5927\u8def',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 37399710,
+                'shield_text': '1',
+                'network': 'AsianHighway',
+            })
+
+    def test_kr_expressway_rel_no_net(self):
+        import dsl
+
+        z, x, y = (16, 55975, 25658)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/90611594
+            dsl.way(90611594, dsl.tile_diagonal(z, x, y), {
+                'name:en': u'Tongyeong\u2013Daejeon Expressway', 'lanes': '2',
+                'name': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
+                'name:ko': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
+                'name:ko_rm': 'Tongyeong-daejeon-gosokdoro',
+                'source': 'openstreetmap.org', 'maxspeed': '100',
+                'oneway': 'yes', 'ref': '35', 'highway': 'motorway',
+            }),
+            dsl.relation(1, {
+                'layer': '1', 'name:en': u'Tongyeong\u2013Daejeon Expressway',
+                'name': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
+                'name:ko': u'\ud1b5\uc601\ub300\uc804\uace0\uc18d\ub3c4\ub85c',
+                'type': 'route', 'route': 'road',
+                'source': 'openstreetmap.org', 'ref': '35',
+            }, ways=[90611594]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 90611594,
+                'shield_text': '35',
+                'network': 'KR:expressway',
+            })
+
+    def test_kr_expressway(self):
+        import dsl
+
+        z, x, y = (16, 55904, 25415)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/59242897
+            dsl.way(59242897, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Seoul Ring Expressway', 'lanes': '4',
+                'name': u'\uc11c\uc6b8\uc678\uacfd\uc21c\ud658\uace0'
+                u'\uc18d\ub3c4\ub85c', 'name:ko': u'\uc11c\uc6b8\uc678'
+                u'\uacfd\uc21c\ud658\uace0\uc18d\ub3c4\ub85c',
+                'name:ko_rm': 'Seouloegwaksunhwangosokdoro',
+                'source': 'openstreetmap.org', 'oneway': 'yes', 'ref': '100',
+                'highway': 'motorway',
+            }),
+            dsl.relation(1, {
+                'name:en': 'Seoul Ring Expressway(KEC), bound for '
+                'Pangyo(Ilsan)', 'name': u'\uc11c\uc6b8\uc678\uacfd\uc21c'
+                u'\ud658\uace0\uc18d\ub3c4\ub85c(\ub3c4\ub85c\uacf5\uc0ac)'
+                u' \ud310\uad50(\uc77c\uc0b0)\ubc29\ud5a5',
+                'name:ko': u'\uc11c\uc6b8\uc678\uacfd\uc21c\ud658\uace0'
+                u'\uc18d\ub3c4\ub85c(\ub3c4\ub85c\uacf5\uc0ac) \ud310'
+                u'\uad50(\uc77c\uc0b0)\ubc29\ud5a5', 'route': 'road',
+                'source': 'openstreetmap.org',
+                'operator': 'Korea Expressway Corporation', 'type': 'route',
+                'road': 'kr:expressway', 'network': 'KR:expressway',
+            }, ways=[59242897]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 59242897,
+                'shield_text': '100',
+                'network': 'KR:expressway',
+            })
+
+    def test_kr_national(self):
+        import dsl
+
+        z, x, y = (16, 55864, 25396)
+
+        self.generate_fixtures(
+            dsl.is_in('KR', z, x, y),
+            # https://www.openstreetmap.org/way/71503022
+            dsl.way(71503022, dsl.tile_diagonal(z, x, y), {
+                'name:en': 'Nambusunhwan-ro', 'name': u'\ub0a8\ubd80'
+                u'\uc21c\ud658\ub85c', 'name:ko': u'\ub0a8\ubd80\uc21c'
+                u'\ud658\ub85c', 'source': 'openstreetmap.org',
+                'oneway': 'yes', 'ref': '92', 'highway': 'primary',
+                'name:ja': u'\u5357\u90e8\u5faa\u74b0\u8def',
+            }),
+            dsl.relation(1, {
+                'type': 'route', 'route': 'road', 'ref': '92',
+                'network': 'KR:national', 'source': 'openstreetmap.org',
+            }, ways=[71503022]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 71503022,
+                'shield_text': '92',
+                'network': 'KR:national',
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -223,6 +223,7 @@ layers:
       - vectordatasource.transform.normalize_aerialways
       - vectordatasource.transform.normalize_cycleway
       - vectordatasource.transform.add_is_bicycle_related
+      - vectordatasource.transform.add_road_network_from_ncat
       - vectordatasource.transform.road_trim_properties
       - vectordatasource.transform.remove_feature_id
       - vectordatasource.transform.tags_remove

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -257,6 +257,10 @@ def add_road_network_from_ncat(shape, properties, fid, zoom):
             # metropolitan city roads - gwangyeoksido
             properties['network'] = 'KR:metropolitan'
 
+        elif ncat == u'\ud2b9\ubcc4\uc2dc\ub3c4':
+            # special city (Seoul) roads - teukbyeolsido
+            properties['network'] = 'KR:metropolitan'
+
         elif ncat == u'\uace0\uc18d\ub3c4\ub85c':
             # expressways - gosokdoro
             properties['network'] = 'KR:expressway'
@@ -4303,6 +4307,10 @@ def _guess_network_kr(tags):
 
         elif name_ko.endswith(u'\uad11\uc5ed\uc2dc\ub3c4\ub85c'):
             # metropolitan city roads - gwangyeoksido
+            network_from_tags = 'KR:metropolitan'
+
+        elif name_ko.endswith(u'\ud2b9\ubcc4\uc2dc\ub3c4'):
+            # special city (Seoul) roads - teukbyeolsido
             network_from_tags = 'KR:metropolitan'
 
         elif (name_ko.endswith(u'\uace0\uc18d\ub3c4\ub85c') or

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -249,23 +249,23 @@ def add_road_network_from_ncat(shape, properties, fid, zoom):
         tags = properties.get('tags', {})
         ncat = _make_unicode_or_none(tags.get('ncat'))
 
-        if ncat == u'\uad6d\ub3c4':
+        if ncat == u'국도':
             # national roads - gukdo
             properties['network'] = 'KR:national'
 
-        elif ncat == u'\uad11\uc5ed\uc2dc\ub3c4\ub85c':
+        elif ncat == u'광역시도로':
             # metropolitan city roads - gwangyeoksido
             properties['network'] = 'KR:metropolitan'
 
-        elif ncat == u'\ud2b9\ubcc4\uc2dc\ub3c4':
+        elif ncat == u'특별시도':
             # special city (Seoul) roads - teukbyeolsido
             properties['network'] = 'KR:metropolitan'
 
-        elif ncat == u'\uace0\uc18d\ub3c4\ub85c':
+        elif ncat == u'고속도로':
             # expressways - gosokdoro
             properties['network'] = 'KR:expressway'
 
-        elif ncat == u'\uc9c0\ubc29\ub3c4':
+        elif ncat == u'지방도':
             # local highways - jibangdo
             properties['network'] = 'KR:local'
 
@@ -4274,8 +4274,8 @@ def _guess_network_jp(tags):
     if name:
         if isinstance(name, str):
             name = unicode(name, 'utf-8')
-        if name.startswith(u'\u56fd\u9053') and \
-           name.endswith(u'\u53f7'):
+        if name.startswith(u'国道') and \
+           name.endswith(u'号'):
             network_from_name = 'JP:national'
 
     networks = []
@@ -4301,24 +4301,24 @@ def _guess_network_kr(tags):
     # national road.
     name_ko = _make_unicode_or_none(tags.get('name:ko') or tags.get('name'))
     if name_ko and network_from_tags is None:
-        if name_ko.endswith(u'\uad6d\ub3c4'):
+        if name_ko.endswith(u'국도'):
             # national roads - gukdo
             network_from_tags = 'KR:national'
 
-        elif name_ko.endswith(u'\uad11\uc5ed\uc2dc\ub3c4\ub85c'):
+        elif name_ko.endswith(u'광역시도로'):
             # metropolitan city roads - gwangyeoksido
             network_from_tags = 'KR:metropolitan'
 
-        elif name_ko.endswith(u'\ud2b9\ubcc4\uc2dc\ub3c4'):
+        elif name_ko.endswith(u'특별시도'):
             # special city (Seoul) roads - teukbyeolsido
             network_from_tags = 'KR:metropolitan'
 
-        elif (name_ko.endswith(u'\uace0\uc18d\ub3c4\ub85c') or
-              name_ko.endswith(u'\uace0\uc18d\ub3c4\ub85c\uc9c0\uc120')):
+        elif (name_ko.endswith(u'고속도로') or
+              name_ko.endswith(u'고속도로지선')):
             # expressways - gosokdoro (and expressway branches)
             network_from_tags = 'KR:expressway'
 
-        elif name_ko.endswith(u'\uc9c0\ubc29\ub3c4'):
+        elif name_ko.endswith(u'지방도'):
             # local highways - jibangdo
             network_from_tags = 'KR:local'
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4256,6 +4256,33 @@ def _guess_network_jp(tags):
     return networks
 
 
+def _guess_network_kr(tags):
+    ref = tags.get('ref')
+
+    # seems really weird to be doing this based on the English name, but
+    # the Korean name ending with gosokdoro didn't seem to be limited to
+    # expressways alone?
+    name_en = tags.get('name:en')
+    network_from_name = None
+    if name_en:
+        if name_en.endswith(' Expressway'):
+            network_from_name = 'KR:expressway'
+
+    networks = []
+    for part in ref.split(';'):
+        if not part:
+            continue
+        network, ref = _normalize_kr_netref(None, part)
+
+        if network is None and network_from_name is not None:
+            network = network_from_name
+
+        if network and part:
+            networks.append((network, part))
+
+    return networks
+
+
 def _do_not_backfill(tags):
     return None
 
@@ -4674,6 +4701,18 @@ def _normalize_jp_netref(network, ref):
     return network, ref
 
 
+def _normalize_kr_netref(network, ref):
+    net, part = _splitref(ref)
+    if net == 'AH':
+        network = 'AsianHighway'
+        ref = part
+
+    elif network == 'AH':
+        network = 'AsianHighway'
+
+    return network, ref
+
+
 def _shield_text_ar(network, ref):
     # Argentinian national routes start with "RN" (ruta nacional), which
     # should be stripped, but other letters shouldn't be!
@@ -4767,6 +4806,10 @@ _COUNTRY_SPECIFIC_ROAD_NETWORK_LOGIC = {
         backfill=_guess_network_jp,
         fix=_normalize_jp_netref,
         shield_text=_use_ref_as_is,
+    ),
+    'KR': CountryNetworkLogic(
+        backfill=_guess_network_kr,
+        fix=_normalize_kr_netref,
     ),
     'MX': CountryNetworkLogic(
         backfill=_guess_network_mx,


### PR DESCRIPTION
In addition to the expressways, national and local roads, there's a [metropolitan type of road too](https://en.wikipedia.org/wiki/Highway_system_in_South_Korea#Special_Metropolitan_City_roads_and_Metropolitan_City_roads), which I've added as `KR:metropolitan`.

Although many of the roads are not in relations, we can infer the network type from the name and the `ncat` tag, which is [sometimes present on the way](https://taginfo.openstreetmap.org/keys/ncat?filter=ways#values). This tag seems to be only used in South Korea, and not really documented anywhere, but as far as I've been able to tell it corresponds well with what we're expect the `network` tag to be. Given that we wouldn't want to export the `ncat` tag in properties in the tile, instead I've extracted it from the tags before we delete them and use it to back-fill `network`.

Connects to #1491.
