### PR TITLE
Too many service areas

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1042,7 +1042,7 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- return the min zoom for a node that looks like a rest area.
-CREATE OR REPLACE FUNCTION tz_looks_like_service_area(name TEXT)
+CREATE OR REPLACE FUNCTION tz_looks_like_rest_area(name TEXT)
 RETURNS INTEGER AS $$
 BEGIN
   IF name ILIKE '%rest area' THEN

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1029,3 +1029,14 @@ BEGIN
   );
 END
 $$ LANGUAGE plpgsql STABLE;
+
+-- return the min zoom for a node that looks like a service area.
+CREATE OR REPLACE FUNCTION tz_looks_like_service_area(name TEXT)
+RETURNS INTEGER AS $$
+BEGIN
+  IF name ILIKE '%service area' OR name ILIKE '%services' OR name ILIKE '%travel plaza' THEN
+    RETURN 13
+  END IF;
+  RETURN 17;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1040,3 +1040,14 @@ BEGIN
   RETURN 17;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- return the min zoom for a node that looks like a rest area.
+CREATE OR REPLACE FUNCTION tz_looks_like_service_area(name TEXT)
+RETURNS INTEGER AS $$
+BEGIN
+  IF name ILIKE '%rest area' THEN
+    RETURN 13
+  END IF;
+  RETURN 17;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/integration-test/1698-too-many-service-areas.py
+++ b/integration-test/1698-too-many-service-areas.py
@@ -1,0 +1,157 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class TooManyServiceAreasTest(FixtureTest):
+
+    def test_large_service_area(self):
+        import dsl
+
+        z, x, y = (11, 602, 769)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/193904383
+            dsl.way(193904383, dsl.tile_box(z, x, y), {
+                'area': u'yes',
+                'highway': u'services',
+                'name': u'Alexander Hamilton Service Area',
+                'source': u'openstreetmap.org',
+                'toilets': u'yes',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 193904383,
+                'kind': 'service_area',
+                'min_zoom': 11,
+            })
+
+    def test_tiny_service_area(self):
+        # this really looks more like mistagging than a service area, not even
+        # a small one.
+        import dsl
+        from shapely.wkt import loads as wkt_loads
+
+        z, x, y = (16, 19285, 24783)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/427844785
+            dsl.way(
+                427844785,
+                wkt_loads(
+                    'POLYGON(('
+                    '-74.0621163 40.1128853002825,'
+                    '-74.0620970 40.1128760002825,'
+                    '-74.0620736 40.1129032002825,'
+                    '-74.0620939 40.1129133002825,'
+                    '-74.0621163 40.1128853002825'
+                    '))'
+                ), {
+                    'area': u'yes',
+                    'highway': u'services',
+                    'name': u'Franklin Submersibles',
+                    'source': u'openstreetmap.org',
+                }
+            ),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 427844785,
+                'kind': u'service_area',
+                'min_zoom': 17,
+            })
+
+    def test_not_really_a_service_node(self):
+        # another case of mistagging?
+        import dsl
+
+        z, x, y = (16, 19317, 24642)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5346072553
+            dsl.point(5346072553, (-73.884929, 40.701724), {
+                'addr:street': u'Myrtle Avenue',
+                'highway': u'services',
+                'name': u'GPS Roofing',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5346072553,
+                'kind': u'service_area',
+                'min_zoom': 17,
+            })
+
+    def test_service_area(self):
+        import dsl
+
+        z, x, y = (13, 2380, 3110)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4938688427
+            dsl.point(4938688427, (-75.396299, 39.695616), {
+                'highway': u'services',
+                'name': u'John Fenwick Service Area',
+                'name:en': u'John Fenwick Service Area',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4938688427,
+                'kind': u'service_area',
+                'min_zoom': 13,
+            })
+
+    def test_services(self):
+        import dsl
+
+        z, x, y = (13, 2380, 3110)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/3621020976
+            dsl.point(3621020976, (-75.396490, 39.698151), {
+                'highway': u'services',
+                'name': u'Clara Barton Services',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 3621020976,
+                'kind': u'service_area',
+                'min_zoom': 13,
+            })
+
+    def test_travel_plaza(self):
+        import dsl
+
+        z, x, y = (13, 2410, 3053)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/450420567
+            dsl.point(450420567, (-74.087849, 41.593617), {
+                'addr:city': u'Modena',
+                'addr:postcode': u'12548',
+                'addr:state': u'NY',
+                'alt_name': u'Modena Service Area',
+                'highway': u'services',
+                'internet_access': u'wlan',
+                'name': u'Modena Travel Plaza',
+                'operator': u'New York State Thruway Authority',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 450420567,
+                'kind': u'service_area',
+                'min_zoom': 13,
+            })

--- a/integration-test/1698-too-many-service-areas.py
+++ b/integration-test/1698-too-many-service-areas.py
@@ -155,3 +155,95 @@ class TooManyServiceAreasTest(FixtureTest):
                 'kind': u'service_area',
                 'min_zoom': 13,
             })
+
+
+class RestAreaTest(FixtureTest):
+
+    def test_rest_area_node(self):
+        import dsl
+
+        z, x, y = (13, 2418, 3054)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1114457072
+            dsl.point(1114457072, (-73.722089, 41.546596), {
+                'amenity': u'toilets',
+                'highway': u'rest_area',
+                'name': u'Stormville Rest Area',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1114457072,
+                'kind': u'rest_area',
+                'min_zoom': 13,
+            })
+
+    def test_not_a_rest_area_node(self):
+        import dsl
+
+        z, x, y = (16, 19323, 24610)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/5166808796
+            # NOTE: i've edited this since, as it's obviously not a rest area!
+            dsl.point(5166808796, (-73.855484, 40.835843), {
+                'highway': u'rest_area',
+                'name': u'Jerry\'s Pizza',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5166808796,
+                'kind': u'rest_area',
+                'min_zoom': 17,
+            })
+
+    def test_small_rest_area_way(self):
+        import dsl
+
+        z, x, y = (15, 9668, 12055)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/87098670
+            dsl.way(87098670, dsl.box_area(z, x, y, 1397), {
+                'area': u'yes',
+                'highway': u'rest_area',
+                'name': u'Clifton Park Rest Area',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 87098670,
+                'kind': u'rest_area',
+                'min_zoom': 15,
+            })
+
+    def test_large_rest_area_way(self):
+        import dsl
+
+        z, x, y = (11, 590, 754)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/319789716
+            dsl.way(319789716, dsl.box_area(z, x, y, 130087), {
+                'area': u'yes',
+                'highway': u'rest_area',
+                'name': u'Preble',
+                'source': u'openstreetmap.org',
+                'toilets': u'yes',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 319789716,
+                'kind': u'rest_area',
+                'min_zoom': 11,
+            })

--- a/integration-test/480-rest_area-services.py
+++ b/integration-test/480-rest_area-services.py
@@ -21,12 +21,14 @@ class RestAreaServices(FixtureTest):
             {'kind': 'rest_area', 'id': 97057565, 'sort_rank': 41})
 
     def test_service_area_node(self):
+        # NOTE: this has been remapped as an area now. the test data here
+        # is superseded by the 1698-too-many-service-areas test.
         # node: Tiffin River
         self.generate_fixtures(dsl.way(200412620, wkt_loads('POINT (-84.41292493378698 41.6045519557572)'), {u'source': u'openstreetmap.org', u'name': u'Tiffin River', u'highway': u'services'}))  # noqa
 
         self.assert_has_feature(
             16, 17401, 24424, 'pois',
-            {'kind': 'service_area', 'id': 200412620, 'min_zoom': 11})
+            {'kind': 'service_area', 'id': 200412620, 'min_zoom': 17})
 
     def test_service_area_way(self):
         # Way: Nicole Driveway (274732386)

--- a/integration-test/480-rest_area-services.py
+++ b/integration-test/480-rest_area-services.py
@@ -6,11 +6,11 @@ from . import FixtureTest
 
 class RestAreaServices(FixtureTest):
     def test_rest_area_node(self):
-        self.generate_fixtures(dsl.way(159773030, wkt_loads('POINT (-76.73912905210828 40.99079246918038)'), {u'source': u'openstreetmap.org', u'highway': u'rest_area'}))  # noqa
+        self.generate_fixtures(dsl.way(159773030, wkt_loads('POINT (-76.73912905210828 40.99079246918038)'), {u'source': u'openstreetmap.org', u'highway': u'rest_area', u'name': u'Foo Rest Area'}))  # noqa
 
         self.assert_has_feature(
             16, 18798, 24573, 'pois',
-            {'kind': 'rest_area', 'id': 159773030, 'min_zoom': 11})
+            {'kind': 'rest_area', 'id': 159773030, 'min_zoom': 13})
 
     def test_rest_area_way(self):
         # Way: Crystal Springs Rest Area (97057565)

--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -120,3 +120,33 @@ def is_in(iso_code, z, x, y, way_id=-1):
         'kind': 'admin_area', 'iso_code': iso_code,
         'source': 'openstreetmap.org',
     })
+
+
+def box_area(z, x, y, area):
+    """
+    Returns a Shapely Polygon which is in the z/x/y tile and has the given
+    area in Mercator square meters.
+    """
+
+    from tilequeue.tile import coord_to_mercator_bounds
+    from tilequeue.tile import reproject_mercator_to_lnglat
+    from shapely.geometry import box
+    from shapely.ops import transform
+    from ModestMaps.Core import Coordinate
+    from math import sqrt
+
+    bounds = coord_to_mercator_bounds(Coordinate(zoom=z, column=x, row=y))
+    size = sqrt(area)
+
+    # make a shape with the given size
+    centre_x = 0.5 * (bounds[0] + bounds[2])
+    centre_y = 0.5 * (bounds[1] + bounds[3])
+
+    mercator_shape = box(
+        centre_x - 0.5 * size,
+        centre_y - 0.5 * size,
+        centre_x + 0.5 * size,
+        centre_y + 0.5 * size,
+    )
+
+    return transform(reproject_mercator_to_lnglat, mercator_shape)

--- a/scripts/mktest.py
+++ b/scripts/mktest.py
@@ -100,6 +100,8 @@ def routes_using(way_id):
 def _make_ident(s):
     if isinstance(s, unicode):
         s = s.encode('ascii', 'replace')
+    elif isinstance(s, (int, long, bool, float)):
+        s = repr(s)
     return s.lower().translate(None, ':-')
 
 

--- a/vectordatasource/meta/function.py
+++ b/vectordatasource/meta/function.py
@@ -377,3 +377,16 @@ def mz_to_float_meters(length):
         return float(m.groups()[0])
 
     return None
+
+
+def tz_looks_like_service_area(name):
+    min_zoom = 17
+
+    if name is not None:
+        name = name.lower()
+        if name.endswith('service area') or \
+           name.endswith('services') or \
+           name.endswith('travel plaza'):
+            min_zoom = 13
+
+    return min_zoom

--- a/vectordatasource/meta/function.py
+++ b/vectordatasource/meta/function.py
@@ -390,3 +390,14 @@ def tz_looks_like_service_area(name):
             min_zoom = 13
 
     return min_zoom
+
+
+def tz_looks_like_rest_area(name):
+    min_zoom = 17
+
+    if name is not None:
+        name = name.lower()
+        if name.endswith('rest area'):
+            min_zoom = 13
+
+    return min_zoom

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -178,6 +178,7 @@ KNOWN_FUNCS = {
     'util.safe_int':                      'notimplemented',
     'util.true_or_none':                  'notimplemented',
     'tz_looks_like_service_area':         'tz_looks_like_service_area',
+    'tz_looks_like_rest_area':            'tz_looks_like_rest_area',
 }
 
 

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -177,6 +177,7 @@ KNOWN_FUNCS = {
     'util.tag_str_to_bool':               'notimplemented',
     'util.safe_int':                      'notimplemented',
     'util.true_or_none':                  'notimplemented',
+    'tz_looks_like_service_area':         'tz_looks_like_service_area',
 }
 
 

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -2065,8 +2065,38 @@ filters:
     output:
       <<: *output_properties
       kind: picnic_site
-  - filter: {highway: services}
-    min_zoom: 11
+
+  # service area points are hard to tell from mistagged points, but we can do
+  # an approximation by looking to see if the name matches one of several
+  # common suffixes and using that to lift the min zoom.
+  - filter:
+      all:
+        - { highway: services }
+        - { geom_type: point }
+    min_zoom: { call: { func: tz_looks_like_service_area, args: [ { col: name } ] } }
+    output:
+      <<: *output_properties
+      kind: service_area
+
+  # for service area polygons, we can look at the area, which we'd expect to
+  # be large.
+  - filter: { highway: services }
+    min_zoom:
+      lookup:
+        key: { col: way_area }
+        op: '>='
+        table:
+          # really big service area polygons tend to cover the parking lots and
+          # all the buildings (i.e: they're landuse areas).
+          - [ 11, 50000 ]
+          - [ 12, 10000 ]
+          # however, there are many smaller ones which appear to just cover a
+          # single building. ideally, these would be re-drawn to cover the whole
+          # area, but most seem to be >3000 square "meters".
+          - [ 13,  3000 ]
+          - [ 14,  1500 ]
+          - [ 15,  1000 ]
+        default: 17
     output:
       <<: *output_properties
       kind: service_area

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1308,6 +1308,76 @@ filters:
     output:
       <<: *output_properties
       kind: {col: emergency}
+
+  # NOTE: services and rest areas often have toilets, and often they're
+  # co-tagged on the same object. therefore, we have to try and match the
+  # service / rest area first, otherwise it'll get assigned as a toilet.
+  #
+  # service area points are hard to tell from mistagged points, but we can do
+  # an approximation by looking to see if the name matches one of several
+  # common suffixes and using that to lift the min zoom.
+  - filter:
+      all:
+        - { highway: services }
+        - { geom_type: point }
+    min_zoom: { call: { func: tz_looks_like_service_area, args: [ { col: name } ] } }
+    output:
+      <<: *output_properties
+      kind: service_area
+
+  # for service area polygons, we can look at the area, which we'd expect to
+  # be large.
+  - filter: { highway: services }
+    min_zoom:
+      lookup:
+        key: { col: way_area }
+        op: '>='
+        table:
+          # really big service area polygons tend to cover the parking lots and
+          # all the buildings (i.e: they're landuse areas).
+          - [ 11, 50000 ]
+          - [ 12, 10000 ]
+          # however, there are many smaller ones which appear to just cover a
+          # single building. ideally, these would be re-drawn to cover the whole
+          # area, but most seem to be >3000 square "meters".
+          - [ 13,  3000 ]
+          - [ 14,  1500 ]
+          - [ 15,  1000 ]
+        default: 17
+    output:
+      <<: *output_properties
+      kind: service_area
+  # identify rest area points from their names.
+  - filter:
+      all:
+        - { highway: rest_area }
+        - { geom_type: point }
+    min_zoom: { call: { func: tz_looks_like_rest_area, args: [ { col: name } ] } }
+    output:
+      <<: *output_properties
+      kind: rest_area
+  # and rest area polygons from their size
+  - filter: { highway: rest_area }
+    min_zoom:
+      lookup:
+        key: { col: way_area }
+        op: '>='
+        table:
+          # really big rest area polygons tend to cover the parking lots and
+          # all the buildings (i.e: they're landuse areas).
+          - [ 11, 50000 ]
+          - [ 12, 25000 ]
+          # however, there are many smaller ones which appear to just cover a
+          # single building. ideally, these would be re-drawn to cover the whole
+          # area, but most seem to be >20,000 square "meters".
+          - [ 13, 10000 ]
+          - [ 14,  5000 ]
+          - [ 15,  1000 ]
+        default: 17
+    output:
+      <<: *output_properties
+      kind: rest_area
+
   - filter: {amenity: toilets}
     min_zoom: 18
     output:
@@ -2066,45 +2136,6 @@ filters:
       <<: *output_properties
       kind: picnic_site
 
-  # service area points are hard to tell from mistagged points, but we can do
-  # an approximation by looking to see if the name matches one of several
-  # common suffixes and using that to lift the min zoom.
-  - filter:
-      all:
-        - { highway: services }
-        - { geom_type: point }
-    min_zoom: { call: { func: tz_looks_like_service_area, args: [ { col: name } ] } }
-    output:
-      <<: *output_properties
-      kind: service_area
-
-  # for service area polygons, we can look at the area, which we'd expect to
-  # be large.
-  - filter: { highway: services }
-    min_zoom:
-      lookup:
-        key: { col: way_area }
-        op: '>='
-        table:
-          # really big service area polygons tend to cover the parking lots and
-          # all the buildings (i.e: they're landuse areas).
-          - [ 11, 50000 ]
-          - [ 12, 10000 ]
-          # however, there are many smaller ones which appear to just cover a
-          # single building. ideally, these would be re-drawn to cover the whole
-          # area, but most seem to be >3000 square "meters".
-          - [ 13,  3000 ]
-          - [ 14,  1500 ]
-          - [ 15,  1000 ]
-        default: 17
-    output:
-      <<: *output_properties
-      kind: service_area
-  - filter: {highway: rest_area}
-    min_zoom: 11
-    output:
-      <<: *output_properties
-      kind: rest_area
   - filter: {amenity: grave_yard}
     min_zoom: { clamp: { min: 13, max: 17, value: { sum: [ { col: zoom }, 3 ] } } }
     output:


### PR DESCRIPTION
Reduce the number of bogus service areas at mid zooms.

The tag `highway=services` appears to get mis-applied to many motoring services stores. Since highway services, which group fuel stations, toilets, restaurants, etc..., are important and highly visible in driving-oriented styles, these mis-tagged points can be conspicuously visible.

This PR applies two filters to boost some genuine `highway=services` to low zooms while trying to keep the mis-tagged items at higher zooms. The first is an area filter, based on observed areas of genuine-looking service areas. The second is based on the name, which often includes a strong hint.

A third signal which is more complex and so wasn't used this time, but might be interesting to add to the mix if this continues to be a problem, is to look at the proximity of the nearest major road and related amenities (parking, fuel, toilets, etc...).

Apply similar logic to both service areas and rest areas.

Connects to #1698.
