### PR TITLE
Drop the all_networks and all_shield_texts at mid zooms

### DIFF
--- a/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
+++ b/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
@@ -1,0 +1,63 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+# To decrease file size let's drop all_networks and all_shield_texts
+# from low and mid-zooms when there's often not room to display this
+# information.
+class DropAllNetworksShieldsAtLowZooms(FixtureTest):
+
+    def _drop_at_zoom(self, z, osm=None, kind=None):
+        import dsl
+
+        x = 1 << (z-1)
+        y = 1 << (z-1)
+
+        self.generate_fixtures(
+            dsl.is_in('US', z, x, y),
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': osm,
+                'source': u'openstreetmap.org',
+            }),
+            dsl.relation(1, {
+                'ref': u'1',
+                'network': 'US:I',
+                'route': u'road',
+                'source': u'openstreetmap.org',
+                'type': u'route',
+            }, ways=[1]),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 1,
+                'kind': kind,
+                'network': u'US:I',
+                'shield_text': u'1',
+                'all_networks': [u'US:I'],
+                'all_shield_texts': [u'1'],
+            })
+
+        # feature should still appear at z9, but without the "all_*"
+        # attributes. (NOTE: don't test shield text, as it might have
+        # been dropped anyway.)
+        self.assert_has_feature(
+            z-1, x//2, y//2, 'roads', {
+                'id': 1,
+                'kind': kind,
+                'all_networks': type(None),
+                'all_shield_texts': type(None),
+            })
+
+    # drop from highway: less than zoom 10
+    def test_highway(self):
+        self._drop_at_zoom(10, osm='motorway', kind='highway')
+
+    # drop from major_road: less than zoom 12
+    def test_major_road(self):
+        self._drop_at_zoom(12, osm='secondary', kind='major_road')
+
+    # drop from other kinds: less than zoom 14
+    def test_other_roads(self):
+        self._drop_at_zoom(14, osm='unclassified', kind='minor_road')
+        self._drop_at_zoom(14, osm='pedestrian', kind='path')

--- a/queries.yaml
+++ b/queries.yaml
@@ -922,6 +922,41 @@ post_process:
         - all_bus_shield_texts
       where: >-
         kind == 'highway'
+  # get rid of all_* properties on highways when zoom < 10.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 10
+      properties:
+        - all_networks
+        - all_shield_texts
+      where: >-
+        kind == 'highway'
+  # want to further drop all_* stuff on major roads at zoom < 12.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 12
+      properties:
+        - all_networks
+        - all_shield_texts
+      where: >-
+        kind == 'major_road'
+  # drop all_networks & all_shield_texts properties on road things where
+  # zoom < 14 and kind isn't highway or major_road, which we've already done
+  # above.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 14
+      properties:
+        - all_networks
+        - all_shield_texts
+      where: >-
+        kind not in ('highway', 'major_road')
   # drop walking network related properties on all roads early
   # as paths are only brought in at zoom 9 and these properties
   # on other kinds would prevent merging at zoom 8 and earlier


### PR DESCRIPTION
Drop the `all_networks` and `all_shield_texts` properties from roads at various zooms. Connects to #1642.
