### PR TITLE
Make ocean polygons valid

### DIFF
--- a/data/apply-updates-non-planet-tables.sql
+++ b/data/apply-updates-non-planet-tables.sql
@@ -1,6 +1,7 @@
 -- correct the invalid data in the ne tables from reprojection
 UPDATE ne_10m_lakes SET the_geom=ST_MakeValid(the_geom) WHERE NOT ST_IsValid(the_geom);
 UPDATE ne_110m_land SET the_geom=ST_MakeValid(the_geom) WHERE NOT ST_IsValid(the_geom);
+UPDATE ne_10m_ocean SET the_geom=ST_MakeValid(the_geom) WHERE NOT ST_IsValid(the_geom);
 
 UPDATE ne_10m_admin_0_boundary_lines_land
   SET


### PR DESCRIPTION
Run ST_MakeValid on geometries after mercator projection in ne_10m_ocean table.

The missing water described in #1557 was because the polygon in `ne_10m_ocean` was not valid, and was being rejected by the processing pipeline.

Connects to #1557.