### PR TITLE
Drop bicycle network and shield text to match style.

### DIFF
--- a/integration-test/1170-very-early-paths-and-bike-routes.py
+++ b/integration-test/1170-very-early-paths-and-bike-routes.py
@@ -130,12 +130,19 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
         self.load_fixtures([
             'http://www.openstreetmap.org/way/44422697',
             'http://www.openstreetmap.org/relation/325779',
-        ], clip=self.tile_bbox(10, 164, 396))
+        ], clip=self.tile_bbox(13, 1313, 3172))
 
+        # keeps bicycle_network at zoom 13
+        self.assert_has_feature(
+            13, 1313, 3172, 'roads',
+            {'kind': 'path', 'is_bicycle_related': True,
+             'bicycle_network': 'rcn'})
+
+        # keeps is_bicycle_related at zoom 10
         self.assert_has_feature(
             10, 164, 396, 'roads',
             {'kind': 'path', 'is_bicycle_related': True,
-             'bicycle_network': 'rcn'})
+             'bicycle_network': type(None)})
 
     def test_residential_with_regional_route(self):
         # Hyltebjerg Allé residential road with rcn in Copenhagen
@@ -144,32 +151,38 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             'https://www.openstreetmap.org/relation/2087590',
         ], clip=self.tile_bbox(10, 547, 320))
 
+        # keep bicycle_network until 13
         self.assert_has_feature(
-            10, 547, 320, 'roads',
+            13, 4379, 2563, 'roads',
             {'kind': 'minor_road', 'is_bicycle_related': True,
              'bicycle_network': 'rcn'})
 
+        # keep the is_bicycle_related at lower zooms
+        self.assert_has_feature(
+            10, 547, 320, 'roads',
+            {'kind': 'minor_road', 'is_bicycle_related': True,
+             'bicycle_network': type(None)})
+
     def test_living_street_with_local_route(self):
-        # lcn in Seattle (living street that would only be visible at zoom 13
-        # otherwise) at zoom 11
+        # lcn in Seattle - LCN only visible at zoom 16
         self.load_fixtures([
             'https://www.openstreetmap.org/way/6477775',
             'https://www.openstreetmap.org/relation/3541926',
-        ], clip=self.tile_bbox(11, 327, 715))
+        ], clip=self.tile_bbox(16, 10492, 22900))
 
         self.assert_has_feature(
-            11, 327, 715, 'roads',
+            16, 10492, 22900, 'roads',
             {'kind': 'minor_road', 'bicycle_network': 'lcn'})
 
     def test_kirkham_street_lcn(self):
-        # Kirkham Street lcn in San Francisco at zoom 11
+        # Kirkham Street lcn in San Francisco at zoom 16
         self.load_fixtures([
             'https://www.openstreetmap.org/way/89802424',
             'https://www.openstreetmap.org/relation/32313',
-        ], clip=self.tile_bbox(11, 327, 791))
+        ], clip=self.tile_bbox(16, 10471, 25334))
 
         self.assert_has_feature(
-            11, 327, 791, 'roads',
+            16, 10471, 25334, 'roads',
             {'kind': 'minor_road', 'bicycle_network': 'lcn'})
 
     def test_asiatisk_plads_service_road_lcn(self):
@@ -177,8 +190,8 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
         self.load_fixtures([
             'https://www.openstreetmap.org/way/164049387',
             'https://www.openstreetmap.org/relation/6199242',
-        ], clip=self.tile_bbox(11, 1095, 641))
+        ], clip=self.tile_bbox(16, 35059, 20513))
 
         self.assert_has_feature(
-            11, 1095, 641, 'roads',
+            16, 35059, 20513, 'roads',
             {'kind': 'minor_road', 'bicycle_network': 'lcn'})

--- a/integration-test/1175-bicycle-route-refs.py
+++ b/integration-test/1175-bicycle-route-refs.py
@@ -4,34 +4,38 @@ from . import FixtureTest
 class BicycleRouteRefs(FixtureTest):
 
     def test_lcn45(self):
-        # https://www.openstreetmap.org/way/417389551
-        #   lcn_ref=45
-        # https://www.openstreetmap.org/relation/32310
-        #   type=route, route=bicycle, network=lcn, ref=45
-        self.load_fixtures(['https://www.openstreetmap.org/way/417389551',
-                            'https://www.openstreetmap.org/relation/32310'],
-                           clip=self.tile_bbox(10, 163, 395))
+        import dsl
+
+        z, x, y = (16, 10481, 25336)
+
+        self.generate_fixtures(
+            dsl.way(417389551, dsl.tile_diagonal(z, x, y), {
+                'source': 'openstreetmap.org',
+                'highway': 'tertiary',
+                'cycleway': 'lane',
+                'lcn_ref': '45',
+            }),
+            dsl.relation(32310, {
+                'type': 'route',
+                'route': 'bicycle',
+                'network': 'lcn',
+                'ref': '45',
+            }, ways=[417389551]),
+        )
 
         self.assert_has_feature(
-            16, 10481, 25336, 'roads',
+            z, x, y, 'roads',
             {'id': 417389551,
              'bicycle_network': None,
              'bicycle_shield_text': '45',
              'all_bicycle_networks': None,
              'all_bicycle_shield_texts': ['45']})
 
-        # make sure the all_* lists are gone by zoom 12 on major roads, but
-        # the "most important", singular network & shield text remain at
-        # earlier zooms
-        self.assert_has_feature(
-            10, 163, 395, 'roads',
-            {'bicycle_network': None,
-             'bicycle_shield_text': '45'})
-
+        # make sure the properties are gone by zoom 15
         self.assert_no_matching_feature(
-            12, 655, 1583, 'roads',
+            z-1, x//2, y//2, 'roads',
             {'all_bicycle_networks': None})
 
         self.assert_no_matching_feature(
-            12, 655, 1583, 'roads',
+            z-1, x//2, y//2, 'roads',
             {'all_bicycle_shield_texts': None})

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -60,10 +60,14 @@ class RoadsSurface(FixtureTest):
                 'kind_detail': 'track',
                 'is_bicycle_related': True,
                 'surface': 'concrete_lanes',
-                'bicycle_network': 'ncn',
                 'min_zoom': 8,
-                'bicycle_shield_text': 'D10',
             }
+
+            if z >= 13:
+                props.update({
+                    'bicycle_network': 'ncn',
+                    'bicycle_shield_text': 'D10',
+                })
 
             self.assert_has_feature(
                 z, 17456 / coord_scale, 10780 / coord_scale, 'roads', props)

--- a/integration-test/1331-drop-road-properties.py
+++ b/integration-test/1331-drop-road-properties.py
@@ -15,7 +15,7 @@ class DropRoadPropertiesTest(FixtureTest):
         # zoom <= 12.
         import dsl
 
-        z, x, y = (13, 4096, 4096)
+        z, x, y = (12, 2048, 2048)
 
         self.generate_fixtures(
             # note: use a major road type, so that the road still exists at
@@ -33,22 +33,29 @@ class DropRoadPropertiesTest(FixtureTest):
             }, ways=[1]),
         )
 
-        # should exist with all properties at zoom 13
+        # should exist with all properties at zoom 12
         self.assert_has_feature(
             z, x, y, 'roads', {
                 'id': 1,
+                'kind': 'major_road',
                 'bicycle_network': u'rcn',
                 'bicycle_shield_text': u'X',
             })
 
-        # should drop properties by zoom 12
-        self.assert_no_matching_feature(
+        # should drop shield text property at zoom 11
+        self.assert_has_feature(
             z-1, x//2, y//2, 'roads', {
-                'bicycle_network': None,
+                'kind': 'major_road',
+                'bicycle_network': u'rcn',
+                'bicycle_shield_text': type(None),
             })
-        self.assert_no_matching_feature(
-            z-1, x//2, y//2, 'roads', {
-                'bicycle_shield_text': None,
+
+        # and drop everything by zoom 10
+        self.assert_has_feature(
+            z-2, x//4, y//4, 'roads', {
+                'kind': 'major_road',
+                'bicycle_network': type(None),
+                'bicycle_shield_text': type(None),
             })
 
     def test_track(self):
@@ -105,10 +112,10 @@ class DropRoadPropertiesTest(FixtureTest):
         #             visible: false
         #
         # roughly translates to: don't draw shields on LCN networks when
-        # zoom <= 15.
+        # zoom < 15.
         import dsl
 
-        z, x, y = (16, 0, 0)
+        z, x, y = (15, 0, 0)
 
         self.generate_fixtures(
             dsl.way(1, dsl.tile_diagonal(z, x, y), {
@@ -124,20 +131,27 @@ class DropRoadPropertiesTest(FixtureTest):
             }, ways=[1]),
         )
 
-        # should exist with all properties at zoom 16 (as should everything).
+        # should exist with all properties at zoom 15.
         self.assert_has_feature(
             z, x, y, 'roads', {
                 'id': 1,
+                'kind': 'minor_road',
                 'bicycle_network': u'lcn',
                 'bicycle_shield_text': u'X',
             })
 
-        # should drop properties by zoom 15
-        self.assert_no_matching_feature(
+        # should drop shield text by zoom 14
+        self.assert_has_feature(
             z-1, x//2, y//2, 'roads', {
-                'bicycle_network': None,
+                'kind': 'minor_road',
+                'bicycle_network': u'lcn',
+                'bicycle_shield_text': type(None),
             })
-        self.assert_no_matching_feature(
-            z-1, x//2, y//2, 'roads', {
-                'bicycle_shield_text': None,
+
+        # should drop everything by <= 13
+        self.assert_has_feature(
+            z-2, x//4, y//4, 'roads', {
+                'kind': 'minor_road',
+                'bicycle_network': type(None),
+                'bicycle_shield_text': type(None),
             })

--- a/integration-test/1331-drop-road-properties.py
+++ b/integration-test/1331-drop-road-properties.py
@@ -1,0 +1,143 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class DropRoadPropertiesTest(FixtureTest):
+
+    def test_rcn(self):
+        # network_rcn:
+        #     filter: { bicycle_network: rcn, $zoom: { max: 12 } }
+        #     draw:
+        #         mapzen_icon_library:
+        #             visible: false
+        #
+        # roughly translates to: don't draw shields on RCN networks when
+        # zoom <= 12.
+        import dsl
+
+        z, x, y = (13, 4096, 4096)
+
+        self.generate_fixtures(
+            # note: use a major road type, so that the road still exists at
+            # low zooms.
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': u'trunk',
+                'source': u'openstreetmap.org',
+            }),
+            dsl.relation(2, {
+                'type': u'route',
+                'route': u'bicycle',
+                'network': u'rcn',
+                'ref': u'X',
+                'source': u'openstreetmap.org',
+            }, ways=[1]),
+        )
+
+        # should exist with all properties at zoom 13
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 1,
+                'bicycle_network': u'rcn',
+                'bicycle_shield_text': u'X',
+            })
+
+        # should drop properties by zoom 12
+        self.assert_no_matching_feature(
+            z-1, x//2, y//2, 'roads', {
+                'bicycle_network': None,
+            })
+        self.assert_no_matching_feature(
+            z-1, x//2, y//2, 'roads', {
+                'bicycle_shield_text': None,
+            })
+
+    def test_track(self):
+        # tracks_network_rcn:
+        #     filter: { $zoom: { max: 12 }, kind_detail: track }
+        #     draw:
+        #         mapzen_icon_library:
+        #             visible: false
+        #
+        # roughly translates to: don't draw shields on tracks when zoom<=12.
+        import dsl
+
+        z, x, y = (13, 4096, 4096)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': u'track',
+                'surface': u'paved',
+                'source': u'openstreetmap.org',
+            }),
+            dsl.relation(2, {
+                'type': u'route',
+                'route': u'bicycle',
+                'network': u'icn',
+                'ref': u'X',
+                'source': u'openstreetmap.org',
+            }, ways=[1]),
+        )
+
+        # should exist with all properties at zoom 13
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 1,
+                'bicycle_network': u'icn',
+                'bicycle_shield_text': u'X',
+                'min_zoom': 11,
+            })
+
+        # should drop properties by zoom 12
+        self.assert_no_matching_feature(
+            z-1, x//2, y//2, 'roads', {
+                'bicycle_network': None,
+            })
+        self.assert_no_matching_feature(
+            z-1, x//2, y//2, 'roads', {
+                'bicycle_shield_text': None,
+            })
+
+    def test_lcn(self):
+        # network_lcn:
+        #     filter: { bicycle_network: lcn, $zoom: { max: 15 } }
+        #     draw:
+        #         mapzen_icon_library:
+        #             visible: false
+        #
+        # roughly translates to: don't draw shields on LCN networks when
+        # zoom <= 15.
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': u'residential',
+                'source': u'openstreetmap.org',
+            }),
+            dsl.relation(2, {
+                'type': u'route',
+                'route': u'bicycle',
+                'network': u'lcn',
+                'ref': u'X',
+                'source': u'openstreetmap.org',
+            }, ways=[1]),
+        )
+
+        # should exist with all properties at zoom 16 (as should everything).
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 1,
+                'bicycle_network': u'lcn',
+                'bicycle_shield_text': u'X',
+            })
+
+        # should drop properties by zoom 15
+        self.assert_no_matching_feature(
+            z-1, x//2, y//2, 'roads', {
+                'bicycle_network': None,
+            })
+        self.assert_no_matching_feature(
+            z-1, x//2, y//2, 'roads', {
+                'bicycle_shield_text': None,
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -991,30 +991,52 @@ post_process:
       properties:
         - walking_network
         - walking_shield_text
-  # drop RCN network & shield text below zoom 13.
+  # drop RCN network & shield text below zoom 11, and shield text at one more
+  # zoom.
+  # https://github.com/tilezen/vector-datasource/pull/1707#discussion_r236522771
   - fn: vectordatasource.transform.drop_properties
     params:
       source_layer: roads
       start_zoom: 0
-      end_zoom: 13
+      end_zoom: 11
       properties:
         - bicycle_network
         - bicycle_shield_text
       where: >-
         bicycle_network == 'rcn'
-  # drop LCN network & shield text below zoom 16. this is earlier than a
-  # previous drop of the all_*, so make sure we clear those out too.
   - fn: vectordatasource.transform.drop_properties
     params:
       source_layer: roads
       start_zoom: 0
-      end_zoom: 16
+      end_zoom: 12
+      properties:
+        - bicycle_shield_text
+      where: >-
+        bicycle_network == 'rcn'
+  # drop LCN network & shield text below zoom 14 and shield text only at
+  # one more zoom level. (should be present at zoom 15).
+  # https://github.com/tilezen/vector-datasource/pull/1707#discussion_r236523895
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 14
       properties:
         - bicycle_network
         - bicycle_shield_text
       where: >-
         bicycle_network == 'lcn'
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 15
+      properties:
+        - bicycle_shield_text
+      where: >-
+        bicycle_network == 'lcn'
   # drop any bicycle network & shield text on tracks below zoom 13.
+  # https://github.com/tilezen/vector-datasource/pull/1707#discussion_r236524127
   - fn: vectordatasource.transform.drop_properties
     params:
       source_layer: roads

--- a/queries.yaml
+++ b/queries.yaml
@@ -821,12 +821,20 @@ post_process:
       start_zoom: 0
       end_zoom: 14
       properties:
-        - all_bicycle_networks
-        - all_bicycle_shield_texts
         - all_walking_networks
         - all_walking_shield_texts
         - all_bus_networks
         - all_bus_shield_texts
+  # drop all_bicycle_* until the max zoom:
+  # https://github.com/tilezen/vector-datasource/pull/1707#discussion_r236522176
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 16
+      properties:
+        - all_bicycle_networks
+        - all_bicycle_shield_texts
   # drop certain road properties at lower zooms
   - fn: vectordatasource.transform.drop_properties
     params:
@@ -929,8 +937,6 @@ post_process:
       start_zoom: 0
       end_zoom: 11
       properties:
-        - all_bicycle_networks
-        - all_bicycle_shield_texts
         - all_walking_networks
         - all_walking_shield_texts
         - bus_network
@@ -1006,8 +1012,6 @@ post_process:
       properties:
         - bicycle_network
         - bicycle_shield_text
-        - all_bicycle_networks
-        - all_bicycle_shield_texts
       where: >-
         bicycle_network == 'lcn'
   # drop any bicycle network & shield text on tracks below zoom 13.

--- a/queries.yaml
+++ b/queries.yaml
@@ -985,6 +985,42 @@ post_process:
       properties:
         - walking_network
         - walking_shield_text
+  # drop RCN network & shield text below zoom 13.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 13
+      properties:
+        - bicycle_network
+        - bicycle_shield_text
+      where: >-
+        bicycle_network == 'rcn'
+  # drop LCN network & shield text below zoom 16. this is earlier than a
+  # previous drop of the all_*, so make sure we clear those out too.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 16
+      properties:
+        - bicycle_network
+        - bicycle_shield_text
+        - all_bicycle_networks
+        - all_bicycle_shield_texts
+      where: >-
+        bicycle_network == 'lcn'
+  # drop any bicycle network & shield text on tracks below zoom 13.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: roads
+      start_zoom: 0
+      end_zoom: 13
+      properties:
+        - bicycle_network
+        - bicycle_shield_text
+      where: >-
+        kind == 'path' and kind_detail == 'track'
   - fn: vectordatasource.transform.update_parenthetical_properties
     params:
       source_layer: pois

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -2294,9 +2294,12 @@ def _project_properties(ctx, action):
             new_features.append((shape, props, fid))
             continue
 
-        # copy params to add a 'zoom' one. would prefer '$zoom', but apparently
-        # that's not allowed in python syntax.
-        local = props.copy()
+        # we're going to use a defaultdict for this, so that references to
+        # properties which don't exist just end up as None without causing an
+        # exception. we also add a 'zoom' one. would prefer '$zoom', but
+        # apparently that's not allowed in python syntax.
+        local = defaultdict(lambda: None)
+        local.update(props)
         local['zoom'] = zoom
 
         # allow decisions based on meters per pixel zoom too.


### PR DESCRIPTION
Drop RCN from 12 down to 0, LCN from 15 down to 0, and any network on track paths from 12 down to zero. These properties inhibit some degree of merging at mid zooms.

[Context](https://github.com/tilezen/vector-datasource/issues/1331#issuecomment-439132593).

Connects to #1331. (Note that this is one part of many - submitting a PR for each to avoid it becoming unreadably large.)
