### PR TITLE
Double simplification tolerance on roads and boundaries layers.

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -234,7 +234,7 @@ layers:
   buildings:
     simplify_before_intersect: yes
     area_threshold: 0.0
-    tolerance: 0.0
+    tolerance: 1.0
     clip_factor: 3.0
     geometry_types: [Point, MultiPoint, Polygon, MultiPolygon]
     transform:

--- a/queries.yaml
+++ b/queries.yaml
@@ -210,6 +210,7 @@ layers:
   roads:
     geometry_types: [LineString, MultiLineString]
     simplify_start: 8
+    tolerance: 2.0
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.tags_name_i18n
@@ -279,6 +280,7 @@ layers:
     geometry_types: [Polygon, MultiPolygon, LineString, MultiLineString]
     simplify_before_intersect: true
     simplify_start: 8
+    tolerance: 2.0
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.tags_name_i18n

--- a/queries.yaml
+++ b/queries.yaml
@@ -1302,7 +1302,8 @@ post_process:
   # multilinestrings which do not have nodes at junctions.
   #
   # note that the linestrings are already simplified by preceding simplify
-  # and clip stage.
+  # and clip stage. we don't want to simplify too much more at this stage, as
+  # that could lead to odd-looking double-simplified stuff.
   - fn: vectordatasource.transform.merge_line_features
     params:
       source_layer: roads
@@ -1317,7 +1318,10 @@ post_process:
       # shorter than 0.1px at nominal zoom to be dropped.
       drop_short_segments: true
       drop_length_pixels: 0.1
-      # integrated simplification step tolerance
+      # integrated simplification step tolerance. NOTE: simplification is only
+      # performed if junction merging is set to true! the idea is to simplify
+      # away points at junctions where the road is straight, so it shouldn't
+      # need to be a large tolerance.
       simplify_tolerance: 1.0
 
   # we do want to merge at 15, but we don't want to merge junctions becase that

--- a/queries.yaml
+++ b/queries.yaml
@@ -1332,8 +1332,6 @@ post_process:
       # shorter than 0.1px at nominal zoom to be dropped.
       drop_short_segments: true
       drop_length_pixels: 0.1
-      # integrated simplification step tolerance
-      simplify_tolerance: 1.0
 
   # NOTE: want to do this _before_ buildings_unify, as after that we might not
   # have a feature ID to match buildings on!


### PR DESCRIPTION
This doubles the simplification tolerance from 1 to 2 on roads and boundary layers.

I was expecting noticeable results, but the images look visually extremely similar, and the tile size changes are down in the noise:


Nominal zoom | Average tile size - master | Average tile size- branch |  Reduction
-- | -- | -- | --
7 | 34870 | 34828 | 0.12%
8 | 36496 | 36482 | 0.04%
9 | 56668 | 56648 | 0.04%
10 | 112210 | 112207 | 0.00%
11 | 198046 | 197988 | 0.03%
12 | 168503 | 168518 | -0.01%
13 | 105679 | 105681 | 0.00%
14 | 78279 | 78279 | 0.00%
15 | 76124 | 76125 | 0.00%

Connects to #641.

Here's a zoom sequence over New York (don't worry about the missing data - my local DB is currently loaded with only NY & NJ). Left is current master, right is this PR/branch.

## Zoom 15
<img src="https://user-images.githubusercontent.com/271360/49511512-4a8da080-f883-11e8-96b7-1e46c362a0f0.png" width="325px" title="Master, zoom 15"/><img src="https://user-images.githubusercontent.com/271360/49511548-5d07da00-f883-11e8-92a2-2b1fd811aeee.png" width="325px" title="Branch, zoom 15"/>

## Zoom 14
<img title="master-z14" src="https://user-images.githubusercontent.com/271360/49511529-52e5db80-f883-11e8-82d0-04debc562e31.png" width="325px"/><img title="branch-z14" src="https://user-images.githubusercontent.com/271360/49511847-30a08d80-f884-11e8-8447-ea1588f0fef9.png" width="325px"/>

# Zoom 13
<img title="master-z13" src="https://user-images.githubusercontent.com/271360/49512048-b7ee0100-f884-11e8-973b-407c26ad8194.png" width="325px"/><img title="branch-z13" src="https://user-images.githubusercontent.com/271360/49511872-3b5b2280-f884-11e8-8b48-46fc77e39627.png" width="325px"/>

# Zoom 12
<img title="master-z12" src="https://user-images.githubusercontent.com/271360/49512046-b7556a80-f884-11e8-90a6-21a1baac097b.png" width="325px"/><img title="branch-z12" src="https://user-images.githubusercontent.com/271360/49511871-3b5b2280-f884-11e8-8f60-90f7325c4ead.png" width="325px"/>

# Zoom 11
<img title="master-z11" src="https://user-images.githubusercontent.com/271360/49512045-b7556a80-f884-11e8-8130-b40dff968dac.png" width="325px"/><img title="branch-z11" src="https://user-images.githubusercontent.com/271360/49511870-3b5b2280-f884-11e8-9f1b-8064ffdab906.png" width="325px"/>

## Zoom 10
<img title="master-z10" src="https://user-images.githubusercontent.com/271360/49512044-b7556a80-f884-11e8-9f5d-29a0387a0633.png" width="325px"/><img title="branch-z10" src="https://user-images.githubusercontent.com/271360/49511869-3b5b2280-f884-11e8-8d39-f3d7342defc7.png" width="325px"/>

## Zoom 9
<img title="master-z09" src="https://user-images.githubusercontent.com/271360/49512043-b7556a80-f884-11e8-8d52-d3d82ccdb932.png" width="325px"/><img title="branch-z09" src="https://user-images.githubusercontent.com/271360/49511868-3b5b2280-f884-11e8-85ef-8afbfa3df88b.png" width="325px"/>

## Zoom 8
<img title="master-z08" src="https://user-images.githubusercontent.com/271360/49512042-b7556a80-f884-11e8-8688-f6a85695a1d2.png" width="325px"/><img title="branch-z08" src="https://user-images.githubusercontent.com/271360/49511867-3ac28c00-f884-11e8-8dc5-a37e87fde2af.png" width="325px"/>

## Zoom 7
<img title="master-z07" src="https://user-images.githubusercontent.com/271360/49512041-b6bcd400-f884-11e8-8ebb-a6c6d6d34619.png" width="325px"/><img title="branch-z07" src="https://user-images.githubusercontent.com/271360/49511865-3ac28c00-f884-11e8-959b-49ae0660317c.png" width="325px"/>
