### PR TITLE
More kinds for maki icon library support

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -891,7 +891,8 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `golf` - Shop selling golf equipment.
 * `golf_course`
 * `government`
-* `greengrocer`
+* `greengrocer` - Shop selling fruits and vegetables.
+* `grocery` - Shop selling non-perishable foods.
 * `group_home`
 * `guest_house`
 * `hairdresser`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -526,7 +526,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `groyne`
 * `guard_rail`
 * `hanami`
-* `harbor` (a.k.a harbour)
+* `harbour`
 * `hospital`
 * `industrial`
 * `kerb`
@@ -762,6 +762,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `accountant`
 * `adit`
 * `administrative`
+* `adult_gaming_centre`
 * `advertising_agency`
 * `aerodrome`
 * `aeroway_gate`
@@ -890,7 +891,6 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `fuel` - Fuel stations provide liquid gas (or diesel) for automotive use.
 * `furniture`
 * `gallery` - An art gallery.
-* `gaming`
 * `garden` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `gardener`
 * `garden_centre`
@@ -903,7 +903,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `golf_course`
 * `government`
 * `greengrocer` - Shop selling fruits and vegetables.
-* `grocery` - Shop selling non-perishable foods.
+* `grocery` - Shop selling non-perishable food often similar to, but smaller than, a `supermarket`. See also [grocery store on Wikipedia](https://en.wikipedia.org/wiki/Grocery_store).
 * `group_home`
 * `guest_house`
 * `hairdresser`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -879,6 +879,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `fuel` - Fuel stations provide liquid gas (or diesel) for automotive use.
 * `furniture`
 * `gallery` - An art gallery.
+* `gaming`
 * `garden` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `gardener`
 * `gas_canister` - Shop selling bottled gas for cooking. Some offer gas canister refills.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -888,6 +888,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `generator`
 * `geyser`
 * `gift`
+* `golf` - Shop selling golf equipment.
 * `golf_course`
 * `government`
 * `greengrocer`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -882,6 +882,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `gaming`
 * `garden` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `gardener`
+* `garden_centre`
 * `gas_canister` - Shop selling bottled gas for cooking. Some offer gas canister refills.
 * `gate` - with `kind_detail` one of `chain`, `gate`, `kissing_gate`, `lift_gate`, `stile`, `swing_gate`.
 * `generator`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -498,6 +498,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `college`
 * `commercial`
 * `common`
+* `container_terminal`
 * `crane`
 * `cutline`
 * `danger` - e.g: military training zones, firing ranges.
@@ -510,6 +511,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `farmland`
 * `farmyard`
 * `fence` - if present, `kind_detail` one of `avalanche`, `barbed_wire`, `bars`, `brick`, `chain`, `chain_link`, `concrete`, `drystone_wall`, `electric`, `grate`, `hedge`, `metal`, `metal_bars`, `net`, `pole`, `railing`, `railings`, `split_rail`, `steel`, `stone`, `wall`, `wire`, `wood`.
+* `ferry_terminal`
 * `footway`
 * `forest`
 * `fort`
@@ -524,6 +526,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `groyne`
 * `guard_rail`
 * `hanami`
+* `harbor` (a.k.a harbour)
 * `hospital`
 * `industrial`
 * `kerb`
@@ -537,6 +540,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `natural_forest` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
 * `natural_park` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
 * `natural_wood` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
+* `naval_base`
 * `park`
 * `parking`
 * `pedestrian`
@@ -547,11 +551,13 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `place_of_worship`
 * `plant`
 * `playground`
+* `port_terminal`
 * `power_line`
 * `power_minor_line`
 * `prison`
 * `protected_area`
 * `quarry`
+* `quay`
 * `railway`
 * `recreation_ground`
 * `recreation_track`
@@ -568,6 +574,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `scree`
 * `scrub`
 * `service_area`
+* `shipyard`
 * `snow_fence`
 * `sports_centre`
 * `stadium`
@@ -589,6 +596,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `water_slide`
 * `water_works`
 * `wetland`
+* `wharf`
 * `wilderness_hut`
 * `wildlife_park`
 * `winery`
@@ -794,6 +802,8 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `boat_rental`
 * `boat_storage`
 * `bollard`
+* `boatyard`
+* `boat_lift`
 * `books`
 * `brewery`
 * `bus_station`
@@ -833,6 +843,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `courthouse`
 * `crane`
 * `cross`
+* `customs` - A place where border control is carried out, which may involve [customs taxes](https://en.wikipedia.org/wiki/Customs_(tax)).
 * `cycle_barrier` - Barrier for bicycles.
 * `dairy_kitchen`
 * `danger` - e.g: military training zones, firing ranges.
@@ -1015,6 +1026,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `scuba_diving`
 * `service_area`
 * `shelter`
+* `ship_chandler`
 * `shoemaker`
 * `shoes`
 * `shower`

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1335,3 +1335,50 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'id': 41979263,
                 'kind': u'gaming',
             })
+
+    def test_garden_centre_node(self):
+        import dsl
+
+        z, x, y = (16, 19293, 24649)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1378081014
+            dsl.point(1378081014, (-74.015906, 40.675089), {
+                'name': u'Chelsea Garden Center Red Hook',
+                'shop': u'garden_centre',
+                'source': u'openstreetmap.org',
+                'website': u'http://www.chelseagardencenter.com/',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1378081014,
+                'kind': u'garden_centre',
+            })
+
+    def test_garden_centre_way(self):
+        import dsl
+
+        z, x, y = (16, 19303, 24648)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/265733658
+            dsl.way(265733658, dsl.tile_box(z, x, y), {
+                'addr:housenumber': u'784',
+                'addr:postcode': u'11238',
+                'addr:street': u'Dean Street',
+                'building': u'yes',
+                'height': u'4.7',
+                'name': u'Natty Garden',
+                'nycdoitt:bin': u'3027945',
+                'shop': u'garden_centre',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 265733658,
+                'kind': u'garden_centre',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1435,3 +1435,60 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'id': 398700987,
                 'kind': u'golf',
             })
+
+    def test_grocery_node(self):
+        import dsl
+
+        z, x, y = (16, 19298, 24628)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2709906342
+            dsl.point(2709906342, (-73.990564, 40.761580), {
+                'addr:city': u'New York',
+                'addr:housenumber': u'681',
+                'addr:postcode': u'10036',
+                'addr:state': u'NY',
+                'addr:street': u'9th Avenue',
+                'name': u'New York Food Market',
+                'phone': u'+1 212 2456470',
+                'shop': u'grocery',
+                'source': u'openstreetmap.org',
+                'website': u'http://newyorkfoodmarket.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2709906342,
+                'kind': u'grocery',
+            })
+
+    def test_grocery_way(self):
+        import dsl
+
+        z, x, y = (16, 19285, 24634)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/409910669
+            dsl.way(409910669, dsl.tile_box(z, x, y), {
+                'addr:city': u'Jersey City',
+                'addr:housenumber': u'2975',
+                'addr:postcode': u'07306',
+                'addr:state': u'NJ',
+                'addr:street': u'John F. Kennedy Boulevard',
+                'building': u'yes',
+                'building:levels': u'1',
+                'name': u'Apna Bazar Cash & Carry',
+                'opening_hours': u'Mo-Su 09:00-21:00',
+                'phone': u'+1 201 217 9701',
+                'shop': u'grocery',
+                'source': u'openstreetmap.org',
+                'website': u'http://www.apnabazarcashandcarry.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 409910669,
+                'kind': u'grocery',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1492,3 +1492,437 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'id': 409910669,
                 'kind': u'grocery',
             })
+
+    def test_harbor_natural_water_way(self):
+        import dsl
+
+        z, x, y = (16, 19002, 25265)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/310557860
+            dsl.way(310557860, dsl.tile_box(z, x, y), {
+                'harbour': u'yes',
+                'natural': u'water',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 310557860,
+                'kind': u'harbor',
+            })
+
+    def test_harbor_pier_way(self):
+        import dsl
+
+        z, x, y = (16, 25307, 36837)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/183049783
+            dsl.way(183049783, dsl.tile_box(z, x, y), {
+                'harbour': u'yes',
+                'man_made': u'pier',
+                'name': u'Porto do Açu',
+                'operator': u'LLX',
+                'seamark:harbour:category': u'tanker;bulk',
+                'seamark:type': u'harbour',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 183049783,
+                # should be 'kind': u'harbor',?
+                'kind': 'pier',
+            })
+
+    def test_harbor_way(self):
+        import dsl
+
+        z, x, y = (16, 38891, 25976)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/515527428
+            dsl.way(515527428, dsl.tile_box(z, x, y), {
+                'addr:city': u'Larnaka',
+                'harbour': u'yes',
+                'name': u'Larnaka harbour',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 515527428,
+                'kind': u'harbor',
+            })
+
+    def test_harbor_landuse_harbour_way(self):
+        import dsl
+
+        z, x, y = (16, 35014, 25282)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/422833298
+            dsl.way(422833298, dsl.tile_box(z, x, y), {
+                'harbour': u'yes',
+                'landuse': u'harbour',
+                'name': u'Cala Dogana',
+                'natural': u'bay',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 422833298,
+                'kind': u'harbor',
+            })
+
+    def test_harbor_landuse_port_way(self):
+        import dsl
+
+        z, x, y = (16, 31231, 20846)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/143517784
+            dsl.way(143517784, dsl.tile_box(z, x, y), {
+                'harbour': u'yes',
+                'landuse': u'port',
+                'maxdraft': u'12',
+                'maxlength': u'300',
+                'operator': u'Port Authority of Killybegs',
+                'phone': u'00353 (0)74 9731032',
+                'seamark:type': u'harbour',
+                'source': u'openstreetmap.org',
+                'vhf_channel': u'14',
+                'website': u'http://www.killybegsharbour.ie/',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 143517784,
+                'kind': u'harbor',
+            })
+
+    def test_port_terminal_way(self):
+        import dsl
+
+        z, x, y = (16, 22575, 37950)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/256125920
+            dsl.way(256125920, dsl.tile_box(z, x, y), {
+                'harbour': u'yes',
+                'landuse': u'port_terminal',
+                'man_made': u'pier',
+                'name': u'Nuevo puerto de Posadas',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 256125920,
+                # TODO: should be 'kind': u'port_terminal',?
+                'kind': 'pier',
+            })
+
+    def test_ferry_terminal_way(self):
+        import dsl
+
+        z, x, y = (16, 31640, 21243)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/55873793
+            dsl.way(55873793, dsl.tile_box(z, x, y), {
+                'access': u'customers',
+                'landuse': u'ferry_terminal',
+                'name': u'Terminal 1',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 55873793,
+                'kind': u'ferry_terminal',
+            })
+
+    def test_container_terminal_way(self):
+        import dsl
+
+        z, x, y = (16, 18282, 31129)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/330811048
+            dsl.way(330811048, dsl.tile_box(z, x, y), {
+                'landuse': u'container_terminal',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 330811048,
+                'kind': u'container_terminal',
+            })
+
+    def test_shipyard_way(self):
+        import dsl
+
+        z, x, y = (16, 29593, 30065)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/398258882
+            dsl.way(398258882, dsl.tile_box(z, x, y), {
+                'landuse': u'shipyard',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 398258882,
+                'kind': u'shipyard',
+            })
+
+    def test_wharf_way(self):
+        import dsl
+
+        z, x, y = (16, 21272, 23202)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/184311022
+            dsl.way(184311022, dsl.tile_box(z, x, y), {
+                'landuse': u'wharf',
+                'name': u'Covehead Wharf',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 184311022,
+                'kind': u'wharf',
+            })
+
+    def test_quay_way(self):
+        import dsl
+
+        z, x, y = (16, 29533, 27314)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/45061639
+            dsl.way(45061639, dsl.tile_box(z, x, y), {
+                'area': u'yes',
+                'landuse': u'quay',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 45061639,
+                'kind': u'quay',
+            })
+
+    def test_naval_base_way(self):
+        import dsl
+
+        z, x, y = (16, 19134, 25058)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/28501295
+            dsl.way(28501295, dsl.tile_box(z, x, y), {
+                'landuse': u'military',
+                'military': u'naval_base',
+                'name': u'United States Coast Guard Training Center',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 28501295,
+                'kind': u'naval_base',
+            })
+
+    def test_boatyard_way(self):
+        import dsl
+
+        z, x, y = (16, 19327, 24653)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/527031661
+            dsl.way(527031661, dsl.tile_box(z, x, y), {
+                'access': u'private',
+                'name': u'Rockman\'s Park Memorial Boat Club',
+                'source': u'openstreetmap.org',
+                'waterway': u'boatyard',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 527031661,
+                'kind': u'boatyard',
+            })
+
+    def test_boatyard_node(self):
+        import dsl
+
+        z, x, y = (16, 19327, 24654)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5082841810
+            dsl.point(5082841810, (-73.830727, 40.654999), {
+                'source': u'openstreetmap.org',
+                'waterway': u'boatyard',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5082841810,
+                'kind': u'boatyard',
+            })
+
+    def test_boat_lift_node(self):
+        import dsl
+
+        z, x, y = (16, 18169, 24135)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2426819553
+            dsl.point(2426819553, (-80.193664, 42.782552), {
+                'man_made': u'crane',
+                'name': u'Travel Lift',
+                'source': u'openstreetmap.org',
+                'waterway': u'boat_lift',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2426819553,
+                'kind': u'boat_lift',
+            })
+
+    def test_boat_lift_way(self):
+        import dsl
+
+        z, x, y = (16, 18828, 24981)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/170211248
+            dsl.way(170211248, dsl.tile_box(z, x, y), {
+                'source': u'openstreetmap.org',
+                'waterway': u'boat_lift',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 170211248,
+                'kind': u'boat_lift',
+            })
+
+    def test_ship_chandler_way(self):
+        import dsl
+
+        z, x, y = (16, 33481, 21751)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/276059237
+            dsl.way(276059237, dsl.tile_box(z, x, y), {
+                'building': u'retail',
+                'name': u'T.D. Bouwman & zn. BV',
+                'ref:bag': u'1676100000449055',
+                'seamark:small_craft_facility:category': u'chandler',
+                'seamark:type': u'small_craft_facility',
+                'shop': u'ship_chandler',
+                'source': u'openstreetmap.org',
+                'source:date': u'2014-02-11',
+                'start_date': u'1800',
+                'website': u'http://www.tdbouwman.nl/',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 276059237,
+                'kind': u'ship_chandler',
+            })
+
+    def test_ship_chandler_node(self):
+        import dsl
+
+        z, x, y = (16, 33480, 21752)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2806599446
+            dsl.point(2806599446, (3.914906, 51.642764), {
+                'addr:city': u'Zierikzee',
+                'addr:housenumber': u'17',
+                'addr:postcode': u'4301RC',
+                'addr:street': u'Deltastraat',
+                'name': u'Mulder Yachtservice',
+                'seamark:small_craft_facility:category': u'boatyard;chandler',
+                'seamark:type': u'small_craft_facility',
+                'shop': u'ship_chandler',
+                'source': u'openstreetmap.org',
+                'source:date': u'2014-02-11',
+                'website': u'http://www.mulderyachtservice.nl/',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2806599446,
+                'kind': u'ship_chandler',
+            })
+
+    def test_customs_node(self):
+        import dsl
+
+        z, x, y = (16, 18868, 23795)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/529165668
+            dsl.point(529165668, (-76.354747, 44.136012), {
+                'amenity': u'customs',
+                'attribution': u'Natural Resources Canada',
+                'canvec:CODE': u'2010100',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 529165668,
+                'kind': u'customs',
+            })
+
+    def test_customs_way(self):
+        import dsl
+
+        z, x, y = (16, 18990, 23680)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/206943159
+            dsl.way(206943159, dsl.tile_box(z, x, y), {
+                'amenity': u'customs',
+                'building': u'yes',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 206943159,
+                'kind': u'customs',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1688,6 +1688,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
             z, x, y, 'landuse', {
                 'id': 398258882,
                 'kind': u'shipyard',
+                'min_zoom': 15,
             })
 
     def test_wharf_way(self):
@@ -1708,6 +1709,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
             z, x, y, 'landuse', {
                 'id': 184311022,
                 'kind': u'wharf',
+                'min_zoom': 16,
             })
 
     def test_quay_way(self):
@@ -1728,6 +1730,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
             z, x, y, 'landuse', {
                 'id': 45061639,
                 'kind': u'quay',
+                'min_zoom': 16,
             })
 
     def test_naval_base_way(self):

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1283,3 +1283,55 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'kind': u'exit',
                 'kind_detail': u'fire_exit',
             })
+
+    def test_gaming_node(self):
+        import dsl
+
+        z, x, y = (16, 19077, 24822)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2100740221
+            dsl.point(2100740221, (-75.203507, 39.951631), {
+                'addr:city': u'Philadelphia',
+                'addr:housenumber': u'4006',
+                'addr:postcode': u'19104',
+                'addr:state': u'PA',
+                'addr:street': u'Spruce Street',
+                'leisure': u'adult_gaming_centre',
+                'name': u'University Family Fun Center',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2100740221,
+                'kind': u'gaming',
+            })
+
+    def test_gaming_way(self):
+        import dsl
+
+        z, x, y = (16, 17768, 25989)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/41979263
+            dsl.way(41979263, dsl.tile_box(z, x, y), {
+                'addr:city': u'Greenville',
+                'addr:housenumber': u'614',
+                'addr:postcode': u'29601',
+                'addr:street': u'North Main Street',
+                'building': u'yes',
+                'height': u'8.7',
+                'leisure': u'adult_gaming_centre',
+                'name': u'Breakout',
+                'source': u'openstreetmap.org',
+                'website': u'https://breakoutgreenville.com/',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 41979263,
+                'kind': u'gaming',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1306,7 +1306,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'pois', {
                 'id': 2100740221,
-                'kind': u'gaming',
+                'kind': u'adult_gaming_centre',
             })
 
     def test_gaming_way(self):
@@ -1333,7 +1333,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'pois', {
                 'id': 41979263,
-                'kind': u'gaming',
+                'kind': u'adult_gaming_centre',
             })
 
     def test_garden_centre_node(self):
@@ -1493,7 +1493,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'kind': u'grocery',
             })
 
-    def test_harbor_natural_water_way(self):
+    def test_harbour_natural_water_way(self):
         import dsl
 
         z, x, y = (16, 19002, 25265)
@@ -1507,13 +1507,14 @@ class KindsForMakiIconSupportTest(FixtureTest):
             }),
         )
 
-        self.assert_has_feature(
+        # note: the harbour=yes by itself isn't enough to make this into a
+        # landuse feature.
+        self.assert_no_matching_feature(
             z, x, y, 'landuse', {
                 'id': 310557860,
-                'kind': u'harbor',
             })
 
-    def test_harbor_pier_way(self):
+    def test_harbour_pier_way(self):
         import dsl
 
         z, x, y = (16, 25307, 36837)
@@ -1534,11 +1535,10 @@ class KindsForMakiIconSupportTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'landuse', {
                 'id': 183049783,
-                # should be 'kind': u'harbor',?
                 'kind': 'pier',
             })
 
-    def test_harbor_way(self):
+    def test_harbour_way(self):
         import dsl
 
         z, x, y = (16, 38891, 25976)
@@ -1553,13 +1553,14 @@ class KindsForMakiIconSupportTest(FixtureTest):
             }),
         )
 
-        self.assert_has_feature(
+        # harbour=yes is not enough by itself to make a feature in the landuse
+        # layer.
+        self.assert_no_matching_feature(
             z, x, y, 'landuse', {
                 'id': 515527428,
-                'kind': u'harbor',
             })
 
-    def test_harbor_landuse_harbour_way(self):
+    def test_harbour_landuse_harbour_way(self):
         import dsl
 
         z, x, y = (16, 35014, 25282)
@@ -1578,10 +1579,10 @@ class KindsForMakiIconSupportTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'landuse', {
                 'id': 422833298,
-                'kind': u'harbor',
+                'kind': u'harbour',
             })
 
-    def test_harbor_landuse_port_way(self):
+    def test_harbour_landuse_port_way(self):
         import dsl
 
         z, x, y = (16, 31231, 20846)
@@ -1605,7 +1606,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'landuse', {
                 'id': 143517784,
-                'kind': u'harbor',
+                'kind': u'port',
             })
 
     def test_port_terminal_way(self):
@@ -1627,8 +1628,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'landuse', {
                 'id': 256125920,
-                # TODO: should be 'kind': u'port_terminal',?
-                'kind': 'pier',
+                'kind': u'port_terminal',
             })
 
     def test_ferry_terminal_way(self):

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1382,3 +1382,56 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'id': 265733658,
                 'kind': u'garden_centre',
             })
+
+    def test_golf_node(self):
+        import dsl
+
+        z, x, y = (16, 19252, 24580)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5622433042
+            dsl.point(5622433042, (-74.244082, 40.962317), {
+                'addr:city': u'Wayne',
+                'addr:housenumber': u'1210',
+                'addr:postcode': u'07470',
+                'addr:state': u'NJ',
+                'addr:street': u'Paterson-Hamburg Turnpike',
+                'name': u'K & J Custom Fit Pro Shop',
+                'shop': u'golf',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5622433042,
+                'kind': u'golf',
+            })
+
+    def test_golf_way(self):
+        import dsl
+
+        z, x, y = (16, 18826, 24953)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/398700987
+            dsl.way(398700987, dsl.tile_box(z, x, y), {
+                'addr:city': u'Loch Raven',
+                'addr:country': u'US',
+                'addr:housenumber': u'803',
+                'addr:postcode': u'21286',
+                'addr:state': u'MD',
+                'addr:street': u'Goucher Boulevard',
+                'addr:unit': u'104',
+                'building': u'retail',
+                'name': u'Golf Galaxy',
+                'shop': u'golf',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 398700987,
+                'kind': u'golf',
+            })

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -610,6 +610,8 @@ filters:
   # port, ferry, container terminals
   - filter:
       landuse:
+        - harbour
+        - port
         - port_terminal
         - ferry_terminal
         - container_terminal
@@ -1134,9 +1136,13 @@ filters:
       kind_detail: {col: "crane:type"}
   - filter:
       landuse:
-        - harbour
-        - port
         - shipyard
+    min_zoom: 15
+    output:
+      <<: *output_properties
+      kind: {col: landuse}
+  - filter:
+      landuse:
         - wharf
         - quay
     min_zoom: 16

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -463,7 +463,6 @@ filters:
     output:
       <<: *output_properties
       kind: naval_base
-      kind_detail: military
       tier: 3
   - filter: {landuse: military}
     min_zoom: *tier3_min_zoom
@@ -608,6 +607,16 @@ filters:
       <<: *output_properties
       kind: winter_sports
       tier: 4
+  # port, ferry, container terminals
+  - filter:
+      landuse:
+        - port_terminal
+        - ferry_terminal
+        - container_terminal
+    min_zoom: { clamp: { min: 11, max: 16, value: { sum: [ { col: zoom }, 1.81 ] } } }
+    output:
+      <<: *output_properties
+      kind: {col: landuse}
   # pier
   - filter:
       man_made: pier
@@ -1124,18 +1133,9 @@ filters:
       kind: crane
       kind_detail: {col: "crane:type"}
   - filter:
-      any:
-        harbour: 'yes'
-        landuse: harbour
-    min_zoom: 16
-    output:
-      <<: *output_properties
-      kind: harbor
-  - filter:
       landuse:
-        - port_terminal
-        - ferry_terminal
-        - container_terminal
+        - harbour
+        - port
         - shipyard
         - wharf
         - quay

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -458,6 +458,13 @@ filters:
       kind: airfield
       kind_detail: military
       tier: 3
+  - filter: {military: naval_base}
+    min_zoom: *tier3_min_zoom
+    output:
+      <<: *output_properties
+      kind: naval_base
+      kind_detail: military
+      tier: 3
   - filter: {landuse: military}
     min_zoom: *tier3_min_zoom
     output:
@@ -1116,3 +1123,23 @@ filters:
       <<: *output_properties
       kind: crane
       kind_detail: {col: "crane:type"}
+  - filter:
+      any:
+        harbour: 'yes'
+        landuse: harbour
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: harbor
+  - filter:
+      landuse:
+        - port_terminal
+        - ferry_terminal
+        - container_terminal
+        - shipyard
+        - wharf
+        - quay
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: {col: landuse}

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -131,7 +131,7 @@ global:
         - aerialway: pylon
         - aeroway: [ gate, helipad ]
         - amenity: [ atm, bbq, bench, bicycle_parking, bicycle_rental,
-            bicycle_repair_station, boat_storage, car_sharing, car_wash, charging_station, fuel, hunting_stand,
+            bicycle_repair_station, boat_storage, car_sharing, car_wash, charging_station, customs, fuel, hunting_stand,
             life_ring, motorcycle_parking, parking, picnic_table, post_box, ranger_station, recycling,
             shelter, shower, telephone, toilets, waste_basket, waste_disposal,
             water_point, watering_place ]
@@ -172,7 +172,7 @@ global:
         - tags->rwn_ref: true
         - tags->whitewater: [ egress, hazard, put_in, put_in;egress, rapid ]
         - tourism: [ alpine_hut, information, picnic_site, viewpoint, wilderness_hut ]
-        - waterway: [ dam, lock, waterfall ]
+        - waterway: [ dam, lock, waterfall, boatyard, boat_lift ]
 
 filters:
   # remove disused things, they're not real POIs any more
@@ -770,7 +770,7 @@ filters:
       <<: *output_properties
       kind: level_crossing
   - filter:
-      amenity: [bank, cinema, courthouse, embassy, fire_station, fuel, library, police,
+      amenity: [bank, cinema, courthouse, customs, embassy, fire_station, fuel, library, police,
         post_office, theatre]
     min_zoom: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 2.7 ] } } }
     output:
@@ -1461,7 +1461,7 @@ filters:
       shop: [art, bakery, beauty, books, butcher, car, car_repair, clothes,
         computer, convenience, fashion, florist, gift, greengrocer, grocery,
         hairdresser, hifi, jewelry, mobile_phone, newsagent, optician,
-        perfumery, stationery, tobacco, travel_agency]
+        perfumery, ship_chandler, stationery, tobacco, travel_agency]
     min_zoom: 17
     output:
       <<: *output_properties
@@ -1614,6 +1614,13 @@ filters:
     output:
       <<: *output_properties
       kind: petroleum_well
+  # a boat lift is a more specific type of object than a crane, although it may
+  # or may not be an instance of a crane.
+  - filter: {waterway: boat_lift}
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: boat_lift
   - filter: {man_made: crane}
     min_zoom: 16
     output:
@@ -1706,6 +1713,12 @@ filters:
     output:
       <<: *output_properties
       kind: gaming
+  - filter:
+      waterway: boatyard
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: boatyard
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1697,6 +1697,15 @@ filters:
     output:
       <<: *output_properties
       kind: quarry
+  - filter:
+      leisure:
+        - adult_gaming_centre
+        # fairly common misspelling
+        - adult_gaming_center
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: gaming
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1459,7 +1459,7 @@ filters:
       kind: cycle_barrier
   - filter:
       shop: [art, bakery, beauty, books, butcher, car, car_repair, clothes,
-        computer, convenience, fashion, florist, gift, greengrocer,
+        computer, convenience, fashion, florist, gift, greengrocer, grocery,
         hairdresser, hifi, jewelry, mobile_phone, newsagent, optician,
         perfumery, stationery, tobacco, travel_agency]
     min_zoom: 17

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -911,7 +911,7 @@ filters:
       <<: *output_properties
       kind: electronics
   - filter:
-      shop: [department_store, supermarket, doityourself, hardware, trade]
+      shop: [department_store, supermarket, doityourself, hardware, trade, garden_centre]
     min_zoom: { clamp: { min: 0, max: 17, value: { sum: [ { col: zoom }, 3.29 ] } } }
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -804,7 +804,7 @@ filters:
       <<: *output_properties
       kind: {col: craft}
   - filter:
-      shop: [variety_store, furniture, shoes, pet]
+      shop: [variety_store, furniture, shoes, pet, golf]
     min_zoom: { clamp: { min: 0, max: 17, value: { sum: [ { col: zoom }, 3.3 ] } } }
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1712,7 +1712,7 @@ filters:
     min_zoom: 17
     output:
       <<: *output_properties
-      kind: gaming
+      kind: adult_gaming_centre
   - filter:
       waterway: boatyard
     min_zoom: 16


### PR DESCRIPTION
Added some more kinds related to #1423.

* `gaming`
* `garden_centre`
* `golf`
* `grocery`
* `harbor`
* `naval_base`
* `port_terminal`
* `ferry_terminal` landuse
* `container_terminal`
* `shipyard`
* `wharf`
* `quay`
* `boatyard`
* `boat_lift`
* `ship_chandler`
* `customs`

(NOTE: we already had `man_made=crane` mapped to `kind: crane`, so there wasn't a need to add that.)

Some follow-ups:

* Added a kind for `grocery`. We already had `greengrocer` and, looking at the Wikipedia pages for [grocery](https://en.wikipedia.org/wiki/Grocery_store) compared with [greengrocer](https://en.wikipedia.org/wiki/Greengrocer), I'm not sure that they're the same thing. For the moment, I've left them as separate kinds.
* Many items tagged as `harbour=yes` are also tagged as other things. For example, this [port terminal](https://www.openstreetmap.org/way/256125920) is tagged `harbour=yes, landuse=port_terminal, man_made=pier`; should that be output as a harbour, port terminal or pier - or should we split the geometry to allow multiple features for the harbour landuse and pier, with a POI for the port terminal? Also, this [pier](https://www.openstreetmap.org/way/183049783) is tagged `harbour=yes, man_made=pier` - should that be harbour, pier or split into two features?
* The `customs` kind mentions the [`amenity=customs`](http://wiki.openstreetmap.org/wiki/Tag:amenity=customs) tag, which has only 742 uses. Should we also include the [`barrier=border_control`](https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dborder_control) tag, which has over 5,000 uses? Should they _both_ be mapped to kind `customs`, or are customs (i.e: taxation) and border control sufficiently distinct things to deserve distinct kinds?
