### PR TITLE
Fix SQL syntax error

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -758,5 +758,16 @@ class RoundTripRuleTest(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class GenerateSQLTest(unittest.TestCase):
+
+    def test_generate_sql(self):
+        from vectordatasource.meta.sql import write_sql
+        from cStringIO import StringIO
+
+        io = StringIO()
+        # this should throw if there's an error.
+        write_sql(io)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -957,7 +957,7 @@ filters:
   - filter:
       any:
         - waterway: fuel
-        - tags->'seamark:small_craft_facility:category': 'fuel_station'
+        - "seamark:small_craft_facility:category": 'fuel_station'
     min_zoom: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 2.7 ] } } }
     output:
       <<: *output_properties


### PR DESCRIPTION
The YAML key `tags->'seamark:small_craft_facility:category'` was turning into a SQL query containing `tags->''seamark:small_craft_facility:category''`. Fixed the YAML, and added a check to the `meta/sql.py` that we won't try in the future to output a tag name with a quote in it. Added the SQL generation to a unit test, so that we're sure it's getting run regularly.