### PR TITLE
Add prefix to M, A, B & C roads in Australia.

### DIFF
--- a/integration-test/1491-australia-shields.py
+++ b/integration-test/1491-australia-shields.py
@@ -28,8 +28,8 @@ class AustraliaShieldTest(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'roads',
-            {'id': 582052008, 'shield_text': '10', 'network': 'AU:A-road',
-             'all_networks': ['AU:A-road'], 'all_shield_texts': ['10']})
+            {'id': 582052008, 'shield_text': 'A10', 'network': 'AU:A-road',
+             'all_networks': ['AU:A-road'], 'all_shield_texts': ['A10']})
 
     def test_s_road_in_both_relations(self):
         import dsl
@@ -188,9 +188,9 @@ class AustraliaShieldTest(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'roads', {
-                'id': 131293316, 'shield_text': '62', 'network': 'AU:B-road',
+                'id': 131293316, 'shield_text': 'B62', 'network': 'AU:B-road',
                 'all_networks': ['AU:B-road', 'AU:T-drive', 'AU:T-drive'],
-                'all_shield_texts': ['62', '28', '30'],
+                'all_shield_texts': ['B62', '28', '30'],
             })
 
     def test_c_road(self):
@@ -223,8 +223,8 @@ class AustraliaShieldTest(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'roads', {
-                'id': 7787334, 'shield_text': '475', 'network': 'AU:C-road',
-                'all_shield_texts': ['475', '476'],
+                'id': 7787334, 'shield_text': 'C475', 'network': 'AU:C-road',
+                'all_shield_texts': ['C475', 'C476'],
                 'all_networks': ['AU:C-road', 'AU:C-road'],
             })
 
@@ -291,7 +291,7 @@ class AustraliaShieldTest(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'roads',
-            {'id': 3188239, 'shield_text': '1', 'network': 'AU:M-road'})
+            {'id': 3188239, 'shield_text': 'M1', 'network': 'AU:M-road'})
 
     # https://en.wikipedia.org/wiki/City_Ring_Route,_Adelaide
     def test_ring_route(self):

--- a/integration-test/1562-australia-shield-text-prefixes.py
+++ b/integration-test/1562-australia-shield-text-prefixes.py
@@ -1,0 +1,88 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class AustraliaShieldTextPrefixesTest(FixtureTest):
+
+    def test_m(self):
+        import dsl
+
+        z, x, y = (16, 60295, 39334)
+
+        self.generate_fixtures(
+            dsl.is_in('AU', z, x, y),
+            # https://www.openstreetmap.org/way/170318728
+            dsl.way(170318728, dsl.tile_diagonal(z, x, y), {
+                'bicycle': u'no',
+                'highway': u'motorway',
+                'lanes': u'2',
+                'layer': u'-1',
+                'maxspeed': u'80',
+                'name': u'Eastern Distributor',
+                'old_network': u'MR',
+                'old_ref': u'1',
+                'oneway': u'yes',
+                'ref': u'M1',
+                'ref:start_date': u'2013-08',
+                'source': u'openstreetmap.org',
+                'surface': u'asphalt',
+                'toll': u'yes',
+            }),
+            dsl.relation(1, {
+                'addr:country': u'AU',
+                'addr:state': u'NSW',
+                'ref': u'M1',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[170318728]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 170318728,
+                'shield_text': 'M1',
+                'network': 'AU:M-road',
+            })
+
+    def test_a(self):
+        import dsl
+
+        z, x, y = (16, 60290, 39332)
+
+        self.generate_fixtures(
+            dsl.is_in('AU', z, x, y),
+            # https://www.openstreetmap.org/way/286361145
+            dsl.way(286361145, dsl.tile_diagonal(z, x, y), {
+                'highway': u'trunk',
+                'lanes': u'4',
+                'lit': u'yes',
+                'maxspeed': u'50',
+                'name': u'King Street',
+                'parking:lane:both:parallel': u'on_street',
+                'parking:lane:both:width': u'2',
+                'ref': u'A36',
+                'ref:start_date': u'2013-06',
+                'sidewalk': u'both',
+                'smoothness:lanes': u'|||intermediate',
+                'source': u'openstreetmap.org',
+                'surface': u'paved',
+                'width': u'13.7',
+            }),
+            dsl.relation(1, {
+                'addr:country': u'AU',
+                'addr:state': u'NSW',
+                'ref': u'A36',
+                'ref:start_date': u'2013-06',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[286361145]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 286361145,
+                'shield_text': 'A36',
+                'network': 'AU:A-road',
+            })

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -6199,6 +6199,24 @@ def _shield_text_ar(network, ref):
     return ref
 
 
+_AU_NETWORK_SHIELD_TEXT = {
+    'AU:M-road': 'M',
+    'AU:A-road': 'A',
+    'AU:B-road': 'B',
+    'AU:C-road': 'C',
+}
+
+
+def _shield_text_au(network, ref):
+    # shields on M, A, B & C roads should have the letter, but not other types
+    # of roads.
+    prefix = _AU_NETWORK_SHIELD_TEXT.get(network)
+    if prefix:
+        ref = prefix + ref
+
+    return ref
+
+
 def _shield_text_gb(network, ref):
     # just remove any space between the letter and number(s)
     prefix, number = _splitref(ref)
@@ -6263,6 +6281,7 @@ _COUNTRY_SPECIFIC_ROAD_NETWORK_LOGIC = {
         backfill=_guess_network_au,
         fix=_normalize_au_netref,
         sort=_sort_network_au,
+        shield_text=_shield_text_au,
     ),
     'BR': CountryNetworkLogic(
         backfill=_guess_network_br,


### PR DESCRIPTION
#1562 says M, B & C, but I've done it for A-roads too, on the basis that they seem to sometimes be signed that way (and sometimes not :confused: ). Let me know if that's not what you wanted - it's easy to revert.

Connects to #1562.