### PR TITLE
Be more robust to None in road network code.

### DIFF
--- a/integration-test/1555-be-more-robust-to-none.py
+++ b/integration-test/1555-be-more-robust-to-none.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class RobustToNoneTest(FixtureTest):
+
+    def test_fake_rel_with_ref_none(self):
+        # this starts with real data, but i've removed the ref from the
+        # relation to inject a None into the network "fixup" code.
+
+        import dsl
+
+        z, x, y = (16, 36334, 21769)
+
+        self.generate_fixtures(
+            dsl.is_in('PL', z, x, y),
+            # https://www.openstreetmap.org/way/367163748
+            dsl.way(367163748, dsl.tile_diagonal(z, x, y), {
+                'highway': u'motorway',
+                'int_ref': u'E 67;E 75',
+                'name': u'Autostrada Bursztynowa',
+                'oneway': u'yes',
+                'source': u'openstreetmap.org',
+            }),
+            dsl.relation(1, {
+                'name': u'Autostrada A1',
+                'network': u'pl:motorways',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[367163748]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 367163748,
+                'network': 'PL:motorway',
+            })

--- a/integration-test/358-merge-same-roads.py
+++ b/integration-test/358-merge-same-roads.py
@@ -16,7 +16,7 @@ def _query_highway(highway):
     # in defiance of conventional x, y coordinate ordering.
     bbox = "36.563,-122.377,37.732,-120.844"
     overpass = "http://overpass-api.de/api/interpreter?data="
-    return overpass + 'way(' + bbox + ')[highway=' + highway + '];>;'
+    return overpass + 'way(' + bbox + ')[highway=' + highway + ']%3B>%3B'
 
 
 class MergeSameRoads(FixtureTest):

--- a/integration-test/731-return-of-the-zombie-buildings.py
+++ b/integration-test/731-return-of-the-zombie-buildings.py
@@ -14,7 +14,7 @@ class ReturnOfTheZombieBuildings(FixtureTest):
         # scheme that overpass expects (south,west,north,east).
         bbox = "%f,%f,%f,%f" % (bounds[1], bounds[0], bounds[3], bounds[2])
         overpass = "http://overpass-api.de/api/interpreter?data="
-        query = "way(" + bbox + ")[" + tag + "];>;"
+        query = "way(" + bbox + ")[" + tag + "]%3B>%3B"
 
         self.load_fixtures([overpass + query])
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -769,3 +769,12 @@ class AdminBoundaryTest(unittest.TestCase):
 
         # the test is simply that an exception isn't thrown.
         admin_boundaries(ctx)
+
+
+class RoadNetworkFixTest(unittest.TestCase):
+
+    def test_normalize_br_netref(self):
+        from vectordatasource.transform import _normalize_br_netref
+        net, ref = _normalize_br_netref(None, "SP-1")
+        self.assertEquals("BR:SP", net)
+        self.assertEquals("SP-1", ref)

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -776,5 +776,12 @@ class RoadNetworkFixTest(unittest.TestCase):
     def test_normalize_br_netref(self):
         from vectordatasource.transform import _normalize_br_netref
         net, ref = _normalize_br_netref(None, "SP-1")
-        self.assertEquals("BR:SP", net)
-        self.assertEquals("SP-1", ref)
+        self.assertEqual("BR:SP", net)
+        self.assertEqual("SP-1", ref)
+
+    def test_guess_network_br(self):
+        from vectordatasource.transform import _guess_network_br
+        # should be empty for a missing ref
+        self.assertEqual([], _guess_network_br({}))
+        # should be empty for a blank ref
+        self.assertEqual([], _guess_network_br(dict(ref="")))

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4196,7 +4196,9 @@ def _guess_network_gb(tags):
 
 def _guess_network_ar(tags):
     ref = tags.get('ref')
-    if ref.startswith('RN'):
+    if ref is None:
+        return None
+    elif ref.startswith('RN'):
         return [('AR:national', ref)]
     elif ref.startswith('RP'):
         return [('AR:provincial', ref)]
@@ -5307,7 +5309,7 @@ def _normalize_br_netref(network, ref):
         else:
             return network, ref
 
-    elif network.startswith('BR:'):
+    elif network and network.startswith('BR:'):
         # turn things like "BR:BA-roads" into just "BR:BA"
         if network.endswith('-roads'):
             network = network[:-6]
@@ -5361,13 +5363,13 @@ def _normalize_ch_netref(network, ref):
 
 
 def _normalize_cn_netref(network, ref):
-    if ref.startswith('S'):
+    if ref and ref.startswith('S'):
         network = 'CN:expressway:regional'
 
-    elif ref.startswith('G'):
+    elif ref and ref.startswith('G'):
         network = 'CN:expressway'
 
-    elif ref.startswith('X'):
+    elif ref and ref.startswith('X'):
         network = 'CN:JX'
 
     elif network == 'CN-expressways':
@@ -5974,9 +5976,9 @@ def _normalize_pl_netref(network, ref):
     elif network == 'PL:expressways':
         network = 'PL:expressway'
 
-    if ref.startswith('A'):
+    if ref and ref.startswith('A'):
         network = 'PL:motorway'
-    elif ref.startswith('S'):
+    elif ref and ref.startswith('S'):
         network = 'PL:expressway'
 
     return network, ref
@@ -6263,11 +6265,11 @@ def _normalize_za_netref(network, ref):
 def _shield_text_ar(network, ref):
     # Argentinian national routes start with "RN" (ruta nacional), which
     # should be stripped, but other letters shouldn't be!
-    if network == 'AR:national' and ref.startswith('RN'):
+    if network == 'AR:national' and ref and ref.startswith('RN'):
         return ref[2:]
 
     # Argentinian provincial routes start with "RP" (ruta provincial)
-    if network == 'AR:provincial' and ref.startswith('RP'):
+    if network == 'AR:provincial' and ref and ref.startswith('RP'):
         return ref[2:]
 
     return ref

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4205,15 +4205,30 @@ def _guess_network_ar(tags):
     return None
 
 
-def _guess_network_au(tags):
+def _guess_network_with(tags, fn):
+    """
+    Common function for backfilling (network, ref) pairs by running the
+    "normalize" function on the parts of the ref. For example, if the
+    ref was 'A1;B2;C3', then the normalize function would be run on
+    fn(None, 'A1'), fn(None, 'B2'), etc...
+
+    This allows us to back-fill the network where it can be deduced from
+    the ref in a particular country (e.g: if all motorways are A[0-9]).
+    """
+
     ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
+        part = part.strip()
         if not part:
             continue
-        network, ref = _normalize_au_netref(None, part)
+        network, ref = fn(None, part)
         networks.append((network, part))
     return networks
+
+
+def _guess_network_au(tags):
+    return _guess_network_with(tags, _normalize_au_netref)
 
 
 # list of all the state codes in Brazil, see
@@ -4348,60 +4363,23 @@ def _guess_network_ch(tags):
 
 
 def _guess_network_cn(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_cn_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_cn_netref)
 
 
 def _guess_network_es(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        part = part.strip()
-        if not part:
-            continue
-        network, ref = _normalize_es_netref(None, part)
-        if network or ref:
-            networks.append((network, ref))
-    return networks
+    return _guess_network_with(tags, _normalize_es_netref)
 
 
 def _guess_network_fr(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_fr_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_fr_netref)
 
 
 def _guess_network_de(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_de_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_de_netref)
 
 
 def _guess_network_ga(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_ga_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_ga_netref)
 
 
 def _guess_network_gr(tags):
@@ -4422,58 +4400,23 @@ def _guess_network_gr(tags):
 
 
 def _guess_network_in(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_in_netref(None, part)
-        networks.append((network, ref))
-    return networks
+    return _guess_network_with(tags, _normalize_in_netref)
 
 
 def _guess_network_mx(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_mx_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_mx_netref)
 
 
 def _guess_network_my(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_my_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_my_netref)
 
 
 def _guess_network_no(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_no_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_no_netref)
 
 
 def _guess_network_pe(tags):
-    ref = tags.get('ref', '')
-    networks = []
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_pe_netref(None, part)
-        networks.append((network, part))
-    return networks
+    return _guess_network_with(tags, _normalize_pe_netref)
 
 
 def _guess_network_jp(tags):
@@ -4548,69 +4491,23 @@ def _guess_network_kr(tags):
 
 
 def _guess_network_pl(tags):
-    ref = tags.get('ref', '')
-    networks = []
-
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_pl_netref(None, part)
-        networks.append((network, part))
-
-    return networks
+    return _guess_network_with(tags, _normalize_pl_netref)
 
 
 def _guess_network_pt(tags):
-    ref = tags.get('ref', '')
-    networks = []
-
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_pt_netref(None, part)
-        networks.append((network, part))
-
-    return networks
+    return _guess_network_with(tags, _normalize_pt_netref)
 
 
 def _guess_network_ro(tags):
-    ref = tags.get('ref', '')
-    networks = []
-
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_ro_netref(None, part)
-        if network or ref:
-            networks.append((network, part))
-
-    return networks
+    return _guess_network_with(tags, _normalize_ro_netref)
 
 
 def _guess_network_ru(tags):
-    ref = tags.get('ref', '')
-    networks = []
-
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_ru_netref(tags.get('network'), part)
-        networks.append((network, part))
-
-    return networks
+    return _guess_network_with(tags, _normalize_ru_netref)
 
 
 def _guess_network_sg(tags):
-    ref = tags.get('ref', '')
-    networks = []
-
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_sg_netref(None, part)
-        networks.append((network, ref))
-
-    return networks
+    return _guess_network_with(tags, _normalize_sg_netref)
 
 
 def _guess_network_tr(tags):
@@ -4629,16 +4526,7 @@ def _guess_network_tr(tags):
 
 
 def _guess_network_ua(tags):
-    ref = tags.get('ref', '')
-    networks = []
-
-    for part in ref.split(';'):
-        if not part:
-            continue
-        network, ref = _normalize_ua_netref(tags.get('network'), part)
-        networks.append((network, part))
-
-    return networks
+    return _guess_network_with(tags, _normalize_ua_netref)
 
 
 _COMMON_SEPARATORS = re.compile('[;,/,]')

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4157,7 +4157,7 @@ def _guess_network_gb(tags):
     # can recover it here.
     highway = tags.get('kind_detail')
 
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     # although roads are part of only one network in the UK, some roads are
     # tagged incorrectly as being part of two, so we have to handle this case.
@@ -4206,7 +4206,7 @@ def _guess_network_ar(tags):
 
 
 def _guess_network_au(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4282,6 +4282,10 @@ def _guess_network_br(tags):
     ref = tags.get('ref')
     networks = []
 
+    # a missing or blank ref isn't going to give us much information
+    if not ref:
+        return networks
+
     # track last prefix, so that we can handle cases where the ref is written
     # as "BR-XXX/YYY" to mean "BR-XXX; BR-YYY".
     last_prefix = None
@@ -4332,7 +4336,7 @@ def _guess_network_ca(tags):
 
 
 def _guess_network_ch(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4344,7 +4348,7 @@ def _guess_network_ch(tags):
 
 
 def _guess_network_cn(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4355,7 +4359,7 @@ def _guess_network_cn(tags):
 
 
 def _guess_network_es(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         part = part.strip()
@@ -4368,7 +4372,7 @@ def _guess_network_es(tags):
 
 
 def _guess_network_fr(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4379,7 +4383,7 @@ def _guess_network_fr(tags):
 
 
 def _guess_network_de(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4390,7 +4394,7 @@ def _guess_network_de(tags):
 
 
 def _guess_network_ga(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4401,7 +4405,7 @@ def _guess_network_ga(tags):
 
 
 def _guess_network_gr(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4418,7 +4422,7 @@ def _guess_network_gr(tags):
 
 
 def _guess_network_in(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4429,7 +4433,7 @@ def _guess_network_in(tags):
 
 
 def _guess_network_mx(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4440,7 +4444,7 @@ def _guess_network_mx(tags):
 
 
 def _guess_network_my(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4451,7 +4455,7 @@ def _guess_network_my(tags):
 
 
 def _guess_network_no(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4462,7 +4466,7 @@ def _guess_network_no(tags):
 
 
 def _guess_network_pe(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
     for part in ref.split(';'):
         if not part:
@@ -4473,7 +4477,7 @@ def _guess_network_pe(tags):
 
 
 def _guess_network_jp(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
 
     name = tags.get('name:ja') or tags.get('name')
     network_from_name = None
@@ -4500,7 +4504,7 @@ def _guess_network_jp(tags):
 
 
 def _guess_network_kr(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     network_from_tags = tags.get('network')
 
     # the name often ends with a word which appears to mean expressway or
@@ -4544,7 +4548,7 @@ def _guess_network_kr(tags):
 
 
 def _guess_network_pl(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
 
     for part in ref.split(';'):
@@ -4557,7 +4561,7 @@ def _guess_network_pl(tags):
 
 
 def _guess_network_pt(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
 
     for part in ref.split(';'):
@@ -4570,7 +4574,7 @@ def _guess_network_pt(tags):
 
 
 def _guess_network_ro(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
 
     for part in ref.split(';'):
@@ -4584,7 +4588,7 @@ def _guess_network_ro(tags):
 
 
 def _guess_network_ru(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
 
     for part in ref.split(';'):
@@ -4597,7 +4601,7 @@ def _guess_network_ru(tags):
 
 
 def _guess_network_sg(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
 
     for part in ref.split(';'):
@@ -4610,7 +4614,7 @@ def _guess_network_sg(tags):
 
 
 def _guess_network_tr(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
 
     for part in _COMMON_SEPARATORS.split(ref):
@@ -4625,7 +4629,7 @@ def _guess_network_tr(tags):
 
 
 def _guess_network_ua(tags):
-    ref = tags.get('ref')
+    ref = tags.get('ref', '')
     networks = []
 
     for part in ref.split(';'):


### PR DESCRIPTION
Tried to find all the places where we call something `.startswith` without checking it's truthy first. Ideally we'd check if `isinstance(whatever, (str, unicode))`, but I think it's always going to be a `str` if it's truthy, and it's quite a bit more concise.

Connects to #1555.
