### PR TITLE
Join countries and regions to Natural Earth for min and max zoom.

### DIFF
--- a/data/apply-schema-update.sql
+++ b/data/apply-schema-update.sql
@@ -121,6 +121,16 @@ PERFORM add_column_if_not_exists('ne_10m_land', 'mz_label_placement', 'geometry(
 PERFORM add_column_if_not_exists('ne_50m_urban_areas', 'mz_label_placement', 'geometry(Geometry, 3857)');
 PERFORM add_column_if_not_exists('ne_10m_urban_areas', 'mz_label_placement', 'geometry(Geometry, 3857)');
 
+-- NOTE: the absence of:
+--
+--  * ne_10m_admin_0_countries
+--  * ne_10m_admin_0_map_units
+--  * ne_10m_admin_1_states_provinces
+--
+-- although we do import the _boundaries_ variants of some of these, we only use
+-- the polygon variants above to join on the wikidata ID, we don't draw or label
+-- them directly.
+
 END$$;
 
 DROP FUNCTION add_column_if_not_exists(text, text, text);

--- a/data/apply-updates-non-planet-tables.sql
+++ b/data/apply-updates-non-planet-tables.sql
@@ -187,3 +187,7 @@ CREATE INDEX ne_10m_land_way_area_index ON ne_10m_land(way_area);
 UPDATE land_polygons SET way_area=ST_Area(the_geom) WHERE the_geom IS NOT NULL;
 CREATE INDEX land_polygons_wayarea_index ON land_polygons(way_area);
 
+-- we look up min_label, max_label by wikidata ID.
+CREATE INDEX ne_10m_admin_0_countries_wikidata_index ON ne_10m_admin_0_countries(wikidataid);
+CREATE INDEX ne_10m_admin_0_map_units_wikidata_index ON ne_10m_admin_0_map_units(wikidataid);
+CREATE INDEX ne_10m_admin_1_states_provinces_wikidata_index ON ne_10m_admin_1_states_provinces(wikidataid);

--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
 bucket: tilezen-assets
-datestamp: 20180612
+datestamp: 20180614
 
 shapefiles:
 
@@ -129,3 +129,15 @@ shapefiles:
   - name: ne_10m_coastline
     url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/physical/ne_10m_coastline.zip
     prj: 43267
+
+  - name: ne_10m_admin_0_countries
+    url: https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_0_countries.zip
+    prj: 4326
+
+  - name: ne_10m_admin_0_map_units
+    url: https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_0_map_units.zip
+    prj: 4326
+
+  - name: ne_10m_admin_1_states_provinces
+    url: https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_1_states_provinces.zip
+    prj: 4326

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -700,7 +700,7 @@ DECLARE
   decimal_matches text[] :=
     regexp_matches(txt, '([0-9]+(\.[0-9]*)?) *(mi|km|m|nmi|ft)');
   imperial_matches text[] :=
-    regexp_matches(txt, E'([0-9]+(\\.[0-9]*)?)\' *(([0-9]+)")?');
+    regexp_matches(txt, E'([0-9]+(\\.[0-9]*)?)\x27 *(([0-9]+)")?');
   numeric_matches text[] :=
     regexp_matches(txt, '([0-9]+(\.[0-9]*)?)');
 BEGIN

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -980,3 +980,52 @@ BEGIN
   RETURN trim(leading 'SH' from label);
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- returns a JSONB object containing __ne_min_zoom and __ne_max_zoom set to the
+-- label min and max zoom of any matching row from the Natural Earth countries,
+-- map units and states/provinces themes.
+CREATE OR REPLACE FUNCTION tz_get_ne_min_max_zoom(wikidata_id TEXT)
+RETURNS JSONB AS $$
+DECLARE
+  min_zoom REAL;
+  max_zoom REAL;
+BEGIN
+  IF wikidata_id IS NULL THEN
+    RETURN '{}'::jsonb;
+  END IF;
+
+  -- first, try the countries table
+  SELECT
+    min_label, max_label INTO min_zoom, max_zoom
+    FROM ne_10m_admin_0_countries c
+    WHERE c.wikidataid = wikidata_id;
+
+  -- if that fails, try map_units (which contains some sub-country but super-
+  -- state level stuff such as England, Scotland and Wales).
+  IF NOT FOUND THEN
+    SELECT
+      min_label, max_label INTO min_zoom, max_zoom
+      FROM ne_10m_admin_0_map_units mu
+      WHERE mu.wikidataid = wikidata_id;
+  END IF;
+
+  -- finally, try states and provinces
+  IF NOT FOUND THEN
+    SELECT
+      min_label, max_label INTO min_zoom, max_zoom
+      FROM ne_10m_admin_1_states_provinces sp
+      WHERE sp.wikidataid = wikidata_id;
+  END IF;
+
+  -- return an empty JSONB rather than null, so that it can be safely
+  -- concatenated with whatever other JSONB rather than needing a check for
+  -- null.
+  IF NOT FOUND THEN
+    RETURN '{}'::jsonb;
+  END IF;
+  RETURN jsonb_build_object(
+    '__ne_min_zoom', min_zoom,
+    '__ne_max_zoom', max_zoom
+  );
+END
+$$ LANGUAGE plpgsql STABLE;

--- a/integration-test/837-no-country-label-low-zoom.py
+++ b/integration-test/837-no-country-label-low-zoom.py
@@ -9,5 +9,5 @@ class NoCountryLabelLowZoom(FixtureTest):
         self.assert_no_matching_feature(
             0, 0, 0, 'places', {'kind': 'country'})
 
-        self.assert_no_matching_feature(
-            1, 0, 0, 'places', {'kind': 'country'})
+        # see integration-test/977-min-zoom-from-ne-join.py -- we now get this
+        # information from joining on the Natural Earth countries table.

--- a/integration-test/977-min-zoom-from-ne-join.py
+++ b/integration-test/977-min-zoom-from-ne-join.py
@@ -117,3 +117,29 @@ class MinZoomFromAdminAreaBasedDefault(FixtureTest):
                 'min_zoom': 0,
                 'max_zoom': 16,
             })
+
+    def test_wales(self):
+        # wales is a country within the UK, but mapped as place=state.
+        # should get a fallback from the states_provinces spreadsheet.
+        import dsl
+
+        z, x, y = (10, 501, 336)
+
+        self.generate_fixtures(
+            dsl.is_in('GB', z, x, y),
+            # https://www.openstreetmap.org/node/2642288017
+            dsl.point(2642288017, (-3.73893, 52.2928116), {
+                'is_in': u'United Kingdom, Europe',
+                'name': u'Wales',
+                'note': u'geographical centre of Wales',
+                'place': u'state',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 2642288017,
+                'min_zoom': 10,
+                'max_zoom': 11,
+            })

--- a/integration-test/977-min-zoom-from-ne-join.py
+++ b/integration-test/977-min-zoom-from-ne-join.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from . import FixtureTest
+
+
+class MinZoomFromNETest(FixtureTest):
+
+    def setUp(self):
+        import dsl
+
+        super(MinZoomFromNETest, self).setUp()
+
+        self.lon, self.lat = (-3.2765753, 54.7023545)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/838090640
+            dsl.point(838090640, (self.lon, self.lat), {
+                'name': u'United Kingdom',
+                'place': u'country',
+                'population': u'61792000',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q145',
+                'wikipedia': u'de:United Kingdom',  # LOL, de:
+                # NOTE: these aren't in the data from OSM, but are joined at
+                # database query time from the Natural Earth data.
+                '__ne_min_zoom': 1.7,
+                '__ne_max_zoom': 6.7,
+            }),
+        )
+
+    def test_uk_should_show_up_zooms_1_to_6(self):
+        from tilequeue.tile import deg2num
+        # should show up in zooms within the range 1-6
+
+        for zoom in xrange(1, 6):
+            x, y = deg2num(self.lat, self.lon, zoom)
+            self.assert_has_feature(
+                zoom, x, y, 'places', {
+                    'id': 838090640,
+                    'min_zoom': 1.7,
+                    'max_zoom': 6.7,
+                })
+
+    def test_uk_should_not_show_up_zoom_0(self):
+        # shouldn't be in the zoom 0 tile because min_zoom >= 1
+        self.assert_no_matching_feature(
+            0, 0, 0, 'places', {'id': 838090640})
+
+    def test_uk_should_not_show_up_zoom_7(self):
+        # shouldn't be in the zoom 0 tile because max_zoom < 7
+        from tilequeue.tile import deg2num
+
+        zoom = 7
+        x, y = deg2num(self.lat, self.lon, zoom)
+        self.assert_no_matching_feature(
+            zoom, x, y, 'places', {'id': 838090640})

--- a/queries.yaml
+++ b/queries.yaml
@@ -567,6 +567,21 @@ post_process:
         - max_zoom
       where: kind == 'country'
 
+  - fn: vectordatasource.transform.point_in_country_logic
+    resources:
+      logic_table:
+        type: file
+        init_fn: vectordatasource.transform.YAMLToDict
+        path: spreadsheets/min_zoom/state_province.yaml
+    params:
+      layer: places
+      country_layer: admin_areas
+      country_code_attr: iso_code
+      output_attrs:
+        - min_zoom
+        - max_zoom
+      where: kind == 'region'
+
   # IMPORTANT! do this _after_ the YAMLToDict default stuff, otherwise the
   # default will overwrite the value fron Natural Earth.
   - fn: vectordatasource.transform.tags_set_ne_min_max_zoom

--- a/queries.yaml
+++ b/queries.yaml
@@ -183,6 +183,7 @@ layers:
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.tags_name_i18n
+      - vectordatasource.transform.tags_set_min_max_zoom
       - vectordatasource.transform.tags_remove
       - vectordatasource.transform.place_population_int
       - vectordatasource.transform.calculate_default_place_min_zoom
@@ -1053,3 +1054,7 @@ post_process:
         white: [255, 255, 255]
         yellow: [255, 255, 0]
         yellowgreen: [154, 205, 50]
+
+  - fn: vectordatasource.transform.max_zoom_filter
+    params:
+      layers: [places]

--- a/queries.yaml
+++ b/queries.yaml
@@ -183,7 +183,6 @@ layers:
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.tags_name_i18n
-      - vectordatasource.transform.tags_set_min_max_zoom
       - vectordatasource.transform.tags_remove
       - vectordatasource.transform.place_population_int
       - vectordatasource.transform.calculate_default_place_min_zoom
@@ -549,6 +548,30 @@ post_process:
         ZA: true # South Africa
         ZM: true # Zambia
         ZW: true # Zimbabwe
+
+  # cut places with admin_areas to put country_code attributes on country,
+  # state and province points. this is used to backfill information such as
+  # min and max zoom based on country defaults.
+  - fn: vectordatasource.transform.point_in_country_logic
+    resources:
+      logic_table:
+        type: file
+        init_fn: vectordatasource.transform.YAMLToDict
+        path: spreadsheets/min_zoom/country.yaml
+    params:
+      layer: places
+      country_layer: admin_areas
+      country_code_attr: iso_code
+      output_attrs:
+        - min_zoom
+        - max_zoom
+      where: kind == 'country'
+
+  # IMPORTANT! do this _after_ the YAMLToDict default stuff, otherwise the
+  # default will overwrite the value fron Natural Earth.
+  - fn: vectordatasource.transform.tags_set_ne_min_max_zoom
+    params:
+      layer: places
 
   - fn: vectordatasource.transform.overlap
     params:

--- a/queries/planet_osm_point.jinja2
+++ b/queries/planet_osm_point.jinja2
@@ -26,7 +26,8 @@ SELECT
   CASE WHEN mz_places_min_zoom IS NOT NULL
     THEN jsonb_build_object(
       'min_zoom', mz_places_min_zoom
-    )
+    ) ||
+      tz_get_ne_min_max_zoom(tags->'wikidata')
   END AS __places_properties__,
 
   CASE WHEN mz_poi_min_zoom IS NOT NULL

--- a/scripts/templates/node_test.jinja2
+++ b/scripts/templates/node_test.jinja2
@@ -1,0 +1,24 @@
+
+    def test_{{name}}(self):
+        import dsl
+
+        z, x, y = ({{z}}, {{x}}, {{y}})
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/{{node_id}}
+            dsl.point({{node_id}}, {{position}}, {
+        {%- for k, v in node_tags|dictsort %}
+                '{{k}}': u'{{v}}',
+        {%- endfor %}
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, '{{layer_name}}', {
+                'id': {{node_id}},
+        {%- if expect is not none %}
+        {%-   for k, v in expect|dictsort %}
+                '{{k}}': u'{{v}}',
+        {%-   endfor %}
+        {%- endif %}
+            })

--- a/spreadsheets/min_zoom/country.yaml
+++ b/spreadsheets/min_zoom/country.yaml
@@ -1,0 +1,949 @@
+---
+# Andorra
+AD:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# United Arab Emirates
+AE:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Afghanistan
+AF:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Antigua and Barb
+AG:
+  min_zoom:  5.0
+  max_zoom:  9.5
+# Anguilla
+AI:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Albania
+AL:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Armenia
+AM:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Angola
+AO:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Antarctica
+AQ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Argentina
+AR:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# American Samoa
+AS:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Austria
+AT:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Australia
+AU:
+  min_zoom:  1.7
+  max_zoom:  5.7
+# Aruba
+AW:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Åland
+AX:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Azerbaijan
+AZ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Bosnia and Herz
+BA:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Barbados
+BB:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Bangladesh
+BD:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Belgium
+BE:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Burkina Faso
+BF:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Bulgaria
+BG:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Bahrain
+BH:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Burundi
+BI:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Benin
+BJ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# St-Barthélemy
+BL:
+  min_zoom:  5.7
+  max_zoom: 10.0
+# Bermuda
+BM:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Brunei
+BN:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Bolivia
+BO:
+  min_zoom:  3.0
+  max_zoom:  7.5
+# Brazil
+BR:
+  min_zoom:  1.7
+  max_zoom:  5.7
+# Bahamas
+BS:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Bhutan
+BT:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Botswana
+BW:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Belarus
+BY:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Belize
+BZ:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Canada
+CA:
+  min_zoom:  1.7
+  max_zoom:  5.7
+# Dem. Rep. Congo
+CD:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Central African Rep
+CF:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Congo
+CG:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Switzerland
+CH:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Côte d'Ivoire
+CI:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Cook Is
+CK:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Chile
+CL:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Cameroon
+CM:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# China
+CN:
+  min_zoom:  1.7
+  max_zoom:  5.7
+# Colombia
+CO:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Costa Rica
+CR:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Cuba
+CU:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Cabo Verde
+CV:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Curaçao
+CW:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Cyprus
+CY:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Czechia
+CZ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Germany
+DE:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Djibouti
+DJ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Denmark
+DK:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Dominica
+DM:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Dominican Rep
+DO:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Algeria
+DZ:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Ecuador
+EC:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Estonia
+EE:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Egypt
+EG:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# W. Sahara
+EH:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# Eritrea
+ER:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Spain
+ES:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Ethiopia
+ET:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Finland
+FI:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Fiji
+FJ:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Falkland Is
+FK:
+  min_zoom:  4.5
+  max_zoom:  9.0
+# Micronesia
+FM:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Faeroe Is
+FO:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Gabon
+GA:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# United Kingdom
+GB:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Grenada
+GD:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Georgia
+GE:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Guernsey
+GG:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Ghana
+GH:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Gibraltar
+GI:
+  min_zoom:  5.0
+  max_zoom:  9.5
+# Greenland
+GL:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Gambia
+GM:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Guinea
+GN:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Eq. Guinea
+GQ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Greece
+GR:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# S. Geo. and the Is
+GS:
+  min_zoom:  5.0
+  max_zoom:  9.0
+# Guatemala
+GT:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Guam
+GU:
+  min_zoom:  3.0
+  max_zoom: 10.0
+# Guinea-Bissau
+GW:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Guyana
+GY:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Hong Kong
+HK:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Heard I. and McDonald Is
+HM:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Honduras
+HN:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Croatia
+HR:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Haiti
+HT:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Hungary
+HU:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Indonesia
+ID:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Ireland
+IE:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Israel
+IL:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Isle of Man
+IM:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# India
+IN:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Br. Indian Ocean Ter
+IO:
+  min_zoom:  5.0
+  max_zoom:  9.5
+# Iraq
+IQ:
+  min_zoom:  3.0
+  max_zoom:  7.5
+# Iran
+IR:
+  min_zoom:  2.5
+  max_zoom:  6.7
+# Iceland
+IS:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Italy
+IT:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Jersey
+JE:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Jamaica
+JM:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Jordan
+JO:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Japan
+JP:
+  min_zoom:  1.7
+  max_zoom:  7.0
+# Kenya
+KE:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Kyrgyzstan
+KG:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Cambodia
+KH:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Kiribati
+KI:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Comoros
+KM:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# St. Kitts and Nevis
+KN:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# North Korea
+KP:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# South Korea
+KR:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Kuwait
+KW:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Cayman Is
+KY:
+  min_zoom:  5.0
+  max_zoom:  9.5
+# Kazakhstan
+KZ:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Laos
+LA:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Lebanon
+LB:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Saint Lucia
+LC:
+  min_zoom:  5.0
+  max_zoom:  9.5
+# Liechtenstein
+LI:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Sri Lanka
+LK:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Liberia
+LR:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Lesotho
+LS:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Lithuania
+LT:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Luxembourg
+LU:
+  min_zoom:  5.7
+  max_zoom: 10.0
+# Latvia
+LV:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Libya
+LY:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Morocco
+MA:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Monaco
+MC:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Moldova
+MD:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Montenegro
+ME:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# St-Martin
+MF:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Madagascar
+MG:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Marshall Is
+MH:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Macedonia
+MK:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Mali
+ML:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Myanmar
+MM:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Mongolia
+MN:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Macao
+MO:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# N. Mariana Is
+MP:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Mauritania
+MR:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Montserrat
+MS:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Malta
+MT:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Mauritius
+MU:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Maldives
+MV:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Malawi
+MW:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Mexico
+MX:
+  min_zoom:  2.0
+  max_zoom:  6.7
+# Malaysia
+MY:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Mozambique
+MZ:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Namibia
+NA:
+  min_zoom:  3.0
+  max_zoom:  7.5
+# New Caledonia
+NC:
+  min_zoom:  4.6
+  max_zoom:  8.0
+# Niger
+NE:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Norfolk Island
+NF:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Nigeria
+NG:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Nicaragua
+NI:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Netherlands
+NL:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Nepal
+NP:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Nauru
+NR:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Niue
+NU:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# New Zealand
+NZ:
+  min_zoom:  2.0
+  max_zoom:  6.7
+# Oman
+OM:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Panama
+PA:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Peru
+PE:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Fr. Polynesia
+PF:
+  min_zoom:  3.5
+  max_zoom:  8.5
+# Papua New Guinea
+PG:
+  min_zoom:  2.5
+  max_zoom:  7.5
+# Philippines
+PH:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Pakistan
+PK:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Poland
+PL:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# St. Pierre and Miquelon
+PM:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Pitcairn Is
+PN:
+  min_zoom:  5.0
+  max_zoom:  9.0
+# Puerto Rico
+PR:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Palestine
+PS:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Portugal
+PT:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Palau
+PW:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Paraguay
+PY:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Qatar
+QA:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Romania
+RO:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Serbia
+RS:
+  min_zoom:  4.0
+  max_zoom:  7.0
+# Russia
+RU:
+  min_zoom:  1.7
+  max_zoom:  5.2
+# Rwanda
+RW:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Saudi Arabia
+SA:
+  min_zoom:  2.7
+  max_zoom:  7.0
+# Solomon Is
+SB:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Seychelles
+SC:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Sudan
+SD:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Sweden
+SE:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Singapore
+SG:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Saint Helena
+SH:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Slovenia
+SI:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Slovakia
+SK:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Sierra Leone
+SL:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# San Marino
+SM:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Senegal
+SN:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Somalia
+SO:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Suriname
+SR:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# S. Sudan
+SS:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# São Tomé and Principe
+ST:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# El Salvador
+SV:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Sint Maarten
+SX:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Syria
+SY:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# eSwatini
+SZ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Turks and Caicos Is
+TC:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Chad
+TD:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Fr. S. Antarctic Lands
+TF:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Togo
+TG:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Thailand
+TH:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Tajikistan
+TJ:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Timor-Leste
+TL:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Turkmenistan
+TM:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Tunisia
+TN:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Tonga
+TO:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Turkey
+TR:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Trinidad and Tobago
+TT:
+  min_zoom:  4.5
+  max_zoom:  9.5
+# Tuvalu
+TV:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Taiwan
+TW:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Tanzania
+TZ:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Ukraine
+UA:
+  min_zoom:  3.0
+  max_zoom:  7.0
+# Uganda
+UG:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# U.S. Minor Outlying Is
+UM:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# United States of America
+US:
+  min_zoom:  1.7
+  max_zoom:  5.7
+# Uruguay
+UY:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Uzbekistan
+UZ:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Vatican
+VA:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# St. Vin. and Gren
+VC:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Venezuela
+VE:
+  min_zoom:  3.0
+  max_zoom:  7.5
+# British Virgin Is
+VG:
+  min_zoom:  5.0
+  max_zoom:  9.5
+# U.S. Virgin Is
+VI:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Vietnam
+VN:
+  min_zoom:  2.0
+  max_zoom:  7.0
+# Vanuatu
+VU:
+  min_zoom:  4.0
+  max_zoom:  9.0
+# Wallis and Futuna Is
+WF:
+  min_zoom:  4.7
+  max_zoom:  9.0
+# Samoa
+WS:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Kosovo
+XK:
+  min_zoom:  5.0
+  max_zoom: 10.0
+# Yemen
+YE:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# South Africa
+ZA:
+  min_zoom:  1.7
+  max_zoom:  6.7
+# Zambia
+ZM:
+  min_zoom:  3.0
+  max_zoom:  8.0
+# Zimbabwe
+ZW:
+  min_zoom:  3.0
+  max_zoom:  8.0

--- a/spreadsheets/min_zoom/state_province.yaml
+++ b/spreadsheets/min_zoom/state_province.yaml
@@ -1,0 +1,949 @@
+---
+# Andorra
+AD:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# United Arab Emirates
+AE:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Afghanistan
+AF:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Antigua and Barb
+AG:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Anguilla
+AI:
+  min_zoom: 11.5
+  max_zoom: 11.5
+# Albania
+AL:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Armenia
+AM:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Angola
+AO:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Antarctica
+AQ:
+  min_zoom: 14.5
+  max_zoom: 14.5
+# Argentina
+AR:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# American Samoa
+AS:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Austria
+AT:
+  min_zoom:  7.8
+  max_zoom: 11.0
+# Australia
+AU:
+  min_zoom:  4.6
+  max_zoom:  8.1
+# Aruba
+AW:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Åland
+AX:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Azerbaijan
+AZ:
+  min_zoom:  9.2
+  max_zoom: 11.0
+# Bosnia and Herz
+BA:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Barbados
+BB:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Bangladesh
+BD:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Belgium
+BE:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Burkina Faso
+BF:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Bulgaria
+BG:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Bahrain
+BH:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Burundi
+BI:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Benin
+BJ:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# St-Barthélemy
+BL:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Bermuda
+BM:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Brunei
+BN:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Bolivia
+BO:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Brazil
+BR:
+  min_zoom:  3.7
+  max_zoom:  8.5
+# Bahamas
+BS:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Bhutan
+BT:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Botswana
+BW:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# Belarus
+BY:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Belize
+BZ:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Canada
+CA:
+  min_zoom:  3.5
+  max_zoom:  7.5
+# Dem. Rep. Congo
+CD:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# Central African Rep
+CF:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Congo
+CG:
+  min_zoom:  7.6
+  max_zoom: 11.0
+# Switzerland
+CH:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Côte d'Ivoire
+CI:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Cook Is
+CK:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Chile
+CL:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# Cameroon
+CM:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# China
+CN:
+  min_zoom:  5.0
+  max_zoom: 10.3
+# Colombia
+CO:
+  min_zoom:  7.0
+  max_zoom: 11.2
+# Costa Rica
+CR:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Cuba
+CU:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Cabo Verde
+CV:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Curaçao
+CW:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Cyprus
+CY:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Czechia
+CZ:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Germany
+DE:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Djibouti
+DJ:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Denmark
+DK:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Dominica
+DM:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Dominican Rep
+DO:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Algeria
+DZ:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Ecuador
+EC:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Estonia
+EE:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Egypt
+EG:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# W. Sahara
+EH:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Eritrea
+ER:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Spain
+ES:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Ethiopia
+ET:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Finland
+FI:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Fiji
+FJ:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Falkland Is
+FK:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Micronesia
+FM:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Faeroe Is
+FO:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Gabon
+GA:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# United Kingdom
+GB:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Grenada
+GD:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Georgia
+GE:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Guernsey
+GG:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Ghana
+GH:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Gibraltar
+GI:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Greenland
+GL:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Gambia
+GM:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Guinea
+GN:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Eq. Guinea
+GQ:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Greece
+GR:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# S. Geo. and the Is
+GS:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Guatemala
+GT:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Guam
+GU:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Guinea-Bissau
+GW:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Guyana
+GY:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Hong Kong
+HK:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Heard I. and McDonald Is
+HM:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Honduras
+HN:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Croatia
+HR:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Haiti
+HT:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Hungary
+HU:
+  min_zoom:  8.5
+  max_zoom: 11.0
+# Indonesia
+ID:
+  min_zoom:  5.0
+  max_zoom: 10.1
+# Ireland
+IE:
+  min_zoom:  8.2
+  max_zoom: 11.0
+# Israel
+IL:
+  min_zoom:  8.4
+  max_zoom: 11.0
+# Isle of Man
+IM:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# India
+IN:
+  min_zoom:  4.6
+  max_zoom: 10.1
+# Br. Indian Ocean Ter
+IO:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Iraq
+IQ:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Iran
+IR:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Iceland
+IS:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# Italy
+IT:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Jersey
+JE:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Jamaica
+JM:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Jordan
+JO:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Japan
+JP:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Kenya
+KE:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Kyrgyzstan
+KG:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Cambodia
+KH:
+  min_zoom:  8.1
+  max_zoom: 11.0
+# Kiribati
+KI:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Comoros
+KM:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# St. Kitts and Nevis
+KN:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# North Korea
+KP:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# South Korea
+KR:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Kuwait
+KW:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Cayman Is
+KY:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Kazakhstan
+KZ:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# Laos
+LA:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Lebanon
+LB:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Saint Lucia
+LC:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Liechtenstein
+LI:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Sri Lanka
+LK:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Liberia
+LR:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Lesotho
+LS:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Lithuania
+LT:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Luxembourg
+LU:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Latvia
+LV:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Libya
+LY:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Morocco
+MA:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Monaco
+MC:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Moldova
+MD:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Montenegro
+ME:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# St-Martin
+MF:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Madagascar
+MG:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Marshall Is
+MH:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Macedonia
+MK:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Mali
+ML:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Myanmar
+MM:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Mongolia
+MN:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# Macao
+MO:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# N. Mariana Is
+MP:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Mauritania
+MR:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Montserrat
+MS:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Malta
+MT:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Mauritius
+MU:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Maldives
+MV:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Malawi
+MW:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Mexico
+MX:
+  min_zoom:  6.9
+  max_zoom: 11.2
+# Malaysia
+MY:
+  min_zoom:  7.2
+  max_zoom: 11.0
+# Mozambique
+MZ:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Namibia
+NA:
+  min_zoom:  6.0
+  max_zoom: 11.0
+# New Caledonia
+NC:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Niger
+NE:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Norfolk Island
+NF:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Nigeria
+NG:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Nicaragua
+NI:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Netherlands
+NL:
+  min_zoom:  8.6
+  max_zoom: 11.0
+# Nepal
+NP:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Nauru
+NR:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Niue
+NU:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# New Zealand
+NZ:
+  min_zoom:  8.5
+  max_zoom: 11.3
+# Oman
+OM:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Panama
+PA:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Peru
+PE:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Fr. Polynesia
+PF:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Papua New Guinea
+PG:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Philippines
+PH:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Pakistan
+PK:
+  min_zoom:  5.0
+  max_zoom: 10.5
+# Poland
+PL:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# St. Pierre and Miquelon
+PM:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Pitcairn Is
+PN:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Puerto Rico
+PR:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Palestine
+PS:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Portugal
+PT:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Palau
+PW:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Paraguay
+PY:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Qatar
+QA:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Romania
+RO:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Serbia
+RS:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Russia
+RU:
+  min_zoom:  5.0
+  max_zoom: 10.2
+# Rwanda
+RW:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Saudi Arabia
+SA:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Solomon Is
+SB:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Seychelles
+SC:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Sudan
+SD:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Sweden
+SE:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Singapore
+SG:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Saint Helena
+SH:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Slovenia
+SI:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Slovakia
+SK:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Sierra Leone
+SL:
+  min_zoom:  7.8
+  max_zoom: 11.0
+# San Marino
+SM:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Senegal
+SN:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Somalia
+SO:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Suriname
+SR:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# S. Sudan
+SS:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# São Tomé and Principe
+ST:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# El Salvador
+SV:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Sint Maarten
+SX:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Syria
+SY:
+  min_zoom:  7.7
+  max_zoom: 11.5
+# eSwatini
+SZ:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Turks and Caicos Is
+TC:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Chad
+TD:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Fr. S. Antarctic Lands
+TF:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Togo
+TG:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Thailand
+TH:
+  min_zoom:  8.2
+  max_zoom: 11.0
+# Tajikistan
+TJ:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Timor-Leste
+TL:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Turkmenistan
+TM:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Tunisia
+TN:
+  min_zoom:  7.7
+  max_zoom: 11.0
+# Tonga
+TO:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Turkey
+TR:
+  min_zoom:  7.0
+  max_zoom: 11.0
+# Trinidad and Tobago
+TT:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Tuvalu
+TV:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# Taiwan
+TW:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# Tanzania
+TZ:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Ukraine
+UA:
+  min_zoom:  6.7
+  max_zoom: 11.0
+# Uganda
+UG:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# U.S. Minor Outlying Is
+UM:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# United States of America
+US:
+  min_zoom:  3.5
+  max_zoom:  7.5
+# Uruguay
+UY:
+  min_zoom:  8.0
+  max_zoom: 11.0
+# Uzbekistan
+UZ:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Vatican
+VA:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# St. Vin. and Gren
+VC:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Venezuela
+VE:
+  min_zoom:  7.1
+  max_zoom: 11.3
+# British Virgin Is
+VG:
+  min_zoom: 18.0
+  max_zoom: 18.0
+# U.S. Virgin Is
+VI:
+  min_zoom: 11.0
+  max_zoom: 11.0
+# Vietnam
+VN:
+  min_zoom:  8.3
+  max_zoom: 11.0
+# Vanuatu
+VU:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Wallis and Futuna Is
+WF:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Samoa
+WS:
+  min_zoom:  9.0
+  max_zoom: 11.0
+# Kosovo
+XK:
+  min_zoom: 10.0
+  max_zoom: 11.0
+# Yemen
+YE:
+  min_zoom:  8.7
+  max_zoom: 11.0
+# South Africa
+ZA:
+  min_zoom:  4.6
+  max_zoom: 10.1
+# Zambia
+ZM:
+  min_zoom:  6.6
+  max_zoom: 11.0
+# Zimbabwe
+ZW:
+  min_zoom:  6.7
+  max_zoom: 11.0

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -47,20 +47,29 @@ filters:
     table: wof
     extra_columns: [ min_zoom ]
   - filter: {name: true, place: country}
-    min_zoom: 2
+    # note: min_zoom needs to be smaller than any min_label in
+    # ne_10m_admin_0_countries to make sure we're not dropping any by not being
+    # included in the PostgreSQL index.
+    min_zoom: 1
     output:
       <<: *output_properties
       kind: country
     table: osm
   - filter: {name: true, place: state}
-    min_zoom: 4
+    # note: min_zoom needs to be smaller than any min_label in
+    # ne_10m_admin_1_states_provinces to make sure we're not dropping any by
+    # not being included in the PostgreSQL index.
+    min_zoom: 3
     output:
       <<: *output_properties
       kind: region
       kind_detail: state
     table: osm
   - filter: {name: true, place: province}
-    min_zoom: 4
+    # note: min_zoom needs to be smaller than any min_label in
+    # ne_10m_admin_1_states_provinces to make sure we're not dropping any by
+    # not being included in the PostgreSQL index.
+    min_zoom: 3
     output:
       <<: *output_properties
       kind: region

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -54,6 +54,8 @@ filters:
     output:
       <<: *output_properties
       kind: country
+      __ne_min_zoom: {col: __ne_min_zoom}
+      __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
   - filter: {name: true, place: state}
     # note: min_zoom needs to be smaller than any min_label in
@@ -64,6 +66,8 @@ filters:
       <<: *output_properties
       kind: region
       kind_detail: state
+      __ne_min_zoom: {col: __ne_min_zoom}
+      __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
   - filter: {name: true, place: province}
     # note: min_zoom needs to be smaller than any min_label in
@@ -74,6 +78,8 @@ filters:
       <<: *output_properties
       kind: region
       kind_detail: province
+      __ne_min_zoom: {col: __ne_min_zoom}
+      __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
   - filter: {name: true, population: true, place: [city, town]}
     min_zoom: 8


### PR DESCRIPTION
Join countries and regions in the `places` layer to Natural Earth using common `wikidata` IDs in order to get the `min_label` and `max_label` properties from the Natural Earth features and use them in the output. Where that's not available, fall back to country-specific defaults in the new files under `spreadsheets/min_zoom/*.yaml`. Although they're YAML files, they felt more like spreadsheets in the sense that they're static data tables rather than sets of rules.

Connects to #977.
