### PR TITLE
Use the NE min zoom to cull places at low zooms.

### DIFF
--- a/integration-test/1687-fewer-places-at-low-zoom.py
+++ b/integration-test/1687-fewer-places-at-low-zoom.py
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class LowZoomPlacesTest(FixtureTest):
+
+    def test_zoom_1(self):
+        import dsl
+
+        z, x, y = (3, 7, 3)
+
+        self.generate_fixtures(
+            dsl.way(607976629, dsl.tile_centre_shape(z, x, y), {
+                "min_zoom": 1,
+                "__ne_max_zoom": 10,
+                "__ne_min_zoom": 3,
+                "area": 0,
+                "place": "country",
+                "name": "Guam",
+                "population": 185427,
+                "source": "openstreetmap.org",
+            }),
+        )
+
+        # should exist at zoom 3 (the min zoom from NE)
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 607976629,
+                'kind': 'country',
+                'name': 'Guam',
+            })
+
+        # should exist at zoom 2 (one past the min zoom)
+        self.assert_has_feature(
+            z-1, x//2, y//2, 'places', {
+                'id': 607976629,
+                'kind': 'country',
+                'name': 'Guam',
+            })
+
+        # should not exist at zoom 1
+        self.assert_no_matching_feature(
+            z-2, x//4, y//4, 'places', {
+                'id': 607976629,
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -596,6 +596,12 @@ post_process:
     params:
       layer: places
 
+  # after we have the NE min zoom, drop features which we won't be displaying
+  # at this zoom.
+  - fn: vectordatasource.transform.min_zoom_filter
+    params:
+      layers: [places]
+
   - fn: vectordatasource.transform.overlap
     params:
       base_layer: buildings

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -7336,6 +7336,32 @@ def max_zoom_filter(ctx):
     return None
 
 
+def min_zoom_filter(ctx):
+    """
+    For features with a min_zoom, remove them if it's > nominal zoom + 1.
+    """
+
+    params = _Params(ctx, 'min_zoom_filter')
+    layers = params.required('layers', typ=list)
+    nominal_zoom = ctx.nominal_zoom
+
+    for layer_name in layers:
+        layer = _find_layer(ctx.feature_layers, layer_name)
+
+        features = layer['features']
+        new_features = []
+
+        for feature in features:
+            _, props, _ = feature
+            min_zoom = props.get('min_zoom')
+            if min_zoom is not None and min_zoom <= nominal_zoom + 1:
+                new_features.append(feature)
+
+        layer['features'] = new_features
+
+    return None
+
+
 def tags_set_ne_min_max_zoom(ctx):
     """
     Override the min zoom and max zoom properties with __ne_* variants from


### PR DESCRIPTION
We were already using the NE min zoom as the min_zoom property, but had failed to actually act on that by removing items outside of the zoom range.

Overall file size reduction (NOTE: most of the very low zoom labels come from the `earth` layer - things like continent labels):

Tile | Previous places size (bytes) | New places layer size (bytes) | Percentage improvement
-- | -- | -- | --
0/0/0 | 518,111 | 0 | 100%
1/0/0 | 139,980 | 0 | 100%
1/0/1 | 42,043 | 0 | 100%
1/1/0 | 266,788 | 0 | 100%
1/1/1 | 83,228 | 0 | 100%
2/0/0 | - | - | -
2/0/1 | 33,015 | 14,536 | 56%
2/0/2 | 20,091 | 1,979 | 90%
2/0/3 | - | - | -
2/1/0 | 4,326 | 4,091 | 5%
2/1/1 | 178,337 | 44,582 | 75%
2/1/2 | 58,487 | 20,020 | 66%
2/1/3 | - | - | -
2/2/0 | 2,145 | 0 | 100%
2/2/1 | 410,712 | 110,756 | 73%
2/2/2 | 83,789 | 32,137 | 62%
2/2/3 | - | - | -
2/3/0 | 827 |   | 100%
2/3/1 | 155,139 | 44,066 | 72%
2/3/2 | 44,228 | 21,546 | 51%
2/3/3 | - | - | -

## Zoom 0

It's all continent and ocean labels, no places visible.

![z0](https://user-images.githubusercontent.com/271360/47513010-4bd7b080-d875-11e8-8cec-50b24411a395.png)

## Zoom 1

It's all continent and ocean labels, no places visible.

![z1](https://user-images.githubusercontent.com/271360/47513012-4bd7b080-d875-11e8-8158-7e093b6ca8fd.png)

## Zoom 2

I was expecting _some_ places to be visible at this zoom level, as some are present in the tiles. Perhaps the label collision prevents any from appearing?

![z2](https://user-images.githubusercontent.com/271360/47513014-4c704700-d875-11e8-8b8d-ae2d9291d8ab.png)

## Zoom 3

Looks like a pretty good selection of capitals, major cities and country labels.

![z3](https://user-images.githubusercontent.com/271360/47513015-4c704700-d875-11e8-848d-dad864bf4bda.png)

## Zoom 4

Nice overview of US states and major cities. Do we have the same state data for Canada - given that we show the state borders, it might be nice to label them too? Perhaps a :umbrella: issue?

![z4](https://user-images.githubusercontent.com/271360/47513018-4c704700-d875-11e8-9095-c9c49bd87100.png)
