### PR TITLE
Fix missing fallback network value for roads

### DIFF
--- a/integration-test/1491-australia-shields.py
+++ b/integration-test/1491-australia-shields.py
@@ -122,7 +122,7 @@ class AustraliaShieldTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'roads', {
                 'id': 16477624, 'shield_text': '9', 'network': 'AU:T-drive',
-                'all_networks': ['AU:T-drive', type(None)],
+                'all_networks': ['AU:T-drive', 'AU'],
                 'all_shield_texts': ['9', '31'],
             })
 
@@ -234,8 +234,7 @@ class AustraliaShieldTest(FixtureTest):
     # https://en.wikipedia.org/wiki/Barndioota_Road
     #
     # so, given that this doesn't correspond to a known highway type in AU,
-    # we emit this with a network type of None, since we can't figure it out
-    # from the available information.
+    # we emit this with a network type of generic 'AU'.
     def test_d_road(self):
         import dsl
 
@@ -261,7 +260,7 @@ class AustraliaShieldTest(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'roads', {
-                'id': 229978585, 'shield_text': '83', 'network': type(None),
+                'id': 229978585, 'shield_text': '83', 'network': 'AU',
             })
 
     def test_m_road(self):

--- a/integration-test/1559-missing-fallback-country-code.py
+++ b/integration-test/1559-missing-fallback-country-code.py
@@ -29,3 +29,29 @@ class MissingFallbackCountryCodeTest(FixtureTest):
                 'shield_text': '4',
                 'network': 'NO',
             })
+
+    def test_ca(self):
+        import dsl
+
+        z, x, y = (16, 13515, 21656)
+
+        self.generate_fixtures(
+            dsl.is_in('CA', z, x, y),
+            # https://www.openstreetmap.org/way/284925161
+            dsl.way(284925161, dsl.tile_diagonal(z, x, y), {
+                'highway': u'primary',
+                'lanes': u'2',
+                'maxspeed': u'100',
+                'name': u'Veterans Memorial Highway',
+                'ref': u'2',
+                'source': u'openstreetmap.org',
+                'surface': u'paved',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 284925161,
+                'shield_text': '2',
+                'network': 'CA',
+            })

--- a/integration-test/1559-missing-fallback-country-code.py
+++ b/integration-test/1559-missing-fallback-country-code.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class MissingFallbackCountryCodeTest(FixtureTest):
+
+    def test_no(self):
+        import dsl
+
+        z, x, y = (16, 34749, 19016)
+
+        self.generate_fixtures(
+            dsl.is_in('NO', z, x, y),
+            # https://www.openstreetmap.org/way/116419571
+            dsl.way(116419571, dsl.tile_diagonal(z, x, y), {
+                'highway': u'trunk',
+                'lanes': u'2',
+                'lit': u'yes',
+                'maxspeed': u'60',
+                'name': u'Hadelandsveien',
+                'ref': u'4',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 116419571,
+                'shield_text': '4',
+                'network': 'NO',
+            })

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4347,6 +4347,10 @@ def _guess_network_ca(tags):
         # https://commons.wikimedia.org/wiki/File:TCH-16_(BC).svg
         networks.append(('CA:transcanada', ref))
 
+    if not networks and ref:
+        # final fallback - all we know is that this is a road in Canada.
+        networks.append(('CA', ref))
+
     return networks
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -6829,6 +6829,7 @@ def _choose_most_important_network(properties, prefix, importance_fn):
 
     networks = properties.pop(all_networks, None)
     shield_texts = properties.pop(all_shield_texts, None)
+    country_code = properties.get('country_code')
 
     if networks and shield_texts:
         def network_key(t):
@@ -6851,7 +6852,8 @@ def _choose_most_important_network(properties, prefix, importance_fn):
                 new_tuples.append((network, ref))
 
             elif ref is not None and ref not in seen_ref:
-                new_tuples.append((network, ref))
+                # network is None, fall back to the country code
+                new_tuples.append((country_code, ref))
 
         tuples = new_tuples
 


### PR DESCRIPTION
Roads in Norway and Canada weren't being assigned `network: NO` or `network: CA` respectively if we couldn't figure out any other information about the road in question. This meant they weren't being shown as country-specific defaults.

Fixed this with a generic fallback for roads where the relation doesn't provide `network`, and a specific fix in Canada's case where we were assigning `network = None` explicitly from the tags.

Connects to #1559.
