### PR TITLE
Swiss road shields.

### DIFF
--- a/integration-test/1491-generic-network-fixes.py
+++ b/integration-test/1491-generic-network-fixes.py
@@ -464,7 +464,10 @@ class GenericNetworkTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'roads', {
                 'id': 26686903,
-                'network': u'CH:Nationalstrasse',
+                'shield_text': '28',
+                'network': u'CH:national',
+                'all_shield_texts': ['28'],
+                'all_networks': ['CH:national'],
             })
 
     def test_chregional(self):

--- a/integration-test/1519-swiss-road-shields.py
+++ b/integration-test/1519-swiss-road-shields.py
@@ -1,0 +1,172 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class SwissShieldTest(FixtureTest):
+    def test_1_chmotorway(self):
+        import dsl
+
+        z, x, y = (16, 34086, 23060)
+
+        self.generate_fixtures(
+            dsl.is_in('CH', z, x, y),
+            # https://www.openstreetmap.org/way/40653024
+            dsl.way(40653024, dsl.tile_diagonal(z, x, y), {
+                'highway': u'motorway',
+                'int_ref': u'E 25',
+                'lanes': u'2',
+                'lit': u'no',
+                'maxspeed': u'120',
+                'oneway': u'yes',
+                'ref': u'A1',
+                'source': u'openstreetmap.org',
+                'surface': u'asphalt',
+                'toll': u'yes',
+            }),
+            dsl.relation(1, {
+                'name': u'A1',
+                'network': u'motorway',
+                'ref': u'A1',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'toll': u'yes',
+                'type': u'route',
+                'wikidata': u'Q675903',
+                'wikipedia': u'de:Autobahn 1 (Schweiz)',
+            }, ways=[40653024]),
+            dsl.relation(2, {
+                'network': u'e-road',
+                'ref': u'E 25',
+                'route': u'road',
+                'section': u'Switzerland middle',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+                'wikipedia': u'en:European route E25',
+            }, ways=[40653024]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 40653024,
+                'network': u'CH:motorway',
+                'shield_text': u'1',
+            })
+
+    def test_28_chnational(self):
+        import dsl
+
+        z, x, y = (16, 34520, 23057)
+
+        self.generate_fixtures(
+            dsl.is_in('CH', z, x, y),
+            # https://www.openstreetmap.org/way/366999324
+            dsl.way(366999324, dsl.tile_diagonal(z, x, y), {
+                'bicycle': u'no',
+                'destination:forward': u'Landquart',
+                'highway': u'primary',
+                'lanes': u'2',
+                'lanes:backward': u'1',
+                'maxheight': u'default',
+                'maxspeed': u'80',
+                'overtaking': u'no',
+                'ref': u'28',
+                'source': u'openstreetmap.org',
+                'width': u'7',
+            }),
+            dsl.relation(1, {
+                'name': u'Hauptstrasse 28',
+                'ref': u'28',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[366999324]),
+            dsl.relation(2, {
+                'name': u'Ausbau N28 Prättigauerstrasse',
+                'network': u'ch:Nationalstrasse',
+                'operator': u'Schweizerische Eidgenossenschaft',
+                'ref': u'N28 (Projekt)',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[366999324]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 366999324,
+                'network': u'CH:national',
+                'shield_text': u'28',
+            })
+
+    def test_20_chnational(self):
+        import dsl
+
+        z, x, y = (16, 34009, 23025)
+
+        self.generate_fixtures(
+            dsl.is_in('CH', z, x, y),
+            # https://www.openstreetmap.org/way/24521024
+            dsl.way(24521024, dsl.tile_diagonal(z, x, y), {
+                'highway': u'primary',
+                'lit': u'yes',
+                'name': u'Boulevard de la Liberté',
+                'ref': u'20',
+                'source': u'openstreetmap.org',
+            }),
+            dsl.relation(1, {
+                'name': u'Hauptstrasse 20',
+                'name:fr': u'Route Principale 20',
+                'network': u'ch:national',
+                'note': u'(F)–Le Locle–La Chaux-de-Fonds–Neuchâtel',
+                'ref': u'20',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[24521024]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 24521024,
+                'network': u'CH:national',
+                'shield_text': u'20',
+            })
+
+    def test_104_chregional(self):
+        import dsl
+
+        z, x, y = (16, 33880, 23262)
+
+        self.generate_fixtures(
+            dsl.is_in('CH', z, x, y),
+            # https://www.openstreetmap.org/way/27912771
+            dsl.way(27912771, dsl.tile_diagonal(z, x, y), {
+                'avz': u'152',
+                'bicycle': u'no',
+                'bridge': u'yes',
+                'cs_dir:forward': u'1',
+                'foot': u'no',
+                'highway': u'secondary',
+                'layer': u'1',
+                'maxspeed': u'60',
+                'name': u'Pont Butin',
+                'oneway': u'yes',
+                'ref': u'104',
+                'source': u'openstreetmap.org',
+            }),
+            dsl.relation(1, {
+                'name': u'Plan-les-Ouates–Pont-Butin–Cointrin',
+                'network': u'ch:regional',
+                'ref': u'104',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[27912771]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 27912771,
+                'network': u'CH:regional',
+                'shield_text': u'104',
+            })

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4608,9 +4608,9 @@ def _sort_network_ca(network, ref):
 def _sort_network_ch(network, ref):
     if network is None:
         network_code = 9999
-    elif network == 'CA:national':
+    elif network == 'CH:national':
         network_code = 0
-    elif network == 'CA:regional':
+    elif network == 'CH:regional':
         network_code = 1
     elif network == 'e-road':
         network_code = 99

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4265,6 +4265,18 @@ def _guess_network_ca(tags):
     return networks
 
 
+def _guess_network_ch(tags):
+    ref = tags.get('ref')
+    networks = []
+    for part in ref.split(';'):
+        if not part:
+            continue
+        network, ref = _normalize_ch_netref(None, part)
+        if network or ref:
+            networks.append((network, ref))
+    return networks
+
+
 def _guess_network_cn(tags):
     ref = tags.get('ref')
     networks = []
@@ -4585,6 +4597,23 @@ def _sort_network_ca(network, ref):
         network_code = 0
     elif network == 'CA:yellowhead':
         network_code = 1
+    else:
+        network_code = len(network.split(':')) + 2
+
+    ref = _ref_importance(ref)
+
+    return network_code * 10000 + min(ref, 9999)
+
+
+def _sort_network_ch(network, ref):
+    if network is None:
+        network_code = 9999
+    elif network == 'CA:national':
+        network_code = 0
+    elif network == 'CA:regional':
+        network_code = 1
+    elif network == 'e-road':
+        network_code = 99
     else:
         network_code = len(network.split(':')) + 2
 
@@ -5062,6 +5091,25 @@ def _normalize_ca_netref(network, ref):
 def _normalize_cd_netref(network, ref):
     if network == 'CD:rrig':
         network = 'CD:RRIG'
+
+    return network, ref
+
+
+def _normalize_ch_netref(network, ref):
+    prefix, ref = _splitref(ref)
+
+    if network == 'CH:Nationalstrasse':
+        # clean up the ref by removing any prefixes and extra stuff after
+        # the number.
+        ref = ref.split(' ')[0]
+        network = 'CH:national'
+
+    elif prefix == 'A':
+        network = 'CH:motorway'
+
+    elif network not in ('CH:motorway', 'CH:national', 'CH:regional'):
+        network = None
+        ref = None
 
     return network, ref
 
@@ -5754,6 +5802,11 @@ _COUNTRY_SPECIFIC_ROAD_NETWORK_LOGIC = {
         backfill=_guess_network_ca,
         fix=_normalize_ca_netref,
         sort=_sort_network_ca,
+    ),
+    'CH': CountryNetworkLogic(
+        backfill=_guess_network_ch,
+        fix=_normalize_ch_netref,
+        sort=_sort_network_ch,
     ),
     'CD': CountryNetworkLogic(
         fix=_normalize_cd_netref,


### PR DESCRIPTION
It looks like there are perhaps 3 different levels of roads in Switzerland:

* Autobahnen / autostrassen. These seem to generally have a ref of `A#`, and/or be in `ch:motorway` relations.
* National roads / hauptstrassen. These just seem to have a numeric ref, some in relations with `ch:national`.
* Regional roads. These just seem to have a numeric ref, some in relations with `ch:regional`.

I've mapped these to `CH:motorway`, `CH:national` or `CH:regional`.

Connects to #1519. Connects to #1491.
