### PR TITLE
Replaced some data-driven tests with generative tests

### DIFF
--- a/integration-test/471-categorize-trains.py
+++ b/integration-test/471-categorize-trains.py
@@ -3,9 +3,28 @@ from . import FixtureTest
 
 class CategorizeTrains(FixtureTest):
     def test_long_distance(self):
-        self.load_fixtures(
-            ['https://www.openstreetmap.org/relation/2812900'],
-            clip=self.tile_bbox(14, 2624, 5722))
+        import dsl
+
+        z, x, y = 5, 5, 11
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/2812900
+            dsl.way(2812900, dsl.tile_diagonal(z, x, y), {
+                "FIXME": "Underlying infrastructure \"Seattle Subdivision\"" \
+                "needs some fixing",
+                "colour": "#191970",
+                "from": "Los Angeles",
+                "name": "Coast Starlight",
+                "network": "Amtrak",
+                "operator": "Amtrak",
+                "public_transport:version": "1",
+                "ref": "11-14",
+                "route": "train",
+                "service": "long_distance",
+                "to": "Seattle",
+                "type": "route",
+                "via": "Portland"
+            }),
+        )
 
         self.assert_has_feature(
             5, 5, 11, 'transit',

--- a/integration-test/502-water-boundaries-slow.py
+++ b/integration-test/502-water-boundaries-slow.py
@@ -4,7 +4,8 @@ from . import FixtureTest
 class WaterBoundariesSlow(FixtureTest):
 
     def test_boundaries(self):
-        from shapely.ops import unary_union
+        from shapely.geometry import Polygon, MultiPolygon
+        import dsl
 
         # River Tocanis, Brasil
 
@@ -23,13 +24,65 @@ class WaterBoundariesSlow(FixtureTest):
             [16, 23775, 33616],
         ]
 
-        all_tiles = no_boundary_tiles + boundary_tiles
-        all_boxes = [self.tile_bbox(*t, padding=2) for t in all_tiles]
-
-        self.load_fixtures([
-            'https://www.openstreetmap.org/relation/275011',
-            'https://www.openstreetmap.org/relation/1363854',
-        ], clip=unary_union(all_boxes))
+        self.generate_fixtures(
+            dsl.way(-275011,
+                    MultiPolygon([
+                        Polygon([
+                            (-49.39061691153051, -4.642129842005724),
+                            (-49.3911190288361, -4.64364792245321),
+                            (-49.3873424215501, -4.64655660425706),
+                            (-49.383544921875, -4.644166012503287),
+                            (-49.383544921875, -4.656281393196448),
+                            (-49.3836036333376, -4.65640167692064),
+                            (-49.3888874340073, -4.65459808086801),
+                            (-49.3950947926206, -4.65838675537571),
+                            (-49.4110107421875, -4.656996327123991),
+                            (-49.4110107421875, -4.642129842005724),
+                            (-49.39061691153051, -4.642129842005724),
+                        ]), Polygon([
+                            (-49.4219970703125, -4.65603655397672),
+                            (-49.449462890625, -4.653637121108541),
+                            (-49.449462890625, -4.642129842005724),
+                            (-49.4219970703125, -4.642129842005724),
+                            (-49.4219970703125, -4.65603655397672),
+                        ]),
+                    ]), {
+                        "natural": "water",
+                        "name": u"Reservat\u00f3rio da Usina "
+                        u"Hidrel\u00e9trica de Tucuru\u00ed",
+                        "short_name": u"Reservat\u00f3rio UHE de Tucuru\u00ed",
+                        "way_area": "2.71214e+09",
+                        "wikipedia": u"pt:Usina Hidrel\u00e9trica de "
+                        u"Tucuru\u00ed",
+                        "name:de": u"Tucuru\u00ed-Stausee",
+                        "water": "reservoir",
+                        "source": "openstreetmap.org",
+                        "wikidata": "Q1475210",
+                    }),
+            dsl.way(-1363854,
+                    MultiPolygon([
+                        Polygon([
+                            (-49.449462890625, -4.653637121108541),
+                            (-49.4219970703125, -4.65603655397672),
+                            (-49.4219970703125, -4.669505032676526),
+                            (-49.449462890625, -4.669505032676526),
+                            (-49.449462890625, -4.653637121108541),
+                        ]), Polygon([
+                            (-49.4110107421875, -4.656996327123991),
+                            (-49.3950947926206, -4.65838675537571),
+                            (-49.38621008393813, -4.669505032676526),
+                            (-49.404887252266015, -4.669505032676526),
+                            (-49.4072058792811, -4.66783843107854),
+                            (-49.40703528549232, -4.669505032676526),
+                            (-49.4110107421875, -4.669505032676526),
+                            (-49.4110107421875, -4.656996327123991),
+                        ])
+                    ]), {
+                        "source": "openstreetmap.org",
+                        "waterway": "riverbank",
+                        "way_area": 7.12568e+08,
+                    })
+        )
 
         for z, x, y in no_boundary_tiles:
             with self.features_in_tile_layer(z, x, y, 'water') as features:

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -23,20 +23,61 @@ class WalkingRouteRefs(FixtureTest):
              'all_walking_shield_texts': ['416']})
 
     def test_multiple_routes(self):
+        import dsl
+
+        z, x, y = 16, 11044, 25309
+
         #   network=nwn, ref="PCT Section H"
         #   type=route, route=hiking, network=nwn, ref=PCT
         #   type=route, route=foot, network=rwn, ref=JMT
         #   type=route, route=foot, network=rwn, ref="", name="PCT - California
         #   Section H"
-        self.load_fixtures([
-            'https://www.openstreetmap.org/way/373532611',
-            'https://www.openstreetmap.org/relation/1225378',
-            'https://www.openstreetmap.org/relation/1244828',
-            'https://www.openstreetmap.org/relation/1244686',
-        ], clip=self.tile_bbox(16, 11044, 25309))
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/373532611
+            dsl.way(373532611, dsl.tile_diagonal(z, x, y), {
+                "horse": "yes",
+                "bicycle": "no",
+                "name": "John Muir Trail",
+                "source": "openstreetmap.org",
+                "alt_name": "Pacific Crest National Scenic Trail",
+                "network": "nwn",
+                "motorcar": "no",
+                "foot": "yes",
+                "ref": "PCT Section H",
+                "highway": "path",
+                "motorcycle": "no",
+            }),
+            # https://www.openstreetmap.org/relation/1225378
+            dsl.relation(1225378, {
+                "name": "Pacific Crest Trail",
+                "network": "nwn",
+                "ref": "PCT",
+                "route": "hiking",
+                "type": "route",
+                "wikidata": "Q2003736",
+                "wikipedia": "en:Pacific Crest Trail",
+            }, ways=[373532611]),
+            # https://www.openstreetmap.org/relation/1244828
+            dsl.relation(1244828, {
+                "name": "John Muir Trail",
+                "network": "rwn",
+                "ref": "JMT",
+                "route": "foot",
+                "type": "route",
+                "wikidata": "Q967917",
+                "wikipedia": "en:John Muir Trail",
+            }, ways=[373532611]),
+            # https://www.openstreetmap.org/relation/1244686
+            dsl.relation(1244686, {
+                "name": "PCT - California Section H",
+                "network": "rwn",
+                "route": "foot",
+                "type": "route",
+            }, ways=[373532611])
+        )
 
         self.assert_has_feature(
-            16, 11044, 25309, 'roads',
+            z, x, y, 'roads',
             {'id': 373532611,
              'walking_network': 'nwn', 'walking_shield_text': 'PCT',
              'all_walking_networks': ['nwn', 'nwn', 'rwn', 'rwn'],

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -35,12 +35,35 @@ class FractionalPois(FixtureTest):
              'network': 'US:NJ:Hudson'})
 
     def test_train_route(self):
-        self.load_fixtures([
-            'http://www.openstreetmap.org/relation/1359387',
-        ], clip=self.tile_bbox(9, 150, 192))
+        import dsl
+
+        z, x, y = 9, 150, 192
+
+        self.generate_fixtures(
+            dsl.way(1359387, dsl.tile_diagonal(z, x, y), {
+                "website": "http://www.amtrak.com",
+                "passenger": "national",
+                "via": "New York Penn Station",
+                "from": "Washington, DC",
+                "name": "Vermonter",
+                "service": "long_distance",
+                "to": "Saint Albans, Vermont",
+                "route": "train",
+                "wikipedia": "en:Vermonter (train)",
+                "route_name": "Vermonter",
+                "route_pref_color": "0",
+                "public_transport:version": "1",
+                "wikidata": "Q1412872",
+                "source": "openstreetmap.org",
+                "operator": "Amtrak",
+                "ref": "54-57",
+                "colour": "#005480",
+                "network": "Amtrak"
+            }),
+        )
 
         self.assert_has_feature(
-            9, 150, 192, 'transit',
+            z, x, y, 'transit',
             {'min_zoom': 5, 'ref': '54-57',
              'source': 'openstreetmap.org',
              'name': 'Vermonter'})


### PR DESCRIPTION
Because they were failing on my system. It looks like the OSM data has been updated since it was cached on my other machine. Eventually, we'll want to replace all the tests with generative ones, but this is only a small step in that direction.
