### PR TITLE
Reduce surface tag precision

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1305,7 +1305,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `all_bus_networks` and `all_bus_shield_texts`: All of the bus and trolley-bus routes of which this road is a part, and each corresponding shield text. See `bus_network` and `bus_shield_text` below. **Note** that these properties will not be present on MVT format tiles, as we cannot currently encode lists as values.
 * `bus_network`: Note that this is often not present for bus routes / networks. This may be replaced with `operator` in the future, see [issue 1194](https://github.com/tilezen/vector-datasource/issues/1194).
 * `bus_shield_text`: Contains text intended to be displayed on a shield related to the bus or trolley-bus network. This is the value from the `ref` tag and is _not_ guaranteed to be numeric, or even concise.
-* `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`. `cobblestone:flattened`, `concrete:plates` and `concrete:lanes` values are transformed to `cobblestone_flattened`, `concrete_plates` and `concrete_lanes` respectively.
+* `surface`: Common values include `asphalt`, `unpaved`, `paved`, `ground`, `gravel`, `dirt`, `concrete`, `grass`, `paving_stones`, `compacted`, `sand`, and `cobblestone`. `cobblestone:flattened`, `concrete:plates` and `concrete:lanes` values are transformed to `cobblestone_flattened`, `concrete_plates` and `concrete_lanes` respectively. These values are simplified at lower zooms, see the section "Roads surface values simplification" for more details.
 
 #### Road properties (optional):
 
@@ -2010,6 +2010,20 @@ Alpha-2 code | Country
 `ZM` | Zambia
 `ZW` | Zimbabwe
 
+
+#### Roads surface values simplification
+
+At lower zooms,
+
+* 14 or lower for `minor_road`,
+* 12 or lower for `path` and
+* 11 or lower for `major_road`
+
+The range of `surface` values is simplified to just 3: `paved`, `compacted` or `unpaved`. The detailed range of values is mapped down as follows:
+
+* `asphalt`, `metal`, `metal_grid`, `paved`, `tartan`, `wood` are simplified to `paved`.
+* `concrete`, `paving_stones`, `sett` are simplified to `compacted`.
+* `artificial_turf`, `clay`, `cobblestone`, `cobblestone_flattened`, `concrete_lanes`, `concrete_plates`, `decoturf`, `dirt`, `earth`, `fine_gravel`, `grass`, `grass_paver`, `gravel`, `ground`, `mud`, `pebblestone`, `salt`, `sand`, `woodchips` are simplified to `unpaved`.
 
 ## Transit
 

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -12,10 +12,10 @@ class RoadsSurface(FixtureTest):
             15, 9371, 12546, 'roads',
             {'id': 190536019, 'kind': 'minor_road', 'surface': 'cobblestone'})
 
-        # and that surface property is dropped at earlier zooms
+        # and that surface property is simplified at some zooms
         self.assert_has_feature(
             13, 2342, 3136, 'roads',
-            {'id': 190536019, 'kind': 'minor_road', 'surface': type(None)})
+            {'id': 190536019, 'kind': 'minor_road', 'surface': 'unpaved'})
 
     def test_asphalt(self):
         # motorway in Kraków, Poland
@@ -60,7 +60,7 @@ class RoadsSurface(FixtureTest):
                 'kind': 'path',
                 'kind_detail': 'track',
                 'is_bicycle_related': True,
-                'surface': 'concrete_lanes',
+                'surface': 'concrete_lanes' if z >= 12 else 'unpaved',
                 'min_zoom': 8,
             }
 

--- a/integration-test/1716-reduce-surface-tag-precision.py
+++ b/integration-test/1716-reduce-surface-tag-precision.py
@@ -42,3 +42,57 @@ class ResidentialTest(FixtureTest):
                 'id': 1,
                 'surface': expect_surface,
             })
+
+
+class HighwayTest(FixtureTest):
+
+    def test_z16(self):
+        self._check(zoom=16, expect_surface='asphalt')
+
+    def test_z15(self):
+        self._check(zoom=15, expect_surface='asphalt')
+
+    def test_z14(self):
+        self._check(zoom=14, expect_surface='asphalt')
+
+    def test_z13(self):
+        self._check(zoom=13, expect_surface='asphalt')
+
+    def test_z12(self):
+        self._check(zoom=12, expect_surface='asphalt')
+
+    def test_z11(self):
+        self._check(zoom=11, expect_surface='asphalt')
+
+    def test_z10(self):
+        self._check(zoom=10, expect_surface='paved')
+
+    def test_z09(self):
+        self._check(zoom=9, expect_surface='paved')
+
+    def test_z08(self):
+        self._check(zoom=8, expect_surface='paved')
+
+    def setUp(self):
+        FixtureTest.setUp(self)
+
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        full_tags = {
+            'source': 'openstreetmap.org',
+            'highway': 'motorway',
+            'surface': 'asphalt',
+        }
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), full_tags),
+        )
+
+    def _check(self, zoom=16, expect_surface=None):
+        self.assert_has_feature(
+            zoom, 0, 0, 'roads', {
+                'id': 1,
+                'surface': expect_surface,
+            })

--- a/integration-test/1716-reduce-surface-tag-precision.py
+++ b/integration-test/1716-reduce-surface-tag-precision.py
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class ResidentialTest(FixtureTest):
+
+    def test_z16(self):
+        self._check(zoom=16, expect_surface='fine_gravel')
+
+    def test_z15(self):
+        self._check(zoom=15, expect_surface='fine_gravel')
+
+    def test_z14(self):
+        self._check(zoom=14, expect_surface='unpaved')
+
+    def test_z13(self):
+        self._check(zoom=13, expect_surface='unpaved')
+
+    def test_z12(self):
+        self._check(zoom=12, expect_surface='unpaved')
+
+    def setUp(self):
+        FixtureTest.setUp(self)
+
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        full_tags = {
+            'source': 'openstreetmap.org',
+            'highway': 'residential',
+            'surface': 'fine_gravel',
+        }
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), full_tags),
+        )
+
+    def _check(self, zoom=16, expect_surface=None):
+        self.assert_has_feature(
+            zoom, 0, 0, 'roads', {
+                'id': 1,
+                'surface': expect_surface,
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -921,16 +921,60 @@ post_process:
         - type
       where: >-
         kind == 'minor_road'
-  # keep "surface" until zoom 15.
-  - fn: vectordatasource.transform.drop_properties
+  # reduce precision of surface tags at roughly the same zoom as we drop the
+  # name (i.e: when we no longer want to uniquely identify the road). this gives
+  # us more opportunities to merge features with other features having the same
+  # set of properties, which can result in much fewer distinct features and
+  # therefore smaller tiles.
+  - fn: vectordatasource.transform.whitelist
     params:
-      source_layer: roads
+      layer: roads
       start_zoom: 0
       end_zoom: 15
-      properties:
-        - surface
+      property: surface
       where: >-
-        kind == 'minor_road'
+        (kind == 'minor_road') or
+        (kind in ('major_road', 'highway') and zoom < 11) or
+        (kind == 'path' and zoom < 12)
+      # map down to these three values (plus implicit missing / None value)
+      whitelist:
+        - paved
+        - compacted
+        - unpaved
+      remap:
+        # paved
+        asphalt: paved
+        metal: paved
+        metal_grid: paved
+        tartan: paved
+        wood: paved
+
+        # compacted
+        concrete: compacted
+        paving_stones: compacted
+        sett: compacted
+
+        # unpaved
+        artificial_turf: unpaved
+        clay: unpaved
+        cobblestone: unpaved
+        cobblestone_flattened: unpaved
+        concrete_lanes: unpaved
+        concrete_plates: unpaved
+        decoturf: unpaved
+        dirt: unpaved
+        earth: unpaved
+        fine_gravel: unpaved
+        grass: unpaved
+        grass_paver: unpaved
+        gravel: unpaved
+        ground: unpaved
+        mud: unpaved
+        pebblestone: unpaved
+        salt: unpaved
+        sand: unpaved
+        woodchips: unpaved
+
   # drop to get better merging at mid zooms.
   - fn: vectordatasource.transform.drop_properties
     params:

--- a/queries.yaml
+++ b/queries.yaml
@@ -975,6 +975,17 @@ post_process:
         sand: unpaved
         woodchips: unpaved
 
+  # # backfill surface=paved for minor roads at zooms 13 and 14
+  # - fn: vectordatasource.transform.backfill
+  #   params:
+  #     layer: roads
+  #     start_zoom: 13
+  #     end_zoom: 15
+  #     defaults:
+  #       surface: paved
+  #     where: >-
+  #       kind == 'minor_road'
+
   # drop to get better merging at mid zooms.
   - fn: vectordatasource.transform.drop_properties
     params:

--- a/queries.yaml
+++ b/queries.yaml
@@ -975,17 +975,6 @@ post_process:
         sand: unpaved
         woodchips: unpaved
 
-  # # backfill surface=paved for minor roads at zooms 13 and 14
-  # - fn: vectordatasource.transform.backfill
-  #   params:
-  #     layer: roads
-  #     start_zoom: 13
-  #     end_zoom: 15
-  #     defaults:
-  #       surface: paved
-  #     where: >-
-  #       kind == 'minor_road'
-
   # drop to get better merging at mid zooms.
   - fn: vectordatasource.transform.drop_properties
     params:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8212,3 +8212,46 @@ def whitelist(ctx):
                 props.pop(property_name)
 
     return None
+
+
+def backfill(ctx):
+    """
+    Backfills default values for some features. In other words, if the feature
+    lacks some or all of the defaults, then set those defaults.
+    """
+
+    params = _Params(ctx, 'whitelist')
+    layer_name = params.required('layer')
+    start_zoom = params.optional('start_zoom', default=0, typ=int)
+    end_zoom = params.optional('end_zoom', typ=int)
+    defaults = params.required('defaults', typ=dict)
+    where = params.optional('where')
+
+    # check that we're in the zoom range where this post-processor is supposed
+    # to operate.
+    if ctx.nominal_zoom < start_zoom:
+        return None
+    if end_zoom is not None and ctx.nominal_zoom >= end_zoom:
+        return None
+
+    if where is not None:
+        where = compile(where, 'queries.yaml', 'eval')
+
+    layer = _find_layer(ctx.feature_layers, layer_name)
+
+    features = layer['features']
+    for feature in features:
+        _, props, _ = feature
+
+        # skip this feature if there's a where clause and it evaluates truthy.
+        if where is not None:
+            local = props.copy()
+            local['zoom'] = ctx.nominal_zoom
+            if not eval(where, {}, local):
+                continue
+
+        for k, v in defaults.iteritems():
+            if k not in props:
+                props[k] = v
+
+    return None


### PR DESCRIPTION
Reduce the number of different values for the `surface` tag on roads layer features below the zooms we typically stop naming the feature. This should allow for some information about surface finish, particularly important for walking and cycling maps, without leading to a combinatoric explosion of all the different properties. This should help effective merging at zoom levels where we don't really care about individual features (because they're just "background texture" or because they are too small to be individually noticeable).

Connects to #1716.
