### PR TITLE
Strip long names from boundaries.

### DIFF
--- a/integration-test/1683-strip-names-off-boundary-lines.py
+++ b/integration-test/1683-strip-names-off-boundary-lines.py
@@ -1,0 +1,77 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class StripNamesOffBoundaryLinesTest(FixtureTest):
+
+    def _setup(self, z, x, y, left_name, right_name):
+        from tilequeue.tile import coord_to_bounds
+        from shapely.geometry import LineString
+        from ModestMaps.Core import Coordinate
+        import dsl
+
+        minx, miny, maxx, maxy = coord_to_bounds(
+            Coordinate(zoom=z, column=x, row=y))
+
+        # move the coordinate points slightly out of the tile, so that we
+        # don't get borders along the sides of the tile.
+        w = maxx - minx
+        h = maxy - miny
+        minx -= 0.5 * w
+        miny -= 0.5 * h
+        maxx += 0.5 * w
+        maxy += 0.5 * h
+
+        self.generate_fixtures(
+            dsl.way(
+                1,
+                LineString([
+                    [minx, miny],
+                    [minx, maxy],
+                    [maxx, maxy],
+                    [minx, miny],
+                ]), {
+                    'boundary': 'administrative',
+                    'admin_level': '2',
+                    'name': left_name,
+                }
+            ),
+            dsl.way(
+                2,
+                LineString([
+                    [minx, miny],
+                    [maxx, maxy],
+                    [maxx, miny],
+                    [minx, miny],
+                ]), {
+                    'boundary': 'administrative',
+                    'admin_level': '2',
+                    'name': right_name,
+                }
+            ),
+        )
+
+    def test_do_not_strip_short_names(self):
+        z, x, y = (8, 128, 128)
+
+        self._setup(z, x, y, 'Foo', 'Bar')
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'country',
+                'name': 'Foo - Bar',
+            })
+
+    def test_strip_long_names(self):
+        z, x, y = (8, 128, 128)
+
+        n = 16
+        self._setup(z, x, y, 'Foo' * n, 'Bar' * n)
+
+        # should have stripped all the names off with such a ridiculously long
+        # name.
+        self.assert_no_matching_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'country',
+                'name': None,
+            })

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -16,9 +16,10 @@ class FractionalPois(FixtureTest):
             'https://www.openstreetmap.org/relation/61320',
         ], clip=self.tile_bbox(9, 150, 192, padding=2))
 
+        # NOTE: might not have an ID if it has been merged
         self.assert_has_feature(
             9, 150, 192, 'boundaries',
-            {'min_zoom': 8, 'id': -224951,
+            {'min_zoom': 8,
              'source': 'openstreetmap.org',
              'name': 'New Jersey - New York'})
 

--- a/integration-test/992-boundaries-min_zoom-and-name.py
+++ b/integration-test/992-boundaries-min_zoom-and-name.py
@@ -127,13 +127,15 @@ class BoundariesMinZoomAndNameNe(FixtureTest):
 class BoundariesMinZoomAndNameOsm(FixtureTest):
     def test_region_boundary_zug_luzern(self):
         # Switzerland region HAS name, OpenStreetMap
+        # do this at z12, as the boundary between Zug and Luzern is quite
+        # short, and we want enough space to label.
         self.load_fixtures([
             'http://www.openstreetmap.org/relation/1686447',
             'http://www.openstreetmap.org/relation/1685677',
-        ], clip=self.tile_bbox(8, 133, 89))
+        ], clip=self.tile_bbox(12, 2144, 1438))
 
         self.assert_has_feature(
-            8, 133, 89, 'boundaries',
+            12, 2144, 1438, 'boundaries',
             {'kind': 'region', 'name': 'Zug - Luzern'})
 
     def test_region_boundary_salzburg_tirol(self):

--- a/integration-test/992-boundaries-min_zoom-and-name.py
+++ b/integration-test/992-boundaries-min_zoom-and-name.py
@@ -125,7 +125,20 @@ class BoundariesMinZoomAndNameNe(FixtureTest):
 
 
 class BoundariesMinZoomAndNameOsm(FixtureTest):
-    def test_region_boundary_zug_luzern(self):
+    def test_region_boundary_zug_luzern_z8(self):
+        # Switzerland region HAS NO name, OpenStreetMap
+        self.load_fixtures([
+            'http://www.openstreetmap.org/relation/1686447',
+            'http://www.openstreetmap.org/relation/1685677',
+        ], clip=self.tile_bbox(8, 133, 89))
+
+        # test that the regional boundary is present at zoom 8, although it
+        # should have had its name stripped off, since it's very short.
+        self.assert_has_feature(
+            8, 133, 89, 'boundaries',
+            {'kind': 'region', 'name': type(None)})
+
+    def test_region_boundary_zug_luzern_z12(self):
         # Switzerland region HAS name, OpenStreetMap
         # do this at z12, as the boundary between Zug and Luzern is quite
         # short, and we want enough space to label.
@@ -134,6 +147,7 @@ class BoundariesMinZoomAndNameOsm(FixtureTest):
             'http://www.openstreetmap.org/relation/1685677',
         ], clip=self.tile_bbox(12, 2144, 1438))
 
+        # name should be present at zoom 12
         self.assert_has_feature(
             12, 2144, 1438, 'boundaries',
             {'kind': 'region', 'name': 'Zug - Luzern'})

--- a/queries.yaml
+++ b/queries.yaml
@@ -592,10 +592,28 @@ post_process:
       attribute: kind
       target_attribute: landuse_kind
       cutting_attrs: { sort_key: 'sort_rank', reverse: True }
+
+
+  # turn admin polygons (countries, regions, etc...) into oriented boundaries with left/right names.
   - fn: vectordatasource.transform.admin_boundaries
     params:
       base_layer: boundaries
       start_zoom: 8
+
+  # try to merge boundaries into as long segments as possible.
+  - fn: vectordatasource.transform.merge_line_features
+    params:
+      source_layer: boundaries
+      start_zoom: 8
+      end_zoom: 15
+
+  # drop labels on boundaries which are too short to render.
+  - fn: vectordatasource.transform.drop_names_on_short_boundaries
+    params:
+      source_layer: boundaries
+      start_zoom: 8
+      end_zoom: 11
+      factor: 11
 
   # drop names on boundary lines (country, region, macroregion) except zoom 7 from Natural Earth
   - fn: vectordatasource.transform.drop_properties

--- a/queries.yaml
+++ b/queries.yaml
@@ -613,7 +613,10 @@ post_process:
       source_layer: boundaries
       start_zoom: 8
       end_zoom: 11
-      factor: 11
+      # pixels (256px nominal) to require per letter in the name. if lines are shorter than this,
+      # the name gets dropped. name pairs (e.g: :left and :right) get dropped if either are longer
+      # than pixels_per_letter. larger values mean fewer lines are eligible for labelling.
+      pixels_per_letter: 11
 
   # drop names on boundary lines (country, region, macroregion) except zoom 7 from Natural Earth
   - fn: vectordatasource.transform.drop_properties


### PR DESCRIPTION
This strips names off boundaries between zooms 8 and 10 when they're too long to be reasonably rendered in the tile, based on some assumption about the scale at which we'll be rendering text. This can help remove many names on very short segments of boundary that we'd never have been able to render anyway.

Additionally, merges boundary lines. We weren't doing this previously, so would have a few fragmented boundaries which were duplicating properties and inflating feature count.

Some quick tests show we're reducing GeoJSON boundaries layer size by around 23% on tile `8/134/89` and MVT boundaries layer size by 9% (because MVT is already deduplicating the name values there's less opportunity for us to save.)

One observation: Many of the names which are using a lot of bytes are not long in terms of number of rendered characters, but the characters take up more space encoded as UTF-8. It would be interesting to see how many of these we could compress away as transliterations, but that would require client-side support.

Connects to #1683.
