### PR TITLE
More kinds for Maki icon library support

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -752,6 +752,10 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `elevation`: Elevation of the peak or volcano in meters, where available.
 * `kind_tile_rank`: A rank of each peak or volcano, with 1 being the most important. Both peaks and volcanos are scored in the same scale. When the zoom is less than 16, only five of these features are included in each tile. At zoom 16, all the features are - although it's rare to have more than 5 peaks in a zoom 16 tile.
 
+#### POI properties (only on `kind:marina`, `kind:camp_site` and `kind:caravan_site`)
+
+* `sanitary_dump_station`: One of `yes`, `customers` or `public` if there are sanitary dump facilities at this location, and who is permitted to use them.
+
 #### POI properties (only on `charging_station`):
 
 * `bicycle`, `scooter`, `car`, `truck`: True, false, or omitted based on if that type of vehicle can be charged, or if the information is not present
@@ -1023,6 +1027,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `rock`
 * `roller_coaster`
 * `saddle`
+* `sanitary_dump_station`
 * `sawmill`
 * `school` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `scuba_diving`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1249,8 +1249,7 @@ Railway `service` values are:
 
 ![image](images/mapzen-vector-tile-docs-roads-piers.png)
 
-**Piers** start showing up at zoom 13+ with `kind_detail` values of `pier`. If mooring information is available, the `mooring` property will be one of `no`, `yes`, `commercial`, `cruise`, `customers`, `declaration`, `ferry`, `guest`, `private`, `public`, `waiting`, `yacht` or `yachts`.
-
+**Piers** and **quays** start showing up at zoom 13+ with `kind_detail` values of `pier` and `quay`, respectively. If mooring information is available, the `mooring` property will be one of `no`, `yes`, `commercial`, `cruise`, `customers`, `declaration`, `ferry`, `guest`, `private`, `public`, `waiting`, `yacht` or `yachts`.
 
 ## Transit
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -557,7 +557,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `prison`
 * `protected_area`
 * `quarry`
-* `quay`
+* `quay` - if available, with `mooring` one of `no`, `yes`, `commercial`, `cruise`, `customers`, `declaration`, `ferry`, `guest`, `private`, `public`, `waiting`, `yacht` or `yachts`.
 * `railway`
 * `recreation_ground`
 * `recreation_track`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -546,7 +546,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `pedestrian`
 * `petting_zoo`
 * `picnic_site`
-* `pier`
+* `pier` - if available, with `mooring` one of `no`, `yes`, `commercial`, `cruise`, `customers`, `declaration`, `ferry`, `guest`, `private`, `public`, `waiting`, `yacht` or `yachts`.
 * `pitch`
 * `place_of_worship`
 * `plant`
@@ -953,6 +953,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `mini_roundabout` - has optional property `drives_on_left` to indicate whether the roundabout is in a country which drives on the left (`drives_on_left=true`) and therefore goes around the mini roundabout in  a clockwise direction as seen from above. The property is omitted when the country drives on the right and has counter-clockwise mini roundabouts (i.e: default `false`).
 * `mobile_phone`
 * `monument`
+* `mooring` - A place to tie up a boat. If available, with `kind_detail` one of `commercial`, `cruise`, `customers`, `declaration`, `ferry`, `guest`, `pile`, `private`, `public`, `waiting`, `yacht` or `yachts`.
 * `motel`
 * `motorcycle`
 * `motorcycle_parking`
@@ -1248,7 +1249,8 @@ Railway `service` values are:
 
 ![image](images/mapzen-vector-tile-docs-roads-piers.png)
 
-**Piers** start showing up at zoom 13+ with `kind_detail` values of `pier`.
+**Piers** start showing up at zoom 13+ with `kind_detail` values of `pier`. If mooring information is available, the `mooring` property will be one of `no`, `yes`, `commercial`, `cruise`, `customers`, `declaration`, `ferry`, `guest`, `private`, `public`, `waiting`, `yacht` or `yachts`.
+
 
 ## Transit
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -910,6 +910,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `halt`
 * `hanami`
 * `handicraft`
+* `harbourmaster`
 * `hardware`
 * `hazard`
 * `healthcare`

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -2333,3 +2333,48 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'kind': u'pier',
                 'mooring': u'customers',
             })
+
+    def test_quay_man_made_way_line(self):
+        import dsl
+
+        z, x, y = (16, 18958, 25284)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/109938886
+            dsl.way(109938886, dsl.tile_diagonal(z, x, y), {
+                'man_made': u'quay',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # should linear quays go into the roads layer like piers?
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 109938886,
+                'kind': u'path',
+                'kind_detail': u'quay',
+            })
+
+    def test_man_made_quay_way_area(self):
+        import dsl
+
+        z, x, y = (16, 33352, 21847)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/465148799
+            dsl.way(465148799, dsl.tile_box(z, x, y), {
+                'man_made': u'quay',
+                'name': u'Kaai 410',
+                'name:de': u'kai 410',
+                'name:fr': u'quai 410',
+                'name:it': u'banchina 410',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # polygonal quays should go into landuse?
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 465148799,
+                'kind': u'quay',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -2604,3 +2604,68 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'kind': u'caravan_site',
                 'sanitary_dump_station': u'yes',
             })
+
+    def test_waterway_fuel_node(self):
+        import dsl
+
+        z, x, y = (16, 19406, 24550)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5489425299
+            dsl.point(5489425299, (-73.398601, 41.085890), {
+                'source': u'openstreetmap.org',
+                'waterway': u'fuel',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5489425299,
+                'kind': u'waterway_fuel',
+            })
+
+    def test_waterway_fuel_way(self):
+        import dsl
+
+        z, x, y = (16, 32043, 22582)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/72074171
+            dsl.way(72074171, dsl.tile_box(z, x, y), {
+                'building': u'yes',
+                'fuel:diesel': u'yes',
+                'seamark:information': u'diesel',
+                'seamark:small_craft_facility:category': u'fuel_station',
+                'seamark:type': u'small_craft_facility',
+                'source': u'openstreetmap.org',
+                'waterway': u'fuel',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 72074171,
+                'kind': u'waterway_fuel',
+            })
+
+    def test_waterway_amenity_fuel_node(self):
+        import dsl
+
+        z, x, y = (16, 34254, 21225)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/270602036
+            dsl.point(270602036, (8.163521, 53.405975), {
+                'amenity': u'fuel',
+                'name': u'Dieseltankstelle',
+                'seamark:small_craft_facility:category': u'fuel_station',
+                'seamark:type': u'small_craft_facility',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 270602036,
+                'kind': u'waterway_fuel',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -2378,3 +2378,229 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'id': 465148799,
                 'kind': u'quay',
             })
+
+    def test_sanitary_dump_station_node(self):
+        import dsl
+
+        z, x, y = (16, 19489, 24603)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3925485395
+            dsl.point(3925485395, (-72.938255, 40.865682), {
+                'amenity': u'sanitary_dump_station',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3925485395,
+                'kind': u'sanitary_dump_station',
+            })
+
+    def test_sanitary_dump_station_way(self):
+        import dsl
+
+        z, x, y = (16, 18684, 24916)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/552257184
+            dsl.way(552257184, dsl.tile_box(z, x, y), {
+                'amenity': u'sanitary_dump_station',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 552257184,
+                'kind': u'sanitary_dump_station',
+            })
+
+    def test_sanitary_dump_station_node(self):
+        import dsl
+
+        z, x, y = (16, 18876, 25380)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3472044600
+            dsl.point(3472044600, (-76.306942, 37.561204), {
+                'source': u'openstreetmap.org',
+                'waterway': u'sanitary_dump_station',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3472044600,
+                'kind': u'sanitary_dump_station',
+            })
+
+    def test_sanitary_dump_station_way(self):
+        import dsl
+
+        z, x, y = (16, 11649, 25525)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/551894147
+            dsl.way(551894147, dsl.tile_box(z, x, y), {
+                'source': u'openstreetmap.org',
+                'waterway': u'sanitary_dump_station',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 551894147,
+                'kind': u'sanitary_dump_station',
+            })
+
+    def test_marina_sanity_dump_station_yes_node(self):
+        import dsl
+
+        z, x, y = (16, 18725, 23827)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3730870302
+            dsl.point(3730870302, (-77.135342, 44.010267), {
+                'leisure': u'marina',
+                'name': u'Port Picton Harbour Marina',
+                'power_supply': u'yes',
+                'sanitary_dump_station': u'yes',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q385085',
+                'wikipedia': u'en:Prince Edward County, Ontario',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3730870302,
+                'kind': u'marina',
+                'sanitary_dump_station': u'yes',
+            })
+
+    def test_marina_sanity_dump_station_yes_way(self):
+        import dsl
+
+        z, x, y = (16, 18844, 25055)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/39392303
+            dsl.way(39392303, dsl.tile_box(z, x, y), {
+                'leisure': u'marina',
+                'name': u'Bert Jabin\'s Yacht Yard',
+                'sanitary_dump_station': u'yes',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 39392303,
+                'kind': u'marina',
+                'sanitary_dump_station': u'yes',
+            })
+
+    def test_camp_site_sanitary_dump_station_yes_node(self):
+        import dsl
+
+        z, x, y = (16, 10802, 24913)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1798722757
+            dsl.point(1798722757, (-120.662796, 39.566655), {
+                'capacity': u'19',
+                'drinking_water': u'yes',
+                'fee': u'yes',
+                'name': u'Loganville Campground',
+                'operator': u'USFS',
+                'sanitary_dump_station': u'yes',
+                'source': u'openstreetmap.org',
+                'toilets': u'yes',
+                'toilets:disposal': u'pitlatrine',
+                'tourism': u'camp_site',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1798722757,
+                'kind': u'camp_site',
+                'sanitary_dump_station': u'yes',
+            })
+
+    def test_camp_site_sanitary_dump_station_yes_way(self):
+        import dsl
+
+        z, x, y = (16, 18937, 24765)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/506304336
+            dsl.way(506304336, dsl.tile_box(z, x, y), {
+                'internet_access': u'wlan',
+                'internet_access:fee': u'yes',
+                'name': u'Lake-in-Wood Campground',
+                'payment:cash': u'yes',
+                'payment:mastercard': u'yes',
+                'payment:visa': u'yes',
+                'sanitary_dump_station': u'yes',
+                'source': u'openstreetmap.org',
+                'tourism': u'camp_site',
+                'wheelchair': u'limited',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 506304336,
+                'kind': u'camp_site',
+                'sanitary_dump_station': u'yes',
+            })
+
+    def test_caravan_site_sanitary_dump_station_yes_node(self):
+        import dsl
+
+        z, x, y = (16, 19122, 23577)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4345342880
+            dsl.point(4345342880, (-74.959569, 44.991434), {
+                'sanitary_dump_station': u'yes',
+                'source': u'openstreetmap.org',
+                'tourism': u'caravan_site',
+                'water_point': u'yes',
+                'name': 'Fake name to pass the no_name_okay filter',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4345342880,
+                'kind': u'caravan_site',
+                'sanitary_dump_station': u'yes',
+            })
+
+    def test_caravan_site_sanitary_dump_station_yes_way(self):
+        import dsl
+
+        z, x, y = (16, 19212, 24226)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/416560900
+            dsl.way(416560900, dsl.tile_box(z, x, y), {
+                'name': u'Nickerson Park Campground',
+                'power_supply': u'yes',
+                'sanitary_dump_station': u'yes',
+                'source': u'openstreetmap.org',
+                'tents': u'yes',
+                'tourism': u'caravan_site',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 416560900,
+                'kind': u'caravan_site',
+                'sanitary_dump_station': u'yes',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -2417,7 +2417,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'kind': u'sanitary_dump_station',
             })
 
-    def test_sanitary_dump_station_node(self):
+    def test_waterway_sanitary_dump_station_node(self):
         import dsl
 
         z, x, y = (16, 18876, 25380)
@@ -2436,7 +2436,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'kind': u'sanitary_dump_station',
             })
 
-    def test_sanitary_dump_station_way(self):
+    def test_waterway_sanitary_dump_station_way(self):
         import dsl
 
         z, x, y = (16, 11649, 25525)

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1929,3 +1929,135 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'id': 206943159,
                 'kind': u'customs',
             })
+
+    def test_harbourmaster_seamark_node(self):
+        import dsl
+
+        z, x, y = (16, 17964, 29191)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/778613459
+            dsl.point(778613459, (-81.318644, 19.272868), {
+                'addr:city': u'Spotts',
+                'addr:country': u'KY',
+                'addr:street': u'Jackson Road',
+                'building': u'yes',
+                'description': u'This is where the ships anchor '\
+                u'during rough seas!',
+                'name': u'Spotts Bay Alternate Cruise Facility of ' \
+                u'Port Authority',
+                'seamark:building:function': u'harbour_master',
+                'seamark:type': u'building',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 778613459,
+                'kind': u'harbourmaster',
+            })
+
+    def test_harbourmaster_seamark_way(self):
+        import dsl
+
+        z, x, y = (16, 18409, 24075)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/84872891
+            dsl.way(84872891, dsl.tile_box(z, x, y), {
+                'building': u'yes',
+                'seamark:building:function': u'harbour_master',
+                'seamark:type': u'building',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 84872891,
+                'kind': u'harbourmaster',
+            })
+
+    def test_harbour_master_node(self):
+        import dsl
+
+        z, x, y = (16, 18224, 23638)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3721714683
+            dsl.point(3721714683, (-79.887715, 44.753227), {
+                'harbour': u'harbour_master',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3721714683,
+                'kind': u'harbourmaster',
+            })
+
+    def test_harbour_master_way(self):
+        import dsl
+
+        z, x, y = (16, 32156, 22859)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/406287049
+            dsl.way(406287049, dsl.tile_box(z, x, y), {
+                'building': u'yes',
+                'harbour': u'harbour_master',
+                'opening_hours': u'Mo-Sa 09:00-12:00,14:00-18:00',
+                'source': u'openstreetmap.org',
+                'wheelchair': u'yes',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 406287049,
+                'kind': u'harbourmaster',
+            })
+
+    def test_harbourmaster_amenity_node(self):
+        import dsl
+
+        z, x, y = (16, 17927, 28133)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4424415086
+            dsl.point(4424415086, (-81.518615, 24.660679), {
+                'amenity': u'harbourmaster',
+                'shop': u'yes',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4424415086,
+                'kind': u'harbourmaster',
+            })
+
+    def test_harbourmaster_amenity_way(self):
+        import dsl
+
+        z, x, y = (16, 17777, 28436)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/259829016
+            dsl.way(259829016, dsl.tile_box(z, x, y), {
+                'amenity': u'harbourmaster',
+                'building': u'yes',
+                'building:levels': u'3',
+                'name': u'Empresa Prácticos de Cuba',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 259829016,
+                'kind': u'harbourmaster',
+            })

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -2061,3 +2061,275 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'id': 259829016,
                 'kind': u'harbourmaster',
             })
+
+    def test_yes_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 18842, 25052)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4341108759
+            dsl.point(4341108759, (-76.493961, 38.972904), {
+                'mooring': u'yes',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # treat mooring=yes as a "yes, there's a mooring here", but we don't
+        # know any more about it.
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4341108759,
+                'kind': u'mooring',
+                'kind_detail': type(None),
+            })
+
+    def test_private_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 19533, 24620)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1989045561
+            dsl.point(1989045561, (-72.699321, 40.796934), {
+                'mooring': u'private',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # TODO: should we show these at all if they're private?
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1989045561,
+                'kind': u'mooring',
+                'access': 'private',
+            })
+
+    def test_no_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 17992, 23772)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5180188472
+            dsl.point(5180188472, (-81.166304, 44.226554), {
+                'leisure': u'slipway',
+                'mooring': u'no',
+                'source': u'openstreetmap.org',
+                'vehicle': u'no',
+            }),
+        )
+
+        # in this case, the mooring=no is a description of the slipway, rather
+        # than a feature in its own right.
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5180188472,
+                'kind': u'slipway',
+                'mooring': 'no',
+            })
+
+    def test_commercial_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 18223, 24746)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2015422399
+            dsl.point(2015422399, (-79.895062, 40.270013), {
+                'man_made': u'mooring',
+                'mooring': u'commercial',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # note: there's not many man_made=mooring, so we ignore that.
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2015422399,
+                'kind': u'mooring',
+                'kind_detail': u'commercial',
+            })
+
+    def test_ferry_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 17344, 23374)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2320763454
+            dsl.point(2320763454, (-84.724975, 45.774231), {
+                'mooring': u'ferry',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2320763454,
+                'kind': u'mooring',
+                'kind_detail': u'ferry',
+            })
+
+    def test_guest_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 17669, 27124)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3667335766
+            dsl.point(3667335766, (-82.936394, 29.590537), {
+                'maxstay': u'minimal',  # wow, sounds super hospitable...
+                'mooring': u'guest',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3667335766,
+                'kind': u'mooring',
+                'kind_detail': u'guest',
+            })
+
+    def test_cruise_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 19903, 24337)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4148336680
+            dsl.point(4148336680, (-70.666619, 41.961962), {
+                'contact:phone': u'+1 508 7462643',
+                'contact:website': u'http://www.captjohn.com/',
+                'mooring': u'cruise',
+                'name': u'Captain John Whale Watching & Fishing Tours',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4148336680,
+                'kind': u'mooring',
+                'kind_detail': u'cruise',
+            })
+
+    def test_waiting_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 33124, 24003)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2102077401
+            dsl.point(2102077401, (1.959648, 43.312300), {
+                'mooring': u'waiting',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2102077401,
+                'kind': u'mooring',
+                'kind_detail': u'waiting',
+            })
+
+    def test_pile_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 33704, 21668)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2410435220
+            dsl.point(2410435220, (5.146992, 51.927532), {
+                'material': u'wood',
+                'mooring': u'pile',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2410435220,
+                'kind': u'mooring',
+                'kind_detail': u'pile',
+            })
+
+    def test_declaration_mooring_node(self):
+        import dsl
+
+        z, x, y = (16, 30526, 40041)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2079122376
+            dsl.point(2079122376, (-12.312872, -37.063474), {
+                'mooring': u'declaration',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2079122376,
+                'kind': u'mooring',
+                'kind_detail': u'declaration',
+            })
+
+    def test_yachts_mooring_way(self):
+        import dsl
+
+        z, x, y = (16, 15565, 26449)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/584249543
+            dsl.way(584249543, dsl.tile_box(z, x, y), {
+                'man_made': u'pier',
+                'mooring': u'yachts',
+                'source': u'openstreetmap.org',
+                'width': u'1.2',
+            }),
+        )
+
+        # this is really a description of the pier, rather than a feature in
+        # its own right, so pass it through on the pier.
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 584249543,
+                'kind': u'pier',
+                'mooring': u'yachts',
+            })
+
+    def test_customers_mooring_way(self):
+        import dsl
+
+        z, x, y = (16, 19866, 24126)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/278952041
+            dsl.way(278952041, dsl.tile_box(z, x, y), {
+                'access': u'customers',
+                'area': u'yes',
+                'floating': u'no',
+                'horse': u'no',
+                'layer': u'2',
+                'lit': u'yes',
+                'man_made': u'pier',
+                'material': u'wood',
+                'mooring': u'customers',
+                'motor_vehicle': u'no',
+                'seamark:type': u'mooring',
+                'seasonal': u'no',
+                'source': u'openstreetmap.org',
+                'surface': u'wood',
+            }),
+        )
+
+        # again, seems like a description of who's allowed to tie up on the
+        # pier, not a separate feature.
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 278952041,
+                'kind': u'pier',
+                'mooring': u'customers',
+            })

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -1161,3 +1161,8 @@ filters:
     output:
       <<: *output_properties
       kind: {col: landuse}
+  - filter: {man_made: quay}
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: quay

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -619,7 +619,19 @@ filters:
     output:
       <<: *output_properties
       kind: {col: landuse}
-  # pier
+  # pier with mooring
+  - filter:
+      man_made: pier
+      geom_type: polygon
+      mooring: [
+        'no', 'yes', commercial, cruise, customers, declaration, ferry, guest,
+        private, public, waiting, yacht, yachts]
+    min_zoom: { clamp: { min: 11, max: 16, value: { sum: [ { col: zoom }, 1.81 ] } } }
+    output:
+      <<: *output_properties
+      kind: pier
+      mooring: {col: mooring}
+  # pier without mooring
   - filter:
       man_made: pier
       geom_type: polygon

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -165,6 +165,7 @@ global:
         - public_transport: [ platform, stop_area ]
         - railway: [ halt, level_crossing, platform, stop, subway_entrance, tram_stop ]
         - "seamark:building:function": harbour_master
+        - "seamark:small_craft_facility:category": fuel_station
         - tags->icn_ref: true
         - tags->iwn_ref: true
         - tags->lcn_ref: true
@@ -175,7 +176,7 @@ global:
         - tags->rwn_ref: true
         - tags->whitewater: [ egress, hazard, put_in, put_in;egress, rapid ]
         - tourism: [ alpine_hut, information, picnic_site, viewpoint, wilderness_hut ]
-        - waterway: [ dam, lock, waterfall, boatyard, boat_lift, sanitary_dump_station ]
+        - waterway: [ dam, lock, waterfall, boatyard, boat_lift, sanitary_dump_station, fuel ]
 
 filters:
   # remove disused things, they're not real POIs any more
@@ -772,6 +773,16 @@ filters:
     output:
       <<: *output_properties
       kind: level_crossing
+  # filter the waterway / boat fuel before generic amenity=fuel, as they appear
+  # to be often tagged with both.
+  - filter:
+      any:
+        - waterway: fuel
+        - "seamark:small_craft_facility:category": fuel_station
+    min_zoom: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 2.7 ] } } }
+    output:
+      <<: *output_properties
+      kind: waterway_fuel
   - filter:
       amenity: [bank, cinema, courthouse, customs, embassy, fire_station, fuel, library, police,
         post_office, theatre]

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -131,7 +131,7 @@ global:
         - aerialway: pylon
         - aeroway: [ gate, helipad ]
         - amenity: [ atm, bbq, bench, bicycle_parking, bicycle_rental,
-            bicycle_repair_station, boat_storage, car_sharing, car_wash, charging_station, customs, fuel, hunting_stand,
+            bicycle_repair_station, boat_storage, car_sharing, car_wash, charging_station, customs, fuel, harbourmaster, hunting_stand,
             life_ring, motorcycle_parking, parking, picnic_table, post_box, ranger_station, recycling,
             shelter, shower, telephone, toilets, waste_basket, waste_disposal,
             water_point, watering_place ]
@@ -148,6 +148,7 @@ global:
             - swing_gate
             - toll_booth
         - emergency: [ lifeguard_tower, phone, defibrillator ]
+        - harbour: harbour_master
         - highway: [ bus_stop, ford, mini_roundabout, motorway_junction, platform,
             rest_area, traffic_signals, trailhead ]
         - historic: landmark
@@ -162,6 +163,7 @@ global:
         - power: [ pole, tower ]
         - public_transport: [ platform, stop_area ]
         - railway: [ halt, level_crossing, platform, stop, subway_entrance, tram_stop ]
+        - "seamark:building:function": harbour_master
         - tags->icn_ref: true
         - tags->iwn_ref: true
         - tags->lcn_ref: true
@@ -1719,6 +1721,15 @@ filters:
     output:
       <<: *output_properties
       kind: boatyard
+  - filter:
+      any:
+        - amenity: harbourmaster
+        - harbour: harbour_master
+        - "seamark:building:function": harbour_master
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: harbourmaster
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1745,7 +1745,7 @@ filters:
   - filter:
       mooring: [
         commercial, cruise, customers, declaration, ferry, guest,
-        pile, private, public, waiting, yacht, yachts]
+        pile, waiting, yacht, yachts]
     min_zoom: 17
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -158,6 +158,7 @@ global:
         - man_made: [ adit, communications_tower, crane, mast, mineshaft, observatory,
             offshore_platform, petroleum_well, power_wind, telescope, water_tower,
             water_well, windmill ]
+        - mooring: true
         - natural: [ cave_entrance, peak, volcano, geyser, hot_spring, rock, saddle,
             stone, spring, tree, waterfall ]
         - power: [ pole, tower ]
@@ -1329,6 +1330,16 @@ filters:
     output:
       <<: *output_properties
       kind: memorial
+  # slipway with mooring info
+  - filter:
+      leisure: slipway
+      mooring: ['yes', 'no']
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: slipway
+      mooring: {col: mooring}
+  # plain slipway without mooring info
   - filter: { leisure: slipway }
     min_zoom: 17
     output:
@@ -1730,6 +1741,30 @@ filters:
     output:
       <<: *output_properties
       kind: harbourmaster
+  # moorings with more detail
+  - filter:
+      mooring: [
+        commercial, cruise, customers, declaration, ferry, guest,
+        pile, private, public, waiting, yacht, yachts]
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: mooring
+      kind_detail: {col: mooring}
+  # moorings with access restrictions
+  - filter:
+      mooring: [ private, public ]
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: mooring
+      access: {col: mooring}
+  # plain moorings, without detail
+  - filter: {mooring: true}
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: mooring
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -133,7 +133,7 @@ global:
         - amenity: [ atm, bbq, bench, bicycle_parking, bicycle_rental,
             bicycle_repair_station, boat_storage, car_sharing, car_wash, charging_station, customs, fuel, harbourmaster, hunting_stand,
             life_ring, motorcycle_parking, parking, picnic_table, post_box, ranger_station, recycling,
-            shelter, shower, telephone, toilets, waste_basket, waste_disposal,
+            sanitary_dump_station, shelter, shower, telephone, toilets, waste_basket, waste_disposal,
             water_point, watering_place ]
         - barrier:
             - block
@@ -175,7 +175,7 @@ global:
         - tags->rwn_ref: true
         - tags->whitewater: [ egress, hazard, put_in, put_in;egress, rapid ]
         - tourism: [ alpine_hut, information, picnic_site, viewpoint, wilderness_hut ]
-        - waterway: [ dam, lock, waterfall, boatyard, boat_lift ]
+        - waterway: [ dam, lock, waterfall, boatyard, boat_lift, sanitary_dump_station ]
 
 filters:
   # remove disused things, they're not real POIs any more
@@ -887,6 +887,10 @@ filters:
     output:
       <<: *output_properties
       kind: marina
+      sanitary_dump_station:
+        case:
+          - when: {sanitary_dump_station: ['yes', 'customers', 'public']}
+            then: {col: sanitary_dump_station}
   - filter: {amenity: townhall}
     min_zoom: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 1.85 ] } } }
     output:
@@ -1300,6 +1304,10 @@ filters:
     output:
       <<: *output_properties
       kind: camp_site
+      sanitary_dump_station:
+        case:
+          - when: {sanitary_dump_station: ['yes', 'customers', 'public']}
+            then: {col: sanitary_dump_station}
   - filter:
       tourism: viewpoint
     min_zoom: 15
@@ -1690,6 +1698,10 @@ filters:
     output:
       <<: *output_properties
       kind: caravan_site
+      sanitary_dump_station:
+        case:
+          - when: {sanitary_dump_station: ['yes', 'customers', 'public']}
+            then: {col: sanitary_dump_station}
   - filter: {tourism: picnic_site}
     min_zoom: 16
     output:
@@ -1765,6 +1777,15 @@ filters:
     output:
       <<: *output_properties
       kind: mooring
+
+  - filter:
+      any:
+        - amenity: sanitary_dump_station
+        - waterway: sanitary_dump_station
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: sanitary_dump_station
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -779,7 +779,7 @@ filters:
       any:
         - waterway: fuel
         - "seamark:small_craft_facility:category": fuel_station
-    min_zoom: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 2.7 ] } } }
+    min_zoom: { clamp: { min: 14, max: 16, value: { sum: [ { col: zoom }, 2.7 ] } } }
     output:
       <<: *output_properties
       kind: waterway_fuel

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -718,6 +718,22 @@ filters:
   # OSM man_made
   #
   #############################################################
+  # pier with mooring
+  - filter:
+      man_made: pier
+      mooring: [
+        'no', 'yes', commercial, cruise, customers, declaration, ferry, guest,
+        private, public, waiting, yacht, yachts]
+    min_zoom: 13
+    table: osm
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network
+      <<: *osm_footway_properties
+      kind: path
+      kind_detail: pier
+      mooring: {col: mooring}
+  # pier without mooring
   - filter:
       man_made: pier
     min_zoom: 13

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -718,9 +718,10 @@ filters:
   # OSM man_made
   #
   #############################################################
-  # pier with mooring
+  # pier/quay with mooring
   - filter:
-      man_made: pier
+      geom_type: line
+      man_made: [pier, quay]
       mooring: [
         'no', 'yes', commercial, cruise, customers, declaration, ferry, guest,
         private, public, waiting, yacht, yachts]
@@ -731,11 +732,12 @@ filters:
       <<: *osm_network
       <<: *osm_footway_properties
       kind: path
-      kind_detail: pier
+      kind_detail: {col: man_made}
       mooring: {col: mooring}
-  # pier without mooring
+  # pier/quay without mooring
   - filter:
-      man_made: pier
+      geom_type: line
+      man_made: [pier, quay]
     min_zoom: 13
     table: osm
     output:
@@ -743,7 +745,7 @@ filters:
       <<: *osm_network
       <<: *osm_footway_properties
       kind: path
-      kind_detail: pier
+      kind_detail: {col: man_made}
   #############################################################
   #
   # OSM piste


### PR DESCRIPTION
Added new kinds:

* `harbourmaster`
* `mooring`
* `sanitary_dump_station`
* `path` with `kind_detail: quay` in `roads` layer, similar to `pier`.

Additional properties:

* `mooring` on `pier` and `quay`
* `sanitary_dump_station` on `marina`, `camp_site` and `caravan_site`.

Connects to #1423.
