### PR TITLE
Modify no-name PONI zooms

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1064,7 +1064,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `physician`
 * `picnic_site`
 * `picnic_table`
-* `pitch`
+* `pitch` - With `kind_detail` optionally describing the sport. Common values are `baseball`, `basketball`, `football`, `hockey`, `soccer, `tennis`.
 * `place_of_worship` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `plant` - _See planned bug fixes in [#1085](https://github.com/tilezen/vector-datasource/issues/1085)._
 * `plaque` - A memorial plaque.

--- a/integration-test/1638-modify-poni-zooms.py
+++ b/integration-test/1638-modify-poni-zooms.py
@@ -44,7 +44,7 @@ class ModifyPoniZoomsTest(FixtureTest):
                 'kind': 'pitch',
             })
 
-    def test_sports_pitch_no_sports_whitelist(self):
+    def test_sports_pitch_no_name_volleyball(self):
         import dsl
 
         z, x, y = (16, 0, 0)
@@ -57,9 +57,10 @@ class ModifyPoniZoomsTest(FixtureTest):
             }),
         )
 
-        # volleyball isn't whitelisted, so POI should not be generated
-        self.assert_no_matching_feature(
+        self.assert_has_feature(
             z, x, y, 'pois', {
+                'id': 1,
+                'min_zoom': 17,
                 'kind': 'pitch',
             })
 

--- a/integration-test/1638-modify-poni-zooms.py
+++ b/integration-test/1638-modify-poni-zooms.py
@@ -1,0 +1,165 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class ModifyPoniZoomsTest(FixtureTest):
+
+    def test_sports_pitch_with_name(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'leisure': 'pitch',
+                'name': 'Foo pitch',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1,
+                'min_zoom': 16,
+                'kind': 'pitch',
+            })
+
+    def test_sports_pitch_no_name(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'leisure': 'pitch',
+                'sport': 'basketball',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1,
+                'min_zoom': 17,
+                'kind': 'pitch',
+            })
+
+    def test_sports_pitch_no_sports_whitelist(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'leisure': 'pitch',
+                'sport': 'volleyball',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # volleyball isn't whitelisted, so POI should not be generated
+        self.assert_no_matching_feature(
+            z, x, y, 'pois', {
+                'kind': 'pitch',
+            })
+
+    def test_drinking_water(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_centre_shape(z, x, y), {
+                'amenity': 'drinking_water',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'kind': 'drinking_water',
+                'min_zoom': 18,
+            })
+
+    def _check_downgrade_poi(self, tags, kind, min_zoom):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        full_tags = tags.copy()
+        full_tags['source'] = 'openstreetmap.org'
+
+        # test without a name
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), full_tags),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'kind': kind,
+                'min_zoom': min_zoom,
+            })
+
+        # and with a name
+        full_tags['name'] = 'Some kind of name'
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), full_tags),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'kind': kind,
+                'name': full_tags['name'],
+                'min_zoom': lambda z: z < min_zoom,
+            })
+
+    def test_information(self):
+        self._check_downgrade_poi(
+            {'tourism': 'information'},
+            'information', 18)
+
+    def test_playground(self):
+        self._check_downgrade_poi(
+            {'leisure': 'playground'},
+            'playground', 18)
+
+    def test_bicycle_parking(self):
+        self._check_downgrade_poi(
+            {'amenity': 'bicycle_parking'},
+            'bicycle_parking', 19)
+
+    def test_toilets(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_centre_shape(z, x, y), {
+                'amenity': 'toilets',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'kind': 'toilets',
+                'min_zoom': 18,
+            })
+
+    def test_traffic_signals(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_centre_shape(z, x, y), {
+                'highway': 'traffic_signals',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'kind': 'traffic_signals',
+                'min_zoom': 18,
+            })

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -244,13 +244,21 @@ class PredictableLayersPois(FixtureTest):
             14, 2777, 6374, 'pois',
             {'id': 902365126, 'kind': 'plant', 'min_zoom': 14})
 
-    def test_pitch_node(self):
+    def test_pitch_node_named(self):
         # Node:2442093493 pitch in POIS
-        self.generate_fixtures(dsl.way(2442093493, wkt_loads('POINT (-120.068494697136 38.93153745806469)'), {u'source': u'openstreetmap.org', u'sport': u'volleyball', u'leisure': u'pitch'}))  # noqa
+        self.generate_fixtures(dsl.way(2442093493, wkt_loads('POINT (-120.068494697136 38.93153745806469)'), {u'source': u'openstreetmap.org', u'sport': u'volleyball', u'leisure': u'pitch', u'name': u'Volleyball pitch'}))  # noqa
 
         self.assert_has_feature(
             16, 10910, 25062, 'pois',
             {'id': 2442093493, 'kind': 'pitch', 'min_zoom': 16})
+
+    def test_pitch_node_unnamed_sport_in_whitelist(self):
+        # Node:2442093493 pitch in POIS
+        self.generate_fixtures(dsl.way(2442093493, wkt_loads('POINT (-120.068494697136 38.93153745806469)'), {u'source': u'openstreetmap.org', u'sport': u'basketball', u'leisure': u'pitch'}))  # noqa
+
+        self.assert_has_feature(
+            16, 10910, 25062, 'pois',
+            {'id': 2442093493, 'kind': 'pitch', 'min_zoom': 17})
 
     def test_protected_area_way(self):
         # Way:296573403 protected_area in POIS

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -173,6 +173,11 @@ def match_distance(actual, expected):
                     misses[exp_k] = "%r not an instance of %r" % (v, exp_v)
                     distance += 1
 
+            elif callable(exp_v):
+                if not exp_v(v):
+                    misses[exp_k] = "%r(%r) is not truthy" % (exp_v, v)
+                    distance += 1
+
             elif v != exp_v:
                 misses[exp_k] = "%r != %r" % (v, exp_v)
                 distance += 1

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -29,6 +29,37 @@ global:
     tram_routes: {col: tram_routes}
   - &health_facility_type_kind_detail
     kind_detail: {col: 'health_facility:type'}
+  # common properties for {bi|motor}cycle parking
+  - &cycle_parking_properties
+    access: {col: access}
+    operator: {col: operator}
+    capacity: {col: tags->capacity}
+    covered:
+      case:
+        - when:
+            covered: 'yes'
+          then: true
+        - when:
+            covered: 'no'
+          then: false
+    fee:
+      case:
+        - when:
+            fee: true
+            not:
+              fee: ['no', 'Free', 'free', '0', 'No', 'none']
+          then: true
+      # TODO tests expect this to be false and not omitted, is that what we want?
+        - else: false
+    cyclestreets_id: {col: tags->cyclestreets_id}
+    maxstay: {col: tags->maxstay}
+    surveillance:
+      case:
+        - when:
+            surveillance: true
+            not:
+              surveillance: ['no', 'none']
+          then: true
 
   - &tier1_min_zoom
     lookup:
@@ -147,6 +178,7 @@ global:
           - car_wash
           - charging_station
           - customs
+          - drinking_water
           - fuel
           - harbourmaster
           - hunting_stand
@@ -192,7 +224,7 @@ global:
             rest_area, street_lamp, traffic_signals, trailhead ]
         - historic: [landmark, wayside_cross]
         - landuse: quarry
-        - leisure: [ dog_park, firepit, fishing, pitch, slipway, swimming_area ]
+        - leisure: [ dog_park, firepit, fishing, pitch, playground, slipway, swimming_area ]
         - lock: yes
         - man_made: [ adit, communications_tower, crane, mast, mineshaft, obelisk, observatory,
             offshore_platform, petroleum_well, power_wind, telescope, water_tower,
@@ -826,10 +858,24 @@ filters:
       tier: 6
   # hedge - no POI
   # pedestrian - no POI
-  # pitch
-  - filter: {leisure: pitch}
+  # pitch - either has a name, or shows at a higher zoom for some sports
+  - filter:
+      leisure: pitch
+      name: true
     # already clamped below area min
     min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: pitch
+      kind_detail: {col: sport}
+      tier: 6
+  # pitch - only show no-name pitches for some smaller set of sports, and at a
+  # higher zoom.
+  - filter:
+      leisure: pitch
+      sport: [baseball, basketball, football, hockey, soccer, tennis]
+    # already clamped below area min
+    min_zoom: 17
     output:
       <<: *output_properties
       kind: pitch
@@ -843,9 +889,18 @@ filters:
       kind: place_of_worship
       tier: 6
   # playground
-  - filter: { leisure: playground }
+  - filter:
+      leisure: playground
+      name: true
     # already clamped below area limit
     min_zoom: 17
+    output:
+      <<: *output_properties
+      kind: playground
+      tier: 6
+  - filter:
+      leisure: playground
+    min_zoom: 18
     output:
       <<: *output_properties
       kind: playground
@@ -1671,23 +1726,42 @@ filters:
       kind: viewpoint
   - filter:
       tourism: information
+      name: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: information
   - filter:
-      amenity: [atm, bureau_de_change, bus_stop, drinking_water, emergency_phone,
+      tourism: information
+    min_zoom: 18
+    output:
+      <<: *output_properties
+      kind: information
+  - filter:
+      amenity: [atm, bureau_de_change, bus_stop, emergency_phone,
         karaoke, karaoke_box, money_transfer, post_box, telephone]
     min_zoom: 17
     output:
       <<: *output_properties
       kind: {col: amenity}
   - filter:
-      highway: [bus_stop, street_lamp, traffic_signals]
+      amenity: drinking_water
+    min_zoom: 18
+    output:
+      <<: *output_properties
+      kind: drinking_water
+  - filter:
+      highway: [bus_stop, street_lamp]
     min_zoom: 17
     output:
       <<: *output_properties
       kind: {col: highway}
+  - filter:
+      highway: traffic_signals
+    min_zoom: 18
+    output:
+      <<: *output_properties
+      kind: traffic_signals
   # memorial plaques more specific than plain memorials
   - filter:
       any:
@@ -1761,40 +1835,21 @@ filters:
       operator: {col: operator}
       capacity: {col: tags->capacity}
       ref: {col: ref}
-  - filter: {amenity: [bicycle_parking, motorcycle_parking] }
+  - filter:
+      amenity: [bicycle_parking, motorcycle_parking]
+      name: true
     min_zoom: 17
     output:
       <<: *output_properties
+      <<: *cycle_parking_properties
       kind: {col: amenity}
-      access: {col: access}
-      operator: {col: operator}
-      capacity: {col: tags->capacity}
-      covered:
-        case:
-          - when:
-              covered: 'yes'
-            then: true
-          - when:
-              covered: 'no'
-            then: false
-      fee:
-        case:
-          - when:
-              fee: true
-              not:
-                fee: ['no', 'Free', 'free', '0', 'No', 'none']
-            then: true
-        # TODO tests expect this to be false and not omitted, is that what we want?
-          - else: false
-      cyclestreets_id: {col: tags->cyclestreets_id}
-      maxstay: {col: tags->maxstay}
-      surveillance:
-        case:
-          - when:
-              surveillance: true
-              not:
-                surveillance: ['no', 'none']
-            then: true
+  - filter:
+      amenity: [bicycle_parking, motorcycle_parking]
+    min_zoom: 19
+    output:
+      <<: *output_properties
+      <<: *cycle_parking_properties
+      kind: {col: amenity}
   - filter:
       amenity: [charging_station]
     min_zoom: 17

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1836,15 +1836,22 @@ filters:
       capacity: {col: tags->capacity}
       ref: {col: ref}
   - filter:
-      amenity: [bicycle_parking, motorcycle_parking]
+      amenity: motorcycle_parking
+    min_zoom: 17
+    output:
+      <<: *output_properties
+      <<: *cycle_parking_properties
+      kind: motorcycle_parking
+  - filter:
+      amenity: bicycle_parking
       name: true
     min_zoom: 17
     output:
       <<: *output_properties
       <<: *cycle_parking_properties
-      kind: {col: amenity}
+      kind: bicycle_parking
   - filter:
-      amenity: [bicycle_parking, motorcycle_parking]
+      amenity: bicycle_parking
     min_zoom: 19
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -49,7 +49,6 @@ global:
             not:
               fee: ['no', 'Free', 'free', '0', 'No', 'none']
           then: true
-      # TODO tests expect this to be false and not omitted, is that what we want?
         - else: false
     cyclestreets_id: {col: tags->cyclestreets_id}
     maxstay: {col: tags->maxstay}
@@ -873,7 +872,6 @@ filters:
   # higher zoom.
   - filter:
       leisure: pitch
-      sport: [baseball, basketball, football, hockey, soccer, tennis]
     # already clamped below area min
     min_zoom: 17
     output:


### PR DESCRIPTION
Push down min_zoom on some POIs with no names (PONIs).

- *Sports pitches:* Drop the `min_zoom` to 17 if there's no name and the sport is whitelisted.
- *Parking:* Nothing to do, we had already changed it independently to zoom 17.
- *Drinking water:* Added to PONIs, output only at zoom 18 (not sure there are many named?)
- *Information:* Drop `min_zoom` to 18 if there's no name.
- *Playgrounds:* Added to PONIs, drop `min_zoom` to 18 if there's no name.
- *Toilets:* Nothing to do, had already been changed to 18.
- *Traffic signals:* Dropped to `min_zoom` 18 - pretty sure these don't usually get named.
- *Bicycle parking:* Dropped to 19 when there's no name.

Connects to #1638.
