### PR TITLE
Use raw strings for regular expressions

### DIFF
--- a/vectordatasource/meta/function.py
+++ b/vectordatasource/meta/function.py
@@ -337,9 +337,9 @@ def mz_calculate_ferry_level(shape):
     return 13
 
 
-DECIMAL_UNIT_PATTERN = re.compile('([0-9]+(\.[0-9]*)?) *(mi|km|m|nmi|ft)$')
-IMPERIAL_PATTERN = re.compile('([0-9]+(\.[0-9]*)?)\' *(([0-9]+)")?')
-NUMERIC_PATTERN = re.compile('^([0-9]+(\.[0-9]*)?)$')
+DECIMAL_UNIT_PATTERN = re.compile(r'([0-9]+(\.[0-9]*)?) *(mi|km|m|nmi|ft)$')
+IMPERIAL_PATTERN = re.compile(r'([0-9]+(\.[0-9]*)?)\' *(([0-9]+)")?')
+NUMERIC_PATTERN = re.compile(r'^([0-9]+(\.[0-9]*)?)$')
 
 
 UNIT_CONVERSION_FACTORS = {

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -57,7 +57,7 @@ digits_pattern = re.compile('^[0-9-]+$')
 
 # used to detect station names which are followed by a
 # parenthetical list of line names.
-station_pattern = re.compile('([^(]*)\(([^)]*)\).*')
+station_pattern = re.compile(r'([^(]*)\(([^)]*)\).*')
 
 # used to detect if an airport's IATA code is the "short"
 # 3-character type. there are also longer codes, and ones
@@ -6676,11 +6676,11 @@ def _bus_network_importance(network, ref):
     return _generic_network_importance(network, ref, {})
 
 
-_NUMBER_AT_FRONT = re.compile('^(\d+\w*)', re.UNICODE)
-_SINGLE_LETTER_AT_FRONT = re.compile('^([^\W\d]) *(\d+)', re.UNICODE)
-_LETTER_THEN_NUMBERS = re.compile('^[^\d\s_]+[ -]?([^\s]+)',
+_NUMBER_AT_FRONT = re.compile(r'^(\d+\w*)', re.UNICODE)
+_SINGLE_LETTER_AT_FRONT = re.compile(r'^([^\W\d]) *(\d+)', re.UNICODE)
+_LETTER_THEN_NUMBERS = re.compile(r'^[^\d\s_]+[ -]?([^\s]+)',
                                   re.UNICODE | re.IGNORECASE)
-_UA_TERRITORIAL_RE = re.compile('^(\w)-(\d+)-(\d+)$',
+_UA_TERRITORIAL_RE = re.compile(r'^(\w)-(\d+)-(\d+)$',
                                 re.UNICODE | re.IGNORECASE)
 
 


### PR DESCRIPTION
Use raw strings for regular expressions containing regular expression escapes. This seems to have been working before, but `flake8` got more strict about it recently.

The problem is that regular expressions various characters to mean special things (e.g: `(` and `)` for grouping, `.` for "any character"), so if a literal character is wanted, they must be escaped. However, Python strings have their own escaping, in which many of the escapes for regular expressions have no meaning (e.g: `\(` is not a valid escape sequence for Python, but means "literal `(`" in a regular expression). Therefore, navigating two levels of escaping is going to be confusing and potentially error-prone where escape sequences clash, and `flake8` is right to call this out as a problem.

Python also has raw strings (`r'...'`), which solve the problem by disabling almost all the Python escape sequences, so we can write escape sequences just for the regular expression syntax.

