### PR TITLE
New kinds for OSM and iD presets

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -493,6 +493,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `caravan_site`
 * `carousel`
 * `cemetery`
+* `chemist` - A shop selling household chemicals, often including soaps, toothpaste and cosmetics.
 * `cinema`
 * `city_wall`
 * `college`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1018,6 +1018,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `pitch`
 * `place_of_worship` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `plant` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
+* `plaque` - A memorial plaque.
 * `playground` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `plumber`
 * `police` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -567,7 +567,6 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `railway`
 * `recreation_ground`
 * `recreation_track`
-* `reef` - A solid feature just under the surface of the ocean, usually made from rock, sand or coral. If known, the `kind_detail` will be given as one of `coral`, `rock`, `sand`.
 * `residential`
 * `resort`
 * `rest_area`
@@ -1446,6 +1445,7 @@ Mapzen calculates the composite exterior edge for overlapping water polygons and
 * `lake` - polygon
 * `ocean` - polygon, point is intended for label placement only
 * `playa` - polygon
+* `reef` - polygon. A solid feature just under the surface of the ocean, usually made from rock, sand or coral. If known, the `kind_detail` will be given as one of `coral`, `rock`, `sand`.
 * `river` - line
 * `riverbank` - polygon
 * `sea` - point, intended for label placement only

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1129,6 +1129,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `waterfall`
 * `watering_place`
 * `watermill` - A structure for using water power to do work. Note that this is different from a modern structure to generate electric power from water, which would be a `generator`.
+* `wayside_cross`
 * `wilderness_hut`
 * `wildlife_park`
 * `windmill`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -627,7 +627,7 @@ The value of the OpenStreetMap `wetland` tag. Common values include `bog`, `fen`
 
 #### Wood and forest `kind_detail` values
 
-* The value of the OpenStreetMap `leaf_type` tag. [Common values](https://taginfo.openstreetmap.org/keys/leaf_type#values) include `broadleaved`, `needleleaved`, or `mixed`.
+* The value of the OpenStreetMap `leaf_type` tag, whitelisted to `broadleaved`, `needleleaved`, `mixed` or `leafless`.
 
 ## Places
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -502,6 +502,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `container_terminal`
 * `crane`
 * `cutline`
+* `cutting` - A lowered area of land, usually to carry a road or railway.
 * `danger` - e.g: military training zones, firing ranges.
 * `dam` - polygon, line
 * `dike`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -997,6 +997,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `nightclub`
 * `notary`
 * `nursing_home` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
+* `obelisk` - A tall structure, usually a monument or memorial (so see also `monument` and `memorial`).
 * `observatory`
 * `office` - An office which didn't match a more specific kind.
 * `offshore_platform`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -627,7 +627,7 @@ The value of the OpenStreetMap `wall` tag. Common values include `brick`, `castl
 
 ##### Wetland `kind_detail` values:
 
-The value of the OpenStreetMap `wetland` tag. Common values include `bog`, `fen`, `mangrove`, `marsh`, `reedbed`, `saltmarsh`, `string_bog`, `swamp`, `tidalflat`, and `wet_meadow`.
+The value of the OpenStreetMap `wetland` tag. If available, value will be one of: `bog`, `fen`, `mangrove`, `marsh`, `mud`, `reedbed`, `saltern`, `saltmarsh`, `string_bog`, `swamp`, `tidalflat`, `wet_meadow`.
 
 #### Wood and forest `kind_detail` values
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -861,7 +861,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `consulting`
 * `convenience`
 * `copyshop` - A shop offering photocopying and printing services.
-* `cosmetics` - A shop selling cosmetics.
+* `cosmetics` - A specialty shop selling cosmetics.
 * `courthouse`
 * `craft` - A shop or workshop producing craft items. Used when the POI doesn't match a more specific craft, such as `brewery`, `carpenter`, `confectionery`, `dressmaker`, etc...
 * `crane`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1210,10 +1210,12 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `ascent`: ski pistes from OpenStreetMap
 * `access`: `private`, `yes`, `no`, `permissive`, `customers`, `destination`, and other values from OpenStreetMap
 * `bicycle`: `yes`, `no`, `designated`, `dismount`, and other values from OpenStreetMap
+* `cutting`: True if the road or railway is in a cutting.
 * `colour`: ski pistes from OpenStreetMap
 * `descent`: ski pistes from OpenStreetMap
 * `description`: OpenStreetMap features
 * `distance`: ski pistes from OpenStreetMap
+* `embankment`: True if the road or railway is on an embankment.
 * `motor_vehicle`: OpenStreetMap features
 * `operator`: OpenStreetMap features
 * `piste_difficulty`: ski pistes from OpenStreetMap

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1210,12 +1210,12 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `ascent`: ski pistes from OpenStreetMap
 * `access`: `private`, `yes`, `no`, `permissive`, `customers`, `destination`, and other values from OpenStreetMap
 * `bicycle`: `yes`, `no`, `designated`, `dismount`, and other values from OpenStreetMap
-* `cutting`: True if the road or railway is in a cutting.
+* `cutting`: If the road or railway is in a cutting the value will be one of `yes`, `left` or `right` depending on whether the cutting is on both sides, the left side or the right side, respectively.
 * `colour`: ski pistes from OpenStreetMap
 * `descent`: ski pistes from OpenStreetMap
 * `description`: OpenStreetMap features
 * `distance`: ski pistes from OpenStreetMap
-* `embankment`: True if the road or railway is on an embankment.
+* `embankment`: If the road or railway is on an embankment the value will be one of `yes`, `left` or `right` depending on whether the embankment is on both sides, the left side or the right side, respectively.
 * `motor_vehicle`: OpenStreetMap features
 * `operator`: OpenStreetMap features
 * `piste_difficulty`: ski pistes from OpenStreetMap

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -486,7 +486,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `attraction`
 * `aviary`
 * `battlefield`
-* `beach`
+* `beach` - Where the land meets the sea gradually. If known, `kind_detail` gives the surface type, one of: `grass`, `gravel`, `pebbles`, `pebblestone`, `rocky`, `sand`.
 * `breakwater`
 * `bridge`
 * `camp_site`
@@ -792,7 +792,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `battlefield`
 * `bbq`
 * `beach_resort`
-* `beach`
+* `beach` - Where the land meets the sea gradually. If known, `kind_detail` gives the surface type, one of: `grass`, `gravel`, `pebbles`, `pebblestone`, `rocky`, `sand`.
 * `beacon`
 * `beauty`
 * `bed_and_breakfast`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -819,6 +819,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `bookmaker`
 * `books`
 * `brewery`
+* `bunker` - A reinforced military building. Where known, the `kind_detail` will be one of: `blockhouse`, `gun_emplacement`, `hardened_aircraft_shelter`, `mg_nest`, `missile_silo`, `munitions`, `pillbox`, `technical`.
 * `bus_station`
 * `bus_stop`
 * `butcher`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -566,6 +566,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `railway`
 * `recreation_ground`
 * `recreation_track`
+* `reef` - A solid feature just under the surface of the ocean, usually made from rock, sand or coral. If known, the `kind_detail` will be given as one of `coral`, `rock`, `sand`.
 * `residential`
 * `resort`
 * `rest_area`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -537,6 +537,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `maze`
 * `meadow`
 * `military`
+* `mud` - An area where the surface is bare mud.
 * `national_park`
 * `nature_reserve`
 * `natural_forest` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -880,6 +880,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `egress`
 * `electrician`
 * `electronics`
+* `elevator` - An enclosure for vertical travel.
 * `embassy`
 * `emergency_phone`
 * `employment_agency`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -998,7 +998,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `nightclub`
 * `notary`
 * `nursing_home` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
-* `obelisk` - A tall structure, usually a monument or memorial (so see also `monument` and `memorial`).
+* `obelisk` - A tall structure, usually a monument or memorial. If known, the `kind_detail` will be set to either `monument` or `memorial`.
 * `observatory`
 * `office` - An office which didn't match a more specific kind.
 * `offshore_platform`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -507,6 +507,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `dike`
 * `ditch`
 * `dog_park`
+* `embankment` - A raised area of land, usually to carry a road or railway.
 * `enclosure`
 * `farm`
 * `farmland`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -554,6 +554,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `pitch`
 * `place_of_worship`
 * `plant`
+* `plant_nursery` - Land used for growing young plants.
 * `playground`
 * `port_terminal`
 * `power_line`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -970,6 +970,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `midwife`
 * `military`
 * `mineshaft`
+* `miniature_golf` - A venue for playing miniature golf.
 * `mini_roundabout` - has optional property `drives_on_left` to indicate whether the roundabout is in a country which drives on the left (`drives_on_left=true`) and therefore goes around the mini roundabout in  a clockwise direction as seen from above. The property is omitted when the country drives on the right and has counter-clockwise mini roundabouts (i.e: default `false`).
 * `mobile_phone`
 * `money_transfer` - A business which specialises in transferring money between people, often internationally.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -544,6 +544,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `natural_park` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
 * `natural_wood` - _See planned bug fix in [#1096](https://github.com/tilezen/vector-datasource/issues/1096)._
 * `naval_base`
+* `orchard` - An area intentionally planted with trees or shrubs for their crops, rather than their wood. If available, `kind_detail` will provide the tree or shrub type. Values are: `agave_plants`, `almond_trees`, `apple_trees`, `avocado_trees`, `banana_plants`, `cherry_trees`, `coconut_palms`, `coffea_plants`, `date_palms`, `hazel_plants`, `hop_plants`, `kiwi_plants`, `macadamia_trees`, `mango_trees`, `oil_palms`, `olive_trees`, `orange_trees`, `papaya_trees`, `peach_trees`, `persimmon_trees`, `pineapple_plants`, `pitaya_plants`, `plum_trees`, `rubber_trees`, `tea_plants`, `walnut_trees`.
 * `park`
 * `parking`
 * `pedestrian`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -901,6 +901,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `firepit`
 * `fishing`
 * `fishing_area`
+* `fishmonger` - A shop selling fish and seafood.
 * `fitness_station`
 * `fitness`
 * `florist`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -859,6 +859,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `consulting`
 * `convenience`
 * `copyshop` - A shop offering photocopying and printing services.
+* `cosmetics` - A shop selling cosmetics.
 * `courthouse`
 * `craft` - A shop or workshop producing craft items. Used when the POI doesn't match a more specific craft, such as `brewery`, `carpenter`, `confectionery`, `dressmaker`, etc...
 * `crane`

--- a/integration-test/1424-add-new-kinds-for-hot-icon-support.py
+++ b/integration-test/1424-add-new-kinds-for-hot-icon-support.py
@@ -1586,51 +1586,53 @@ class KindsForHotIconSupportTest(FixtureTest):
     def test_shop_fallback_node(self):
         import dsl
 
-        z, x, y = (16, 19298, 24631)
+        z, x, y = (16, 19297, 24646)
 
         self.generate_fixtures(
-            # https://www.openstreetmap.org/node/663098951
-            dsl.point(663098951, (-73.988039, 40.749678), {
-                'name': u'Lush',
-                'shop': u'chemist',
+            # https://www.openstreetmap.org/node/2549967219
+            dsl.point(2549967219, (-73.994662, 40.685270), {
+                'addr:housenumber': u'254',
+                'addr:postcode': u'11231',
+                'addr:street': u'Court Street',
+                'name': u'American Beer Distributing Co.',
+                'shop': u'beverages',
                 'source': u'openstreetmap.org',
             }),
         )
 
-        # currently we don't break out shop=chemist as a separate kind (many of
-        # them are also amentity=pharmacy), so this triggers the fallback to
-        # the generic shop kind.
+        # currently we don't break out shop=beverages as a separate kind, so
+        # this triggers the fallback to the generic shop kind.
         self.assert_has_feature(
             z, x, y, 'pois', {
-                'id': 663098951,
+                'id': 2549967219,
                 'kind': u'shop',
             })
 
     def test_shop_fallback_way(self):
         import dsl
 
-        z, x, y = (16, 19209, 24618)
+        z, x, y = (16, 19303, 24648)
 
         self.generate_fixtures(
-            # https://www.openstreetmap.org/way/586396929
-            dsl.way(586396929, dsl.tile_box(z, x, y), {
-                'addr:city': u'Morristown',
-                'addr:housenumber': u'117',
-                'addr:street': u'Speedwell Avenue',
+            # https://www.openstreetmap.org/way/265733688
+            dsl.way(265733688, dsl.tile_box(z, x, y), {
+                'addr:housenumber': u'648',
+                'addr:postcode': u'11238',
+                'addr:street': u'Washington Avenue',
                 'building': u'yes',
-                'name': u'CVS',
-                'roof:shape': u'flat',
-                'shop': u'chemist',
+                'height': u'11.5',
+                'name': u'Prospect Heights Beer Works',
+                'nycdoitt:bin': u'3027946',
+                'shop': u'beverages',
                 'source': u'openstreetmap.org',
             }),
         )
 
-        # currently we don't break out shop=chemist as a separate kind (many of
-        # them are also amentity=pharmacy), so this triggers the fallback to
-        # the generic shop kind.
+        # currently we don't break out shop=beverages as a separate kind, so
+        # this triggers the fallback to the generic shop kind.
         self.assert_has_feature(
             z, x, y, 'pois', {
-                'id': 586396929,
+                'id': 265733688,
                 'kind': u'shop',
             })
 

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1260,3 +1260,41 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 3577265515,
                 'kind': u'plaque',
             })
+
+    def test_obelisk_node(self):
+        import dsl
+
+        z, x, y = (16, 18088, 25938)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5370564611
+            dsl.point(5370564611, (-80.634831, 35.088498), {
+                'man_made': u'obelisk',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5370564611,
+                'kind': u'obelisk',
+            })
+
+    def test_obelisk_way(self):
+        import dsl
+
+        z, x, y = (16, 15094, 26381)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/481307273
+            dsl.way(481307273, dsl.tile_box(z, x, y), {
+                'man_made': u'obelisk',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 481307273,
+                'kind': u'obelisk',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -151,3 +151,23 @@ class MoreOSMFeaturesTest(FixtureTest):
                     'kind': u'beach',
                     'kind_detail': u'rocky',
                 })
+
+    def test_chemist_node(self):
+        import dsl
+
+        z, x, y = (16, 19298, 24631)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/663098951
+            dsl.point(663098951, (-73.988039, 40.749678), {
+                'name': u'Lush',
+                'shop': u'chemist',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 663098951,
+                'kind': u'chemist',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1438,3 +1438,54 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'kind_detail': 'primary',
                 'embankment': 'yes',
             })
+
+    def test_monument_obelisk_node(self):
+        import dsl
+
+        z, x, y = (16, 17450, 26571)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4028552922
+            dsl.point(4028552922, (-84.140170, 32.194609), {
+                'historic': u'monument',
+                'man_made': u'obelisk',
+                'monument:type': u'obelisk',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4028552922,
+                'kind': u'obelisk',
+                'kind_detail': u'monument',
+            })
+
+    def test_monument_obelisk_way(self):
+        import dsl
+
+        z, x, y = (16, 19439, 24108)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/178594567
+            dsl.way(178594567, dsl.tile_box(z, x, y), {
+                'building': u'yes',
+                'height': u'267',
+                'historic': u'monument',
+                'man_made': u'obelisk',
+                'name': u'Bennington Battle Monument',
+                'obelisk:size': u'monumental',
+                'ref:nrhp': u'71000054',
+                'source': u'openstreetmap.org',
+                'website': u'http://historicsites.vermont.gov',
+                'wikidata': u'Q4889875',
+                'wikipedia': u'en:Bennington Battle Monument',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 178594567,
+                'kind': u'obelisk',
+                'kind_detail': u'monument',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -865,3 +865,22 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'kind': u'orchard',
                 'kind_detail': u'oil_palms',
             })
+
+    def test_plant_nursery_way(self):
+        import dsl
+
+        z, x, y = (16, 19319, 24594)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/442214478
+            dsl.way(442214478, dsl.tile_box(z, x, y), {
+                'landuse': u'plant_nursery',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 442214478,
+                'kind': u'plant_nursery',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -884,3 +884,24 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 442214478,
                 'kind': u'plant_nursery',
             })
+
+    def test_plaque_node(self):
+        import dsl
+
+        z, x, y = (16, 19299, 24630)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1289222425
+            dsl.point(1289222425, (-73.982936, 40.752781), {
+                'historic': u'memorial',
+                'memorial': u'plaque',
+                'name': u'Wendell L. Willkie',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1289222425,
+                'kind': u'plaque',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -229,3 +229,43 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 374783696,
                 'kind': u'embankment',
             })
+
+    def test_miniature_golf_node(self):
+        import dsl
+
+        z, x, y = (16, 19284, 24583)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5181018838
+            dsl.point(5181018838, (-74.068437, 40.948861), {
+                'leisure': u'miniature_golf',
+                'name': u'Monster Mini Golf',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5181018838,
+                'kind': u'miniature_golf',
+            })
+
+    def test_miniature_golf_way(self):
+        import dsl
+
+        z, x, y = (16, 19293, 24645)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/510028688
+            dsl.way(510028688, dsl.tile_box(z, x, y), {
+                'leisure': u'miniature_golf',
+                'name': u'FIGMENT Mini Golf',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 510028688,
+                'kind': u'miniature_golf',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -171,3 +171,42 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 663098951,
                 'kind': u'chemist',
             })
+
+    def test_elevator_way(self):
+        import dsl
+
+        z, x, y = (16, 19300, 24647)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/510502210
+            dsl.way(510502210, dsl.tile_box(z, x, y), {
+                'highway': u'elevator',
+                'level': u'(-1,-2)',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 510502210,
+                'kind': u'elevator',
+            })
+
+    def test_elevator_node(self):
+        import dsl
+
+        z, x, y = (16, 19312, 24643)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3017396520
+            dsl.point(3017396520, (-73.911936, 40.699476), {
+                'highway': u'elevator',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3017396520,
+                'kind': u'elevator',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -977,3 +977,52 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 280081650,
                 'kind': u'cosmetics',
             })
+
+    def test_fishmonger_node(self):
+        import dsl
+
+        z, x, y = (16, 19327, 24641)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2274506529
+            dsl.point(2274506529, (-73.830344, 40.709093), {
+                'addr:housenumber': u'81-18',
+                'addr:street': u'Lefferts Boulevard',
+                'name': u'Kew Gardens Fish Market',
+                'shop': u'fishmonger',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2274506529,
+                'kind': u'fishmonger',
+            })
+
+    def test_fishmonger_way(self):
+        import dsl
+
+        z, x, y = (16, 19331, 24643)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/283172152
+            dsl.way(283172152, dsl.tile_box(z, x, y), {
+                'addr:city': u'Jamaica',
+                'addr:housenumber': u'91-02',
+                'addr:postcode': u'11435',
+                'addr:street': u'Sutphin Boulevard',
+                'building': u'yes',
+                'height': u'10.0',
+                'name': u'Corner Fish Market',
+                'nycdoitt:bin': u'4213900',
+                'shop': u'fishmonger',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 283172152,
+                'kind': u'fishmonger',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1298,3 +1298,22 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 481307273,
                 'kind': u'obelisk',
             })
+
+    def test_cutting_way(self):
+        import dsl
+
+        z, x, y = (16, 17064, 30550)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/283464048
+            dsl.way(283464048, dsl.tile_diagonal(z, x, y), {
+                'man_made': u'cutting',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 283464048,
+                'kind': u'cutting',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1216,3 +1216,22 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'kind': u'bunker',
                 'kind_detail': u'missile_silo',
             })
+
+    def test_wayside_cross_node(self):
+        import dsl
+
+        z, x, y = (16, 19309, 24677)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4987290359
+            dsl.point(4987290359, (-73.927802, 40.559544), {
+                'historic': u'wayside_cross',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4987290359,
+                'kind': u'wayside_cross',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1343,7 +1343,7 @@ class MoreOSMFeaturesTest(FixtureTest):
             z, x, y, 'roads', {
                 'id': 95467617,
                 'kind': u'rail',
-                'cutting': True,
+                'cutting': 'yes',
             })
 
     def test_railway_embankment_yes_way(self):
@@ -1373,5 +1373,68 @@ class MoreOSMFeaturesTest(FixtureTest):
             z, x, y, 'roads', {
                 'id': 95467611,
                 'kind': u'rail',
-                'embankment': True,
+                'embankment': 'yes',
+            })
+
+    def test_embankment_left_way(self):
+        import dsl
+
+        z, x, y = (16, 19715, 24176)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/430667681
+            dsl.way(430667681, dsl.tile_diagonal(z, x, y), {
+                'attribution': u'Office of Geographic and ' \
+                u'Environmental Information (MassGIS)',
+                'condition': u'fair',
+                'embankment': u'left',
+                'highway': u'residential',
+                'lanes': u'2',
+                'massgis:way_id': u'187669',
+                'name': u'South Row Road',
+                'source': u'openstreetmap.org',
+                'width': u'9.1',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 430667681,
+                'kind': u'minor_road',
+                'kind_detail': 'residential',
+                'embankment': 'left',
+            })
+
+    def test_embankment_both_way(self):
+        import dsl
+
+        z, x, y = (16, 16196, 25177)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/540442026
+            dsl.way(540442026, dsl.tile_diagonal(z, x, y), {
+                'embankment': u'both',
+                'hgv': u'designated',
+                'hgv:national_network': u'yes',
+                'highway': u'primary',
+                'lanes': u'2',
+                'maxspeed': u'55 mph',
+                'name': u'Highway 50',
+                'NHS': u'yes',
+                'ref': u'US 50',
+                'source': u'openstreetmap.org',
+                'surface': u'asphalt',
+                'tiger:cfcc': u'A21',
+                'tiger:county': u'Franklin, MO',
+                'tiger:reviewed': u'no',
+            }),
+        )
+
+        # NOTE: embankment=both is mapped to embankment:yes.
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 540442026,
+                'kind': u'major_road',
+                'kind_detail': 'primary',
+                'embankment': 'yes',
             })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -905,3 +905,24 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 1289222425,
                 'kind': u'plaque',
             })
+
+    def test_reef_way(self):
+        import dsl
+
+        z, x, y = (16, 59972, 36438)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/300536075
+            dsl.way(300536075, dsl.tile_box(z, x, y), {
+                'natural': u'reef',
+                'reef': u'coral',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 300536075,
+                'kind': u'reef',
+                'kind_detail': 'coral',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1026,3 +1026,193 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 283172152,
                 'kind': u'fishmonger',
             })
+
+    def test_pillbox_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 19298, 24706)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2576451001
+            dsl.point(2576451001, (-73.991799, 40.438530), {
+                'bunker_type': u'pillbox',
+                'military': u'bunker',
+                'name': u'Battery Kingman',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2576451001,
+                'kind': u'bunker',
+                'kind_detail': u'pillbox',
+            })
+
+    def test_munitions_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 13379, 25960)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3911068941
+            dsl.point(3911068941, (-106.505514, 34.991425), {
+                'access': u'no',
+                'bunker_type': u'munitions',
+                'location': u'underground',
+                'military': u'bunker',
+                'name': u'Point 105',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3911068941,
+                'kind': u'bunker',
+                'kind_detail': u'munitions',
+            })
+
+    def test_gun_emplacement_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 19470, 30932)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3516716377
+            dsl.point(3516716377, (-73.045059, 10.029707), {
+                'building': u'bunker',
+                'bunker_type': u'gun_emplacement',
+                'FIXME': u'name',
+                'landuse': u'military',
+                'military': u'bunker',
+                'name': u'Batallón de Alta Montaña',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3516716377,
+                'kind': u'bunker',
+                'kind_detail': u'gun_emplacement',
+            })
+
+    def test_hardened_aircraft_shelter_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 18873, 28902)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/462127948
+            dsl.point(462127948, (-76.326978, 20.766293), {
+                'building': u'bunker',
+                'bunker_type': u'hardened_aircraft_shelter',
+                'military': u'bunker',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 462127948,
+                'kind': u'bunker',
+                'kind_detail': u'hardened_aircraft_shelter',
+            })
+
+    def test_blockhouse_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 34926, 24316)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4687134694
+            dsl.point(4687134694, (11.854714, 42.045672), {
+                'building': u'bunker',
+                'bunker_type': u'blockhouse',
+                'landuse': u'military',
+                'military': u'bunker',
+                'name': u'Tobruk',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4687134694,
+                'kind': u'bunker',
+                'kind_detail': u'blockhouse',
+            })
+
+    def test_technical_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 31253, 23940)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4955741213
+            dsl.point(4955741213, (-8.318059, 43.563983), {
+                'abandoned': u'yes',
+                'bunker_type': u'technical',
+                'description': u'Antigua batería militar',
+                'historic': u'yes',
+                'military': u'bunker',
+                'name': u'Proyectores B6',
+                'official_name': u'Batería Militar 6',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4955741213,
+                'kind': u'bunker',
+                'kind_detail': u'technical',
+            })
+
+    def test_mg_nest_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 32669, 24924)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4949636318
+            dsl.point(4949636318, (-0.541801, 39.518136), {
+                'bunker_type': u'mg_nest',
+                'historic': u'yes',
+                'military': u'bunker',
+                'ruins': u'no',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4949636318,
+                'kind': u'bunker',
+                'kind_detail': u'mg_nest',
+            })
+
+    def test_missile_silo_bunker_node(self):
+        import dsl
+
+        z, x, y = (16, 10814, 26017)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5434097308
+            dsl.point(5434097308, (-120.596493, 34.734051), {
+                'building': u'bunker',
+                'bunker_type': u'missile_silo',
+                'landuse': u'military',
+                'military': u'bunker',
+                'name': u'Titan--',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5434097308,
+                'kind': u'bunker',
+                'kind_detail': u'missile_silo',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -269,3 +269,23 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 510028688,
                 'kind': u'miniature_golf',
             })
+
+    def test_mud_way(self):
+        import dsl
+
+        z, x, y = (16, 19455, 24611)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/451611986
+            dsl.way(451611986, dsl.tile_box(z, x, y), {
+                'name': u'mud',
+                'natural': u'mud',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 451611986,
+                'kind': u'mud',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1235,3 +1235,28 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 4987290359,
                 'kind': u'wayside_cross',
             })
+
+    def test_memorial_plaque_node(self):
+        import dsl
+
+        z, x, y = (16, 32531, 21365)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3577265515
+            dsl.point(3577265515, (-1.297031, 52.944488), {
+                'dedicatee': u'Oswald Short',
+                'historic': u'memorial_plaque',
+                'inscription': u'Oswald Short (1883-1969) of Short ' \
+                u'Brothers Aeronautical Engineers / Lived here ' \
+                u'1881-c.1895 / Erected by public subscription',
+                'name': u'Oswald Short (1883-1969)',
+                'plaque:colour': u'blue',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3577265515,
+                'kind': u'plaque',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -289,3 +289,579 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 451611986,
                 'kind': u'mud',
             })
+
+    def test_agave_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 30230, 27328)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/513078325
+            dsl.way(513078325, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'agave_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 513078325,
+                'kind': u'orchard',
+                'kind_detail': u'agave_plants',
+            })
+
+    def test_almond_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 18136, 33416)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/532775111
+            dsl.way(532775111, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'almond_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 532775111,
+                'kind': u'orchard',
+                'kind_detail': u'almond_trees',
+            })
+
+    def test_apple_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 19240, 24746)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/40150611
+            dsl.way(40150611, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'name': u'Battleview Orchards',
+                'source': u'openstreetmap.org',
+                'trees': u'apple_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 40150611,
+                'kind': u'orchard',
+                'kind_detail': u'apple_trees',
+            })
+
+    def test_avocado_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 18505, 32780)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/512033575
+            dsl.way(512033575, dsl.tile_box(z, x, y), {
+                'genus': u'Persea',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'species': u'Persea americana Mill.',
+                'trees': u'avocado_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 512033575,
+                'kind': u'orchard',
+                'kind_detail': u'avocado_trees',
+            })
+
+    def test_banana_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 19570, 29284)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/193575953
+            dsl.way(193575953, dsl.tile_box(z, x, y), {
+                'fixme': u'position',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'banana_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 193575953,
+                'kind': u'orchard',
+                'kind_detail': u'banana_plants',
+            })
+
+    def test_cherry_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 16764, 29918)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/399567949
+            dsl.way(399567949, dsl.tile_box(z, x, y), {
+                'genus': u'Musa',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'cherry_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 399567949,
+                'kind': u'orchard',
+                'kind_detail': u'cherry_trees',
+            })
+
+    def test_coconut_palms_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 20064, 29188)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/179537246
+            dsl.way(179537246, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'name': u'Coco',
+                'source': u'openstreetmap.org',
+                'trees': u'coconut_palms',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 179537246,
+                'kind': u'orchard',
+                'kind_detail': u'coconut_palms',
+            })
+
+    def test_coffea_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 15130, 29155)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/358441066
+            dsl.way(358441066, dsl.tile_box(z, x, y), {
+                'crop': u'coffee',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'coffea_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 358441066,
+                'kind': u'orchard',
+                'kind_detail': u'coffea_plants',
+            })
+
+    def test_date_palms_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 19090, 30857)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/89570508
+            dsl.way(89570508, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'name': u'Cultivo de Palma',
+                'produce': u'Vegetal Oil for Biodiesel',
+                'source': u'openstreetmap.org',
+                'trees': u'date_palms',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 89570508,
+                'kind': u'orchard',
+                'kind_detail': u'date_palms',
+            })
+
+    def test_hazel_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 32233, 30965)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/554513274
+            dsl.way(554513274, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'hazel_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 554513274,
+                'kind': u'orchard',
+                'kind_detail': u'hazel_plants',
+            })
+
+    def test_hop_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 19947, 23903)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/491352755
+            dsl.way(491352755, dsl.tile_box(z, x, y), {
+                'genus': u'Humulus',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'hop_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 491352755,
+                'kind': u'orchard',
+                'kind_detail': u'hop_plants',
+            })
+
+    def test_kiwi_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 10909, 25550)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/61037561
+            dsl.way(61037561, dsl.tile_box(z, x, y), {
+                'attribution': u'Fresno_County_GIS',
+                'genus': u'Actinidia',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'kiwi_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 61037561,
+                'kind': u'orchard',
+                'kind_detail': u'kiwi_plants',
+            })
+
+    def test_macadamia_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 16240, 30096)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/147212021
+            dsl.way(147212021, dsl.tile_box(z, x, y), {
+                'designation': u'Las Macadamias',
+                'genus': u'Macadamia',
+                'landuse': u'orchard',
+                'name': u'Valhalla Farm',
+                'source': u'openstreetmap.org',
+                'trees': u'macadamia_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 147212021,
+                'kind': u'orchard',
+                'kind_detail': u'macadamia_trees',
+            })
+
+    def test_mango_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 19546, 29340)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/109112765
+            dsl.way(109112765, dsl.tile_box(z, x, y), {
+                'addr:city': u'leogane',
+                'addr:street': u'cassagne',
+                'commune': u'leogane',
+                'departement': u'l\'ouest',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'mango_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 109112765,
+                'kind': u'orchard',
+                'kind_detail': u'mango_trees',
+            })
+
+    def test_olive_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 18135, 33416)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/532775110
+            dsl.way(532775110, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'olive_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 532775110,
+                'kind': u'orchard',
+                'kind_detail': u'olive_trees',
+            })
+
+    def test_orange_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 15048, 28966)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/328878925
+            dsl.way(328878925, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'orange_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 328878925,
+                'kind': u'orchard',
+                'kind_detail': u'orange_trees',
+            })
+
+    def test_papaya_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 15196, 29232)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/399116133
+            dsl.way(399116133, dsl.tile_box(z, x, y), {
+                'genus': u'Carica',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'species': u'Carica papaya',
+                'trees': u'papaya_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 399116133,
+                'kind': u'orchard',
+                'kind_detail': u'papaya_trees',
+            })
+
+    def test_peach_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 17827, 25945)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/423428753
+            dsl.way(423428753, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'peach_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 423428753,
+                'kind': u'orchard',
+                'kind_detail': u'peach_trees',
+            })
+
+    def test_persimmon_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 10879, 25716)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/61193578
+            dsl.way(61193578, dsl.tile_box(z, x, y), {
+                'attribution': u'Fresno_County_GIS',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'persimmon_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 61193578,
+                'kind': u'orchard',
+                'kind_detail': u'persimmon_trees',
+            })
+
+    def test_pineapple_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 17741, 31218)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/497946838
+            dsl.way(497946838, dsl.tile_box(z, x, y), {
+                'genus': u'Ananas',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'pineapple_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 497946838,
+                'kind': u'orchard',
+                'kind_detail': u'pineapple_plants',
+            })
+
+    def test_pitaya_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 17075, 30576)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/541768573
+            dsl.way(541768573, dsl.tile_box(z, x, y), {
+                'genus': u'Hylocereus',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'pitaya_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 541768573,
+                'kind': u'orchard',
+                'kind_detail': u'pitaya_plants',
+            })
+
+    def test_plum_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 10976, 25637)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/61206687
+            dsl.way(61206687, dsl.tile_box(z, x, y), {
+                'attribution': u'Fresno_County_GIS',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'plum_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 61206687,
+                'kind': u'orchard',
+                'kind_detail': u'plum_trees',
+            })
+
+    def test_rubber_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 16028, 30065)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/396725369
+            dsl.way(396725369, dsl.tile_box(z, x, y), {
+                'genus': u'Ficus',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'species': u'Ficus elastica',
+                'trees': u'rubber_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 396725369,
+                'kind': u'orchard',
+                'kind_detail': u'rubber_trees',
+            })
+
+    def test_tea_plants_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 18575, 33078)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/463858557
+            dsl.way(463858557, dsl.tile_box(z, x, y), {
+                'genus': u'Camellia',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'species': u'Camellia sinensis (L.) Kuntze',
+                'trees': u'tea_plants',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 463858557,
+                'kind': u'orchard',
+                'kind_detail': u'tea_plants',
+            })
+
+    def test_walnut_trees_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 10774, 25826)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/242904453
+            dsl.way(242904453, dsl.tile_box(z, x, y), {
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'walnut_trees',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 242904453,
+                'kind': u'orchard',
+                'kind_detail': u'walnut_trees',
+            })
+
+    def test_oil_palms_orchard_way(self):
+        import dsl
+
+        z, x, y = (16, 16793, 29899)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/394728216
+            dsl.way(394728216, dsl.tile_box(z, x, y), {
+                'genus': u'Elaeis',
+                'landuse': u'orchard',
+                'source': u'openstreetmap.org',
+                'trees': u'oil_palms',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 394728216,
+                'kind': u'orchard',
+                'kind_detail': u'oil_palms',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -941,7 +941,7 @@ class MoreOSMFeaturesTest(FixtureTest):
         )
 
         self.assert_has_feature(
-            z, x, y, 'landuse', {
+            z, x, y, 'water', {
                 'id': 300536075,
                 'kind': u'reef',
                 'kind_detail': 'coral',

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1,0 +1,153 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class MoreOSMFeaturesTest(FixtureTest):
+
+    def test_sand_beach_way(self):
+        import dsl
+
+        z, x, y = (16, 19335, 24602)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/108403305
+            dsl.way(108403305, dsl.tile_box(z, x, y), {
+                'ele': u'2',
+                'gnis:feature_id': u'959437',
+                'name': u'Orchard Beach',
+                'natural': u'beach',
+                'source': u'openstreetmap.org',
+                'surface': u'sand',
+                'wikidata': u'Q7100176',
+                'wikipedia': u'en:Orchard Beach, Bronx',
+            }),
+        )
+
+        for layer in ('pois', 'landuse'):
+            self.assert_has_feature(
+                z, x, y, layer, {
+                    'id': 108403305,
+                    'kind': u'beach',
+                    'kind_detail': u'sand',
+                })
+
+    def test_pebblestone_beach_way(self):
+        import dsl
+
+        z, x, y = (16, 19253, 24394)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/233695433
+            dsl.way(233695433, dsl.tile_box(z, x, y), {
+                'access': u'yes',
+                'name': u'Lake Minnewaska Beach',
+                'natural': u'beach',
+                'source': u'openstreetmap.org',
+                'surface': u'pebblestone',
+            }),
+        )
+
+        for layer in ('pois', 'landuse'):
+            self.assert_has_feature(
+                z, x, y, layer, {
+                    'id': 233695433,
+                    'kind': u'beach',
+                    'kind_detail': u'pebblestone',
+                })
+
+    def test_gravel_beach_way(self):
+        import dsl
+
+        z, x, y = (16, 19304, 24371)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/360547782
+            dsl.way(360547782, dsl.tile_box(z, x, y), {
+                'natural': u'beach',
+                'source': u'openstreetmap.org',
+                'surface': u'gravel',
+                # fake name to get the POI to appear
+                'name': 'Fake beach name',
+            }),
+        )
+
+        for layer in ('pois', 'landuse'):
+            self.assert_has_feature(
+                z, x, y, layer, {
+                    'id': 360547782,
+                    'kind': u'beach',
+                    'kind_detail': u'gravel',
+                })
+
+    def test_pebbles_beach_way(self):
+        import dsl
+
+        z, x, y = (16, 19296, 24645)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/328291105
+            dsl.way(328291105, dsl.tile_box(z, x, y), {
+                'natural': u'beach',
+                'source': u'openstreetmap.org',
+                'surface': u'pebbles',
+                # fake name to get the POI to appear
+                'name': 'Fake beach name',
+            }),
+        )
+
+        for layer in ('pois', 'landuse'):
+            self.assert_has_feature(
+                z, x, y, layer, {
+                    'id': 328291105,
+                    'kind': u'beach',
+                    'kind_detail': u'pebbles',
+                })
+
+    def test_grass_beach_way(self):
+        import dsl
+
+        z, x, y = (16, 19124, 24555)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/231284265
+            dsl.way(231284265, dsl.tile_box(z, x, y), {
+                'natural': u'beach',
+                'source': u'openstreetmap.org',
+                'surface': u'grass',
+                # fake name to get the POI to appear
+                'name': 'Fake beach name',
+            }),
+        )
+
+        for layer in ('pois', 'landuse'):
+            self.assert_has_feature(
+                z, x, y, layer, {
+                    'id': 231284265,
+                    'kind': u'beach',
+                    'kind_detail': u'grass',
+                })
+
+    def test_rocky_beach_way(self):
+        import dsl
+
+        z, x, y = (16, 19039, 24855)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/322805403
+            dsl.way(322805403, dsl.tile_box(z, x, y), {
+                'access': u'no',
+                'natural': u'beach',
+                'source': u'openstreetmap.org',
+                'surface': u'rocky',
+                # fake name to get the POI to appear
+                'name': 'Fake beach name',
+            }),
+        )
+
+        for layer in ('pois', 'landuse'):
+            self.assert_has_feature(
+                z, x, y, layer, {
+                    'id': 322805403,
+                    'kind': u'beach',
+                    'kind_detail': u'rocky',
+                })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1557,3 +1557,92 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'kind': u'bunker',
                 'min_zoom': 18,
             })
+
+    def test_washington_monument(self):
+        import dsl
+
+        z, x, y = (16, 18744, 25072)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/3374540
+            dsl.way(3374540, dsl.tile_box(z, x, y), {
+                "addr:city": "Washington",
+                "addr:housenumber": "1601",
+                "addr:postcode": "20560",
+                "addr:state": "DC",
+                "addr:street": "Independence Avenue",
+                "building": "obelisk",
+                "building:colour": "white",
+                "dcgis:address": "1601 Independence Ave, NW",
+                "dcgis:aid": "294406",
+                "dcgis:gis": "HSE_0015",
+                "dcgis:list_info": "Reg",
+                "dcgis:nr_eligibl": "0",
+                "dcgis:objectid": "259",
+                "dcgis:ssl": "PAR 03160011",
+                "dcgis:update_date": "Wed Feb 01 00:00:00 UTC 2006",
+                "fee": "no",
+                "height": "169.16",
+                "historic": "monument",
+                "landmark": "yes",
+                "man_made": "obelisk",
+                "memorial:type": "obelisk",
+                "name": "Washington Monument",
+                "name:da": u"Washington-monumentet",
+                "name:de": u"Washington-Denkmal",
+                "name:es": u"Monumento a Washington",
+                "name:hu": u"Washington-emlékmű",
+                "name:it": u"Monumento a Washington",
+                "obelisk:size": "monumental",
+                "roof:colour": "white",
+                "roof:height": "16.76",
+                "roof:shape": "pyramidal",
+                "start_date": "1885-02-28",
+                "tourism": "attraction",
+                "type": "multipolygon",
+                "wikidata": "Q178114",
+                "wikipedia": "en:Washington Monument",
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3374540,
+                'kind': u'obelisk',
+                'min_zoom': 14,
+            })
+
+    def test_obelisco_macuteo(self):
+        import dsl
+
+        z, x, y = (16, 35039, 24352)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/128740184
+            dsl.way(128740184, dsl.tile_box(z, x, y), {
+                'artwork_type': u'obelisk',
+                'height': u'14.52',
+                'historic': u'monument',
+                'historic:civilization': u'ancient_egyptian',
+                'historic:era': u'dynasty_XIX',
+                'historic:period': u'new_kingdom',
+                'man_made': u'obelisk',
+                'name': u'Obelisco Macuteo',
+                'obelisk:height': u'6.34',
+                'obelisk:material': u'red_granite',
+                'obelisk:size': u'monumental',
+                'source': u'openstreetmap.org',
+                'start_date': u'C13 BC',
+                'tourism': u'artwork',
+                'wikidata': u'Q3348569',
+                'wikipedia': u'it:Obelisco del Pantheon',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 128740184,
+                'kind': u'obelisk',
+                'min_zoom': 15,
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -210,3 +210,22 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 3017396520,
                 'kind': u'elevator',
             })
+
+    def test_embankment_way(self):
+        import dsl
+
+        z, x, y = (16, 19317, 24645)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/374783696
+            dsl.way(374783696, dsl.tile_diagonal(z, x, y), {
+                'man_made': u'embankment',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 374783696,
+                'kind': u'embankment',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -926,3 +926,54 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'kind': u'reef',
                 'kind_detail': 'coral',
             })
+
+    def test_cosmetics_node(self):
+        import dsl
+
+        z, x, y = (16, 19299, 24646)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5343308393
+            dsl.point(5343308393, (-73.986721, 40.687488), {
+                'name': u'Anwaar Co.',
+                'phone': u'+1 718 875 3791',
+                'shop': u'cosmetics',
+                'source': u'openstreetmap.org',
+                'website': u'http://anwaarco.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5343308393,
+                'kind': u'cosmetics',
+            })
+
+    def test_cosmetics_way(self):
+        import dsl
+
+        z, x, y = (16, 19305, 24637)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/280081650
+            dsl.way(280081650, dsl.tile_box(z, x, y), {
+                'addr:city': u'Brooklyn',
+                'addr:housenumber': u'95',
+                'addr:postcode': u'11222',
+                'addr:state': u'NY',
+                'addr:street': u'Nassau Avenue',
+                'building': u'yes',
+                'height': u'15.1',
+                'name': u'Ziolko Cosmetics & Herbal',
+                'nycdoitt:bin': u'3322680',
+                'phone': u'718 609 9279',
+                'shop': u'cosmetics',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 280081650,
+                'kind': u'cosmetics',
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1509,3 +1509,51 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'kind': u'obelisk',
                 'kind_detail': u'monument',
             })
+
+    def test_bunker_name_z16_way(self):
+        import dsl
+
+        z, x, y = (16, 19286, 24667)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/35099149
+            dsl.way(35099149, dsl.tile_box(z, x, y), {
+                'building': u'yes',
+                'historic': u'ruins',
+                'military': u'bunker',
+                'name': u'Battery Upton',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # bunker _with name_ should have z16
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 35099149,
+                'kind': u'bunker',
+                'min_zoom': 16,
+            })
+
+    def test_bunker_noname_z18_way(self):
+        import dsl
+
+        z, x, y = (16, 19286, 24665)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/35136899
+            dsl.way(35136899, dsl.tile_box(z, x, y), {
+                'building': u'yes',
+                'description': u'watchtower CRF North coincident range finder',
+                'historic': u'ruins',
+                'level': u'-1',
+                'military': u'bunker',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 35136899,
+                'kind': u'bunker',
+                'min_zoom': 18,
+            })

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -55,7 +55,7 @@ class MoreOSMFeaturesTest(FixtureTest):
                     'kind_detail': u'pebblestone',
                 })
 
-    def test_gravel_beach_way(self):
+    def test_gravel_beach_pois_way(self):
         import dsl
 
         z, x, y = (16, 19304, 24371)
@@ -71,13 +71,33 @@ class MoreOSMFeaturesTest(FixtureTest):
             }),
         )
 
-        for layer in ('pois', 'landuse'):
-            self.assert_has_feature(
-                z, x, y, layer, {
-                    'id': 360547782,
-                    'kind': u'beach',
-                    'kind_detail': u'gravel',
-                })
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 360547782,
+                'kind': u'beach',
+                'kind_detail': u'gravel',
+            })
+
+    def test_gravel_beach_landuse_way(self):
+        import dsl
+
+        z, x, y = (16, 19304, 24371)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/360547782
+            dsl.way(360547782, dsl.tile_box(z, x, y), {
+                'natural': u'beach',
+                'source': u'openstreetmap.org',
+                'surface': u'gravel',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 360547782,
+                'kind': u'beach',
+                'kind_detail': u'gravel',
+            })
 
     def test_pebbles_beach_way(self):
         import dsl

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -1317,3 +1317,61 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'id': 283464048,
                 'kind': u'cutting',
             })
+
+    def test_railway_cutting_yes_way(self):
+        import dsl
+
+        z, x, y = (16, 19279, 24646)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/95467617
+            dsl.way(95467617, dsl.tile_diagonal(z, x, y), {
+                'cutting': u'yes',
+                'electrified': u'no',
+                'gauge': u'1435',
+                'maxspeed': u'15 mph',
+                'name': u'Bayonne Connection',
+                'railway': u'rail',
+                'railway:traffic_mode': u'freight',
+                'source': u'openstreetmap.org',
+                'source:maxspeed': u'Conrail ETT 2013-10-17',
+                'usage': u'industrial',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 95467617,
+                'kind': u'rail',
+                'cutting': True,
+            })
+
+    def test_railway_embankment_yes_way(self):
+        import dsl
+
+        z, x, y = (16, 19278, 24646)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/95467611
+            dsl.way(95467611, dsl.tile_diagonal(z, x, y), {
+                'electrified': u'no',
+                'embankment': u'yes',
+                'gauge': u'1435',
+                'maxspeed': u'25 mph',
+                'name': u'National Docks Branch',
+                'old_railway_operator': u'LV',
+                'operator': u'Conrail',
+                'railway': u'rail',
+                'railway:traffic_mode': u'freight',
+                'source': u'openstreetmap.org',
+                'source:maxspeed': u'Conrail ETT 2013-10-17',
+                'usage': u'branch',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 95467611,
+                'kind': u'rail',
+                'embankment': True,
+            })

--- a/scripts/mktest.py
+++ b/scripts/mktest.py
@@ -362,7 +362,7 @@ class _OverpassWay(object):
         point = element['geometry'][0]
         self.position = tuple(point[p] for p in ('lat', 'lon'))
         self.element_id = element['id']
-        self.tags = element['tags']
+        self.tags = element.get('tags', {})
 
     def element_type(self):
         return 'way'

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -976,7 +976,10 @@ filters:
     output:
       <<: *output_properties
       kind: wetland
-      kind_detail: {col: wetland}
+      kind_detail:
+        case:
+          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
+            then: {col: wetland}
   - filter: {natural: park}
     min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
     output:

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -493,6 +493,17 @@ filters:
       <<: *output_properties
       kind: glacier
       tier: 3
+  # reef
+  - filter: {natural: reef}
+    min_zoom: *tier3_min_zoom
+    output:
+      <<: *output_properties
+      kind: reef
+      tier: 3
+      kind_detail:
+        case:
+          - when: { reef: [coral, rock, sand] }
+            then: { col: reef }
 
   ############################################################
   # TIER 4

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -1151,11 +1151,11 @@ filters:
     output:
       <<: *output_properties
       kind: {col: barrier}
-  - filter: {man_made: embankment}
+  - filter: {man_made: [embankment, cutting]}
     min_zoom: 16
     output:
       <<: *output_properties
-      kind: embankment
+      kind: { col: man_made }
   - filter:
       military: danger_area
       geom_type: polygon

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -766,6 +766,43 @@ filters:
         case:
           - when: {surface: [grass, gravel, pebbles, pebblestone, rocky, sand]}
             then: {col: surface}
+  # orchard
+  - filter: { landuse: orchard }
+    min_zoom: *tier5_min_zoom
+    output:
+      <<: *output_properties
+      kind: orchard
+      kind_detail:
+        case:
+          - when:
+              trees:
+                - agave_plants
+                - almond_trees
+                - apple_trees
+                - avocado_trees
+                - banana_plants
+                - cherry_trees
+                - coconut_palms
+                - coffea_plants
+                - date_palms
+                - hazel_plants
+                - hop_plants
+                - kiwi_plants
+                - macadamia_trees
+                - mango_trees
+                - oil_palms
+                - olive_trees
+                - orange_trees
+                - papaya_trees
+                - peach_trees
+                - persimmon_trees
+                - pineapple_plants
+                - pitaya_plants
+                - plum_trees
+                - rubber_trees
+                - tea_plants
+                - walnut_trees
+            then: { col: trees }
 
   ############################################################
   # TIER 6

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -493,17 +493,6 @@ filters:
       <<: *output_properties
       kind: glacier
       tier: 3
-  # reef
-  - filter: {natural: reef}
-    min_zoom: *tier3_min_zoom
-    output:
-      <<: *output_properties
-      kind: reef
-      tier: 3
-      kind_detail:
-        case:
-          - when: { reef: [coral, rock, sand] }
-            then: { col: reef }
 
   ############################################################
   # TIER 4

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -803,6 +803,12 @@ filters:
                 - tea_plants
                 - walnut_trees
             then: { col: trees }
+  # plant nursery
+  - filter: { landuse: plant_nursery }
+    min_zoom: *tier5_min_zoom
+    output:
+      <<: *output_properties
+      kind: plant_nursery
 
   ############################################################
   # TIER 6

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -133,8 +133,12 @@ global:
         - US National Park Service
         - U.S. National Park Service
         - US National Park service
+  # whitelist for leaf_type
   - &leaftype_kind_detail
-    kind_detail: { col: leaf_type }
+    kind_detail:
+      case:
+        - when: {leaf_type: [broadleaved, leafless, mixed, needleleaved]}
+          then: {col: leaf_type}
 filters:
   - filter: {meta.source: ne}
     min_zoom: 4

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -756,6 +756,12 @@ filters:
       <<: *output_properties
       kind: beach
       tier: 5
+      # whitelist most common surface values for beaches. i'm not quite sure i'd
+      # call surface=grass a beach, but it's in the data..?
+      kind_detail:
+        case:
+          - when: {surface: [grass, gravel, pebbles, pebblestone, rocky, sand]}
+            then: {col: surface}
 
   ############################################################
   # TIER 6

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -1085,6 +1085,11 @@ filters:
     output:
       <<: *output_properties
       kind: {col: barrier}
+  - filter: {man_made: embankment}
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: embankment
   - filter:
       military: danger_area
       geom_type: polygon

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -1030,6 +1030,11 @@ filters:
     output:
       <<: *output_properties
       kind: rock
+  - filter: {natural: mud}
+    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
+    output:
+      <<: *output_properties
+      kind: mud
   - filter: {tourism: caravan_site}
     min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
     output:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -960,7 +960,7 @@ filters:
       <<: *output_properties
       kind: {col: craft}
   - filter:
-      shop: [charity, chemist, cosmetics, furniture, golf, pet, shoes, variety_store]
+      shop: [charity, chemist, cosmetics, fishmonger, furniture, golf, pet, shoes, variety_store]
     min_zoom: { clamp: { min: 0, max: 17, value: { sum: [ { col: zoom }, 3.3 ] } } }
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -190,7 +190,7 @@ global:
         - harbour: harbour_master
         - highway: [ bus_stop, elevator, ford, mini_roundabout, motorway_junction, platform,
             rest_area, street_lamp, traffic_signals, trailhead ]
-        - historic: landmark
+        - historic: [landmark, wayside_cross]
         - landuse: quarry
         - leisure: [ dog_park, firepit, fishing, pitch, slipway, swimming_area ]
         - lock: yes
@@ -2134,6 +2134,12 @@ filters:
     output:
       <<: *output_properties
       kind: elevator
+
+  - filter: { historic: wayside_cross }
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: wayside_cross
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1156,6 +1156,17 @@ filters:
     output:
       <<: *output_properties
       kind: motorway_junction
+  # obelisk - note that this takes precedence over monument and memorial!
+  - filter: {man_made: obelisk}
+    min_zoom: { clamp: { min: 15, max: 17, value: { sum: [ { col: zoom }, 2.24 ] } } }
+    output:
+      <<: *output_properties
+      kind: obelisk
+      # keep information about whether this was a monument or memorial
+      kind_detail:
+        case:
+          - when: {historic: [monument, memorial]}
+            then: {col: historic}
   - filter: {historic: monument}
     min_zoom: { clamp: { min: 15, max: 17, value: { sum: [ { col: zoom }, 2.24 ] } } }
     output:
@@ -1608,12 +1619,6 @@ filters:
     output:
       <<: *output_properties
       kind: memorial
-  # obelisk - but not a monument or a memorial
-  - filter: {man_made: obelisk}
-    min_zoom: 17
-    output:
-      <<: *output_properties
-      kind: obelisk
   # slipway with mooring info
   - filter:
       leisure: slipway

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -194,7 +194,7 @@ global:
         - landuse: quarry
         - leisure: [ dog_park, firepit, fishing, pitch, slipway, swimming_area ]
         - lock: yes
-        - man_made: [ adit, communications_tower, crane, mast, mineshaft, observatory,
+        - man_made: [ adit, communications_tower, crane, mast, mineshaft, obelisk, observatory,
             offshore_platform, petroleum_well, power_wind, telescope, water_tower,
             water_well, watermill, windmill ]
         - military: bunker
@@ -1608,6 +1608,12 @@ filters:
     output:
       <<: *output_properties
       kind: memorial
+  # obelisk - but not a monument or a memorial
+  - filter: {man_made: obelisk}
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: obelisk
   # slipway with mooring info
   - filter:
       leisure: slipway

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -960,7 +960,7 @@ filters:
       <<: *output_properties
       kind: {col: craft}
   - filter:
-      shop: [charity, chemist, furniture, golf, pet, shoes, variety_store]
+      shop: [charity, chemist, cosmetics, furniture, golf, pet, shoes, variety_store]
     min_zoom: { clamp: { min: 0, max: 17, value: { sum: [ { col: zoom }, 3.3 ] } } }
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -188,7 +188,7 @@ global:
           - lifeguard_tower
           - phone
         - harbour: harbour_master
-        - highway: [ bus_stop, ford, mini_roundabout, motorway_junction, platform,
+        - highway: [ bus_stop, elevator, ford, mini_roundabout, motorway_junction, platform,
             rest_area, street_lamp, traffic_signals, trailhead ]
         - historic: landmark
         - landuse: quarry
@@ -2105,6 +2105,12 @@ filters:
     output:
       <<: *output_properties
       kind: sanitary_dump_station
+
+  - filter: {highway: elevator}
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: elevator
 
   ############################################################
   # TIER 6 EXTRA - ATTRACTION

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -500,7 +500,7 @@ filters:
       tier: 3
   # bunker
   - filter: {military: bunker}
-    min_zoom: 16
+    min_zoom: {case: [{when: {name: true}, then: 16}, {else: 18}]}
     output:
       <<: *output_properties
       kind: bunker

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -781,6 +781,26 @@ filters:
       kind: winery
       tier: 5
 
+  # obelisk - note that this takes precedence over artwork, monument and memorial!
+  - filter: {man_made: obelisk}
+    min_zoom:
+      lookup:
+        key: { call: { func: mz_to_float_meters, args: [ { col: height } ] } }
+        op: '>='
+        table:
+          - [ 14, 20 ]  # z14 if height >= 20m
+          - [ 15, 10 ]  # z15 if height >= 10m
+        default: 16
+    output:
+      <<: *output_properties
+      kind: obelisk
+      tier: 5
+      # keep information about whether this was a monument or memorial
+      kind_detail:
+        case:
+          - when: {historic: [monument, memorial]}
+            then: {col: historic}
+
   ############################################################
   # TIER 6
   ############################################################
@@ -1156,17 +1176,6 @@ filters:
     output:
       <<: *output_properties
       kind: motorway_junction
-  # obelisk - note that this takes precedence over monument and memorial!
-  - filter: {man_made: obelisk}
-    min_zoom: { clamp: { min: 15, max: 17, value: { sum: [ { col: zoom }, 2.24 ] } } }
-    output:
-      <<: *output_properties
-      kind: obelisk
-      # keep information about whether this was a monument or memorial
-      kind_detail:
-        case:
-          - when: {historic: [monument, memorial]}
-            then: {col: historic}
   - filter: {historic: monument}
     min_zoom: { clamp: { min: 15, max: 17, value: { sum: [ { col: zoom }, 2.24 ] } } }
     output:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1594,7 +1594,10 @@ filters:
       <<: *output_properties
       kind: {col: highway}
   # memorial plaques more specific than plain memorials
-  - filter: {historic: memorial, memorial: plaque}
+  - filter:
+      any:
+        - {historic: memorial, memorial: plaque}
+        - historic: memorial_plaque
     min_zoom: 16
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -197,6 +197,7 @@ global:
         - man_made: [ adit, communications_tower, crane, mast, mineshaft, observatory,
             offshore_platform, petroleum_well, power_wind, telescope, water_tower,
             water_well, watermill, windmill ]
+        - military: bunker
         - mooring: true
         - natural: [ cave_entrance, peak, volcano, geyser, hot_spring, rock, saddle,
             stone, spring, tree, waterfall ]
@@ -497,6 +498,16 @@ filters:
       <<: *output_properties
       kind: danger_area
       tier: 3
+  # bunker
+  - filter: {military: bunker}
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: bunker
+      kind_detail:
+        case:
+          - when: { bunker_type: [pillbox, munitions, gun_emplacement, hardened_aircraft_shelter, blockhouse, technical, mg_nest, missile_silo] }
+            then: { col: bunker_type }
   # military
   - filter: {landuse: military}
     min_zoom: { min: [ { max: [ 8, { sum: [ { col: zoom }, 2 ] }, *tier3_min_zoom ] }, 14 ] }

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1582,6 +1582,13 @@ filters:
     output:
       <<: *output_properties
       kind: {col: highway}
+  # memorial plaques more specific than plain memorials
+  - filter: {historic: memorial, memorial: plaque}
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: plaque
+  # plain memorial
   - filter: {historic: memorial}
     min_zoom: 17
     output:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -2000,6 +2000,11 @@ filters:
     output:
       <<: *output_properties
       kind: firepit
+  - filter: {leisure: miniature_golf}
+    min_zoom: { clamp: { min: 16, max: 17, value: { sum: [ { col: zoom }, 1 ] } } }
+    output:
+      <<: *output_properties
+      kind: miniature_golf
   - filter: {tourism: caravan_site}
     min_zoom: { clamp: { min: 14, max: 15, value: { col: zoom } } }
     output:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -2139,7 +2139,7 @@ filters:
       kind: sanitary_dump_station
 
   - filter: {highway: elevator}
-    min_zoom: 16
+    min_zoom: 17
     output:
       <<: *output_properties
       kind: elevator

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -730,6 +730,12 @@ filters:
       <<: *output_properties
       kind: beach
       tier: 5
+      # whitelist most common surface values for beaches. i'm not quite sure i'd
+      # call surface=grass a beach, but it's in the data..?
+      kind_detail:
+        case:
+          - when: {surface: [grass, gravel, pebbles, pebblestone, rocky, sand]}
+            then: {col: surface}
   # glacier - no POI
   # maze
   - filter:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -960,7 +960,7 @@ filters:
       <<: *output_properties
       kind: {col: craft}
   - filter:
-      shop: [charity, furniture, golf, pet, shoes, variety_store]
+      shop: [charity, chemist, furniture, golf, pet, shoes, variety_store]
     min_zoom: { clamp: { min: 0, max: 17, value: { sum: [ { col: zoom }, 3.3 ] } } }
     output:
       <<: *output_properties

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -80,12 +80,16 @@ global:
       sidewalk_right: {col: 'sidewalk:right'}
       cutting:
         case:
-          - when: {cutting: ['yes', 'right', 'left', 'both']}
-            then: true
+          - when: {cutting: ['yes', right, left]}
+            then: {col: cutting}
+          - when: {cutting: both}
+            then: 'yes'
       embankment:
         case:
-          - when: {embankment: ['yes', 'right', 'left', 'two_sided', 'both']}
-            then: true
+          - when: {embankment: ['yes', right, left]}
+            then: {col: embankment}
+          - when: {embankment: [both, two_sided]}
+            then: 'yes'
   - &osm_network
       mz_networks: {col: mz_networks}
       network: {col: network}

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -78,6 +78,14 @@ global:
       sidewalk: {col: sidewalk}
       sidewalk_left: {col: 'sidewalk:left'}
       sidewalk_right: {col: 'sidewalk:right'}
+      cutting:
+        case:
+          - when: {cutting: ['yes', 'right', 'left', 'both']}
+            then: true
+      embankment:
+        case:
+          - when: {embankment: ['yes', 'right', 'left', 'two_sided', 'both']}
+            then: true
   - &osm_network
       mz_networks: {col: mz_networks}
       network: {col: network}

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -119,6 +119,19 @@ filters:
       <<: *water_standard_properties_osm
       kind: drain
     table: osm
+  # reef
+  - filter:
+      natural: reef
+      geom_type: polygon
+    min_zoom: *water_standard_min_zoom
+    output:
+      <<: *water_standard_properties_osm
+      kind: reef
+      kind_detail:
+        case:
+          - when: { reef: [coral, rock, sand] }
+            then: { col: reef }
+    table: osm
   - filter: {featurecla: Coastline}
     min_zoom: 0
     output:


### PR DESCRIPTION
New kinds:

* `chemist`
* `elevator`
* `embankment` (also an `embankment` property on roads and railways, and `cutting`)
* `miniature_golf`
* `mud`
* `orchard`
* `plant_nursery`
* `plaque` (merging both `memorial=plaque` and `historic=memorial_plaque`)
* `reef`
* `cosmetics`
* `fishmonger`
* `bunker`
* `wayside_cross`
* `obelisk`

Added `kind_detail` whitelists on:

* `beach`
* `forest` and `wood`
* `wetland`

Verified that all the kinds mentioned in #1425 are either implemented here or have been previously implemented. Checked docs and tests, too.

Connects to #1425.