### PR TITLE
Only query countries (admin_level=2) from admin_areas table.

### DIFF
--- a/queries/admin_areas.jinja2
+++ b/queries/admin_areas.jinja2
@@ -13,4 +13,5 @@ FROM
   admin_areas
 
 WHERE
-    {{ bounds['polygon']|bbox_filter('the_geom', 3857) }}
+    {{ bounds['polygon']|bbox_filter('the_geom', 3857) }} AND
+    admin_leve = '2'

--- a/queries/admin_areas.jinja2
+++ b/queries/admin_areas.jinja2
@@ -14,4 +14,6 @@ FROM
 
 WHERE
     {{ bounds['polygon']|bbox_filter('the_geom', 3857) }} AND
+    -- NOTE: this _is not_ a typo! this table is loaded from a shapefile, which truncates column names to
+    -- 8 characters.
     admin_leve = '2'


### PR DESCRIPTION
Previously, we were querying everything, which meant that some places were getting overlapping state or regional codes as their `country_code`. This meant that sometimes the wrong rules would be applied to figure out the network and `shield_text`.

This wasn't happening at zooms 13 and above, as the RAWR tile queries were limited to `admin_level=2`.

Connects to #1548.