### PR TITLE
Strip country_code from roads.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1070,8 +1070,6 @@ Road names are **abbreviated** so directionals like `North` is replaced with `N`
 
 Tilezen calculates the `landuse_kind` value by intercutting `roads` with the `landuse` layer to determine if a road segment is over a parks, hospitals, universities or other landuse features. Use this property to modify the visual appearance of roads over these features. For instance, light grey minor roads look great in general, but aren't legible over most landuse colors unless they are darkened.
 
-Tilezen also calculates an ISO 3166-1 alpha2 `country_code` value by working out which country a `roads` layer feature is in, using [Valhalla's](https://github.com/valhalla/valhalla/) [administrative areas](https://github.com/valhalla/valhalla/blob/master/docs/mjolnir/admins.md). If we can't tell that a road segment is unambiguously in a country, then the `country_code` parameter is omitted.
-
 To improve performance, some road segments are merged at low and mid-zooms. To facilitate this, certain properties are dropped at those zooms. Examples include `is_bridge` and `is_tunnel`, `name`, `network`, `oneway`, and `ref`. The exact zoom varies per feature class (major roads keep this properties over a wider range, minor roads drop them starting at zoom 14). When roads are merged, the original OSM `id` values are dropped.
 
 #### Road properties (common):
@@ -1120,7 +1118,6 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `bus_network`: Note that this is often not present for bus routes / networks. This may be replaced with `operator` in the future, see [issue 1194](https://github.com/tilezen/vector-datasource/issues/1194).
 * `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus or trolley-bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
 * `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`. `cobblestone:flattened`, `concrete:plates` and `concrete:lanes` values are transformed to `cobblestone_flattened`, `concrete_plates` and `concrete_lanes` respectively.
-* `country_code`: The ISO 3166-1 alpha2 code for the country that the road is in, if we can tell. Note that this means that this property is _optional_, and you should not assume that it is always present.
 
 #### Road properties (optional):
 

--- a/integration-test/135-add-country-codes-on-roads.py
+++ b/integration-test/135-add-country-codes-on-roads.py
@@ -12,9 +12,7 @@ class AddCountryCodesToRoads(FixtureTest):
         # get geometry into the pipeline. in real usage, the admin_area comes
         # from a static shapefile.
         self.generate_fixtures(
-            dsl.way(1, dsl.tile_box(z, x, y),
-                    {'kind': 'admin_area', 'iso_code': 'GB',
-                     'source': 'openstreetmap.org'}),
+            dsl.is_in('GB', z, x, y),
             dsl.way(2, dsl.tile_diagonal(z, x, y),
                     {'highway': 'motorway', 'ref': 'M4',
                      'source': 'openstreetmap.org'}),
@@ -24,11 +22,12 @@ class AddCountryCodesToRoads(FixtureTest):
         with self.layers_in_tile(z, x, y) as layers:
             self.assertNotIn('admin_areas', layers)
 
-        # but should have used it to add a "country_code" parameter to the
-        # road.
+        # the country_code will have been used internally to generate a
+        # "country_code" property, but (as per #1534) it should be stripped out
+        # before the tile is output.
         self.assert_has_feature(
             z, x, y, 'roads',
-            {'id': 2, 'country_code': 'GB', 'network': 'GB:M-road'})
+            {'id': 2, 'country_code': type(None), 'network': 'GB:M-road'})
 
     # the backfill national network in the UK should still be more important
     # than the EU "e-road" desigation, as that isn't signed.

--- a/integration-test/1534-strip-road-country-code.py
+++ b/integration-test/1534-strip-road-country-code.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class StripRoadCountryCodeTest(FixtureTest):
+
+    def test_strip_country_code(self):
+        import dsl
+
+        z, x, y = (16, 32211, 20777)
+
+        self.generate_fixtures(
+            dsl.is_in('GB', z, x, y),
+            # https://www.openstreetmap.org/way/31862058
+            dsl.way(31862058, dsl.tile_diagonal(z, x, y), {
+                'highway': u'trunk',
+                'lanes': u'2',
+                'lit': u'no',
+                'maxspeed': u'60 mph',
+                'maxspeed:type': u'GB:nsl_single',
+                'ref': u'A595',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 31862058,
+                'shield_text': 'A595',
+                'network': 'GB:A-road-green',
+                'country_code': type(None),
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -463,6 +463,14 @@ post_process:
     params:
       layer: roads
 
+  # having calculated the country_code on roads, now drop it. we don't want it
+  # in the output (and it's already part of the `network`, if any got added to
+  # the feature.)
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      properties: [country_code]
+
   - fn: vectordatasource.transform.point_in_country_logic
     params:
       layer: pois


### PR DESCRIPTION
We use this internally to provide country-specific logic for interpreting road `ref` and `network` tags. However, it's wasteful to include it on all road features, especially given that it's included as a prefix of any `network` properties that we output.

Connects to #1534.