### PR TITLE
Exclude more features from places layer at low zooms

### DIFF
--- a/integration-test/1687-fewer-places-at-low-zoom.py
+++ b/integration-test/1687-fewer-places-at-low-zoom.py
@@ -30,12 +30,10 @@ class LowZoomPlacesTest(FixtureTest):
                 'name': 'Guam',
             })
 
-        # should exist at zoom 2 (one past the min zoom)
-        self.assert_has_feature(
+        # should not exist at zoom 2 (one past the min zoom)
+        self.assert_no_matching_feature(
             z-1, x//2, y//2, 'places', {
-                'id': 607976629,
-                'kind': 'country',
-                'name': 'Guam',
+                'id': 607976629
             })
 
         # should not exist at zoom 1

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -105,7 +105,7 @@ class FractionalPoisNe(FixtureTest):
     def test_water_osm(self):
         self.assert_has_feature(
             9, 150, 192, 'water',
-            {'min_zoom': 0,
+            {'min_zoom': 1,
              'source': 'openstreetmapdata.com',
              'kind': 'ocean',
              'name': type(None)})

--- a/integration-test/977-min-zoom-from-ne-join.py
+++ b/integration-test/977-min-zoom-from-ne-join.py
@@ -27,11 +27,11 @@ class MinZoomFromNETest(FixtureTest):
             }),
         )
 
-    def test_uk_should_show_up_zooms_1_to_6(self):
+    def test_uk_should_show_up_zooms_2_to_6(self):
         from tilequeue.tile import deg2num
-        # should show up in zooms within the range 1-6
+        # should show up in zooms within the range 2-6
 
-        for zoom in xrange(1, 6):
+        for zoom in xrange(2, 6):
             x, y = deg2num(self.lat, self.lon, zoom)
             self.assert_has_feature(
                 zoom, x, y, 'places', {
@@ -40,13 +40,17 @@ class MinZoomFromNETest(FixtureTest):
                     'max_zoom': 6.7,
                 })
 
-    def test_uk_should_not_show_up_zoom_0(self):
-        # shouldn't be in the zoom 0 tile because min_zoom >= 1
-        self.assert_no_matching_feature(
-            0, 0, 0, 'places', {'id': 838090640})
+    def test_uk_should_not_show_up_zoom_0_to_1(self):
+        from tilequeue.tile import deg2num
+        # shouldn't be in the zoom 0 or zoom 1 tiles because min_zoom >= 1.5
+
+        for zoom in xrange(0, 1):
+            x, y = deg2num(self.lat, self.lon, zoom)
+            self.assert_no_matching_feature(
+                zoom, x, y, 'places', {'id': 838090640})
 
     def test_uk_should_not_show_up_zoom_7(self):
-        # shouldn't be in the zoom 0 tile because max_zoom < 7
+        # shouldn't be in the zoom 7 tile because max_zoom < 7
         from tilequeue.tile import deg2num
 
         zoom = 7

--- a/integration-test/977-min-zoom-from-ne-join.py
+++ b/integration-test/977-min-zoom-from-ne-join.py
@@ -36,7 +36,7 @@ class MinZoomFromNETest(FixtureTest):
             self.assert_has_feature(
                 zoom, x, y, 'places', {
                     'id': 838090640,
-                    'min_zoom': 1.7,
+                    'min_zoom': 2.0,
                     'max_zoom': 6.7,
                 })
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8129,7 +8129,7 @@ def min_zoom_filter(ctx):
         for feature in features:
             _, props, _ = feature
             min_zoom = props.get('min_zoom')
-            if min_zoom is not None and min_zoom <= nominal_zoom + 0.5:
+            if min_zoom is not None and min_zoom < nominal_zoom + 1:
                 new_features.append(feature)
 
         layer['features'] = new_features
@@ -8150,7 +8150,10 @@ def tags_set_ne_min_max_zoom(ctx):
     for _, props, _ in layer['features']:
         min_zoom = props.pop('__ne_min_zoom', None)
         if min_zoom is not None:
-            props['min_zoom'] = min_zoom
+            if math.ceil(min_zoom) == math.trunc(min_zoom) + 1:
+                props['min_zoom'] = math.ceil(min_zoom)
+            else:
+                props['min_zoom'] = min_zoom
 
         max_zoom = props.pop('__ne_max_zoom', None)
         if max_zoom is not None:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8152,8 +8152,10 @@ def tags_set_ne_min_max_zoom(ctx):
     for _, props, _ in layer['features']:
         min_zoom = props.pop('__ne_min_zoom', None)
         if min_zoom is not None:
-            if math.ceil(min_zoom) == math.trunc(min_zoom) + 1:
-                props['min_zoom'] = math.ceil(min_zoom)
+            # don't overstuff features that are in the long tail of won't display
+            # but make their min_zoom consistent with when they show in tiles
+            if ceil(min_zoom) == trunc(min_zoom) + 1:
+                props['min_zoom'] = ceil(min_zoom)
             else:
                 props['min_zoom'] = min_zoom
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3,7 +3,6 @@
 
 from collections import defaultdict, namedtuple
 from math import ceil
-from math import trunc
 from numbers import Number
 from shapely.geometry.collection import GeometryCollection
 from shapely.geometry import box as Box

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8129,7 +8129,7 @@ def min_zoom_filter(ctx):
         for feature in features:
             _, props, _ = feature
             min_zoom = props.get('min_zoom')
-            if min_zoom is not None and min_zoom <= nominal_zoom + 1:
+            if min_zoom is not None and min_zoom <= nominal_zoom + 0.5:
                 new_features.append(feature)
 
         layer['features'] = new_features

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -2,6 +2,8 @@
 # transformation functions to apply to features
 
 from collections import defaultdict, namedtuple
+from math import ceil
+from math import trunc
 from numbers import Number
 from shapely.geometry.collection import GeometryCollection
 from shapely.geometry import box as Box

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8152,8 +8152,9 @@ def tags_set_ne_min_max_zoom(ctx):
     for _, props, _ in layer['features']:
         min_zoom = props.pop('__ne_min_zoom', None)
         if min_zoom is not None:
-            # don't overstuff features that are in the long tail of won't display
-            # but make their min_zoom consistent with when they show in tiles
+            # don't overstuff features into tiles when they are in the
+            # long tail of won't display, but make their min_zoom
+            # consistent with when they actually show in tiles
             if ceil(min_zoom) == trunc(min_zoom) + 1:
                 props['min_zoom'] = ceil(min_zoom)
             else:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8155,10 +8155,9 @@ def tags_set_ne_min_max_zoom(ctx):
             # don't overstuff features into tiles when they are in the
             # long tail of won't display, but make their min_zoom
             # consistent with when they actually show in tiles
-            if ceil(min_zoom) == trunc(min_zoom) + 1:
-                props['min_zoom'] = ceil(min_zoom)
-            else:
-                props['min_zoom'] = min_zoom
+            if min_zoom % 1 > 0.5:
+                min_zoom = ceil(min_zoom)
+            props['min_zoom'] = min_zoom
 
         max_zoom = props.pop('__ne_max_zoom', None)
         if max_zoom is not None:

--- a/yaml/earth.yaml
+++ b/yaml/earth.yaml
@@ -13,7 +13,7 @@ filters:
   - filter:
       place: continent
       name: true
-    min_zoom: 0
+    min_zoom: 1
     output:
       <<: *output_properties
       kind: continent

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -215,7 +215,7 @@ filters:
   #     - {kind: ocean}
   #   table: shp
   - filter: {meta.source: shp}
-    min_zoom: 0
+    min_zoom: 1
     output:
       <<: *output_properties
       kind: ocean


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/1729 to limit **places layer** features to only >= +0.5 of the nominal zoom instead of >= +1 to reduce amount of features (and reduce file size, translations multiply!), especially at low zooms.

This better matches how Natural Earth is curated starting in **version 4.1** for `min_zoom`.

For example, this will remove the 1.7 features above from the zoom 1 tile, but they'll show up in zoom 2 tile and collide out min_zoom 2.0 features – good).