### PR TITLE
Revise min_zoom for turning_circle, turning_loop, and mini_roundabout

### DIFF
--- a/integration-test/1218-poni-whitelist.py
+++ b/integration-test/1218-poni-whitelist.py
@@ -162,7 +162,7 @@ class PoniWhitelist(FixtureTest):
         self.generate_fixtures(dsl.way(110392851, wkt_loads('POINT (-122.5540299617 37.9050195779691)'), {u'source': u'openstreetmap.org', u'highway': u'mini_roundabout'}))  # noqa
 
         self.assert_has_feature(
-            15, 5228, 12650, 'pois',
+            16, 10456, 25300, 'pois',
             {'id': 110392851})
 
     def test_highway_platform(self):

--- a/integration-test/1218-poni-whitelist.py
+++ b/integration-test/1218-poni-whitelist.py
@@ -162,7 +162,7 @@ class PoniWhitelist(FixtureTest):
         self.generate_fixtures(dsl.way(110392851, wkt_loads('POINT (-122.5540299617 37.9050195779691)'), {u'source': u'openstreetmap.org', u'highway': u'mini_roundabout'}))  # noqa
 
         self.assert_has_feature(
-            16, 10457, 25300, 'pois',
+            16, 10457, 25301, 'pois',
             {'id': 110392851})
 
     def test_highway_platform(self):

--- a/integration-test/1218-poni-whitelist.py
+++ b/integration-test/1218-poni-whitelist.py
@@ -162,7 +162,7 @@ class PoniWhitelist(FixtureTest):
         self.generate_fixtures(dsl.way(110392851, wkt_loads('POINT (-122.5540299617 37.9050195779691)'), {u'source': u'openstreetmap.org', u'highway': u'mini_roundabout'}))  # noqa
 
         self.assert_has_feature(
-            16, 10456, 25300, 'pois',
+            16, 10457, 25300, 'pois',
             {'id': 110392851})
 
     def test_highway_platform(self):

--- a/integration-test/1695-turning-circles-turning-loops.py
+++ b/integration-test/1695-turning-circles-turning-loops.py
@@ -20,7 +20,7 @@ class TurningCirclesAndLoops(FixtureTest):
         self.generate_fixtures(
             dsl.point(4260010359, (8.43452, 49.4596352),
                       {u'source': u'openstreetmap.org',
-                       u'highway': u'turning_loop'})
+                       u'highway': u'turning_loop'}))
 
         self.assert_has_feature(
             16, 34303, 22378, 'pois',

--- a/integration-test/1695-turning-circles-turning-loops.py
+++ b/integration-test/1695-turning-circles-turning-loops.py
@@ -14,14 +14,14 @@ class TurningCirclesAndLoops(FixtureTest):
 
         self.assert_has_feature(
             16, 32703, 21771, 'pois',
-            {'id': 106186562, 'kind': 'turning_circle'})
+            {'id': 106186562, 'kind': 'turning_circle', 'min_zoom': 17})
 
     def turning_loop(self):
         self.generate_fixtures(
             dsl.point(4260010359, (8.43452, 49.4596352),
                       {u'source': u'openstreetmap.org',
-                       u'highway': u'turning_loop'}))
+                       u'highway': u'turning_loop'})
 
         self.assert_has_feature(
             16, 34303, 22378, 'pois',
-            {'id': 4260010359, 'kind': 'turning_loop'})
+            {'id': 4260010359, 'kind': 'turning_loop', 'min_zoom': 17})

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1475,12 +1475,12 @@ filters:
       <<: *output_properties
       kind: toll_booth
   - filter: {highway: [turning_circle, turning_loop]}
-    min_zoom: 16
+    min_zoom: 17
     output:
       <<: *output_properties
       kind: { col: highway }
   - filter: {highway: mini_roundabout}
-    min_zoom: 15
+    min_zoom: 16
     output:
       <<: *output_properties
       kind: mini_roundabout


### PR DESCRIPTION
Connects with #1695, based on QA review comments for release sign-off:

- Moves `min_zoom` of turning_circle` from 16 to 17.  
  (new in this release, mod)
- Moves `min_zoom` of turning_loop` from 16 to 17.
  (new in this release, mod)
- Moves `min_zoom` of mini_roundabout` from 15 to 16.
  (existing feature, within MINOR version allowed change)