### PR TITLE
Restore building scale rank

### DIFF
--- a/integration-test/1732-restore-building-scale-rank.py
+++ b/integration-test/1732-restore-building-scale-rank.py
@@ -1,0 +1,128 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class Buildings(object):
+    def __init__(self, z, x, y, landuse_kind=None):
+        from tilequeue.tile import coord_to_mercator_bounds
+        from ModestMaps.Core import Coordinate
+        import dsl
+
+        bounds = coord_to_mercator_bounds(Coordinate(zoom=z, column=x, row=y))
+        self.origin_x = bounds[0]
+        self.origin_y = bounds[1]
+        self.buildings = []
+        self.way_id = 1
+
+        if landuse_kind is not None:
+            self.buildings.append(dsl.way(self.way_id, dsl.tile_box(z, x, y), {
+                'landuse': landuse_kind,
+                'source': 'openstreetmap.org',
+            }))
+            self.way_id += 1
+
+    # minx, miny, maxx, maxy are in mercator meters from the bottom left
+    # corner of the tile, so it's easier to calculate area.
+    def add(self, minx, miny, maxx, maxy, height=5, extra_tags={}):
+        from dsl import way
+        from shapely.geometry import box
+        from shapely.ops import transform
+        from tilequeue.tile import reproject_mercator_to_lnglat
+
+        shape = box(self.origin_x + minx, self.origin_y + miny,
+                    self.origin_x + maxx, self.origin_y + maxy)
+        shape_lnglat = transform(reproject_mercator_to_lnglat, shape)
+
+        tags = {
+            'source': 'openstreetmap.org',
+            'building': 'yes',
+        }
+        tags.update(extra_tags)
+
+        self.buildings.append(way(self.way_id, shape_lnglat, tags))
+        self.way_id += 1
+
+
+class BuildingScaleRankTest(FixtureTest):
+
+    def _setup_row(self, z, x, y, width, depth, n, height=5, extra_tags={},
+                   landuse_kind=None):
+        b = Buildings(z, x, y, landuse_kind=landuse_kind)
+        for i in xrange(0, n * width, width):
+            b.add(i, 0, i + width, depth, height=height, extra_tags=extra_tags)
+
+        self.generate_fixtures(*b.buildings)
+
+    def test_not_merged_z16(self):
+        # make a row of buildings, check that they get assigned scale
+        # rank and are _not_ merged at z16.
+        z, x, y = (16, 0, 0)
+
+        self._setup_row(z, x, y, 10, 40, 10)
+
+        # and there are 10 buildings with scale rank 5
+        self.assert_n_matching_features(
+            z, x, y, 'buildings', {
+                'kind': 'building',
+                'scale_rank': 5,
+            }, 10)
+
+        # and none with any other scale rank value.
+        self.assert_no_matching_feature(
+            z, x, y, 'buildings', {
+                'scale_rank': (lambda r: r != 5)
+            })
+
+    def test_merged_z15(self):
+        # make a row of buildings, check that they get assigned scale
+        # rank and are merged at z15.
+        z, x, y = (15, 0, 0)
+
+        self._setup_row(z, x, y, 10, 40, 10)
+
+        # should be only 1 building feature now
+        self.assert_n_matching_features(
+            z, x, y, 'buildings', {
+                'kind': 'building',
+                'scale_rank': 5,
+            }, 1)
+
+        # and none with any other scale rank value.
+        self.assert_no_matching_feature(
+            z, x, y, 'buildings', {
+                'scale_rank': (lambda r: r != 5)
+            })
+
+    def test_drop_scale_rank_5_at_z14(self):
+        # make a row of buildings, check that they get assigned scale
+        # rank and are merged at z15.
+        z, x, y = (14, 0, 0)
+
+        self._setup_row(z, x, y, 10, 40, 10)
+
+        # scale_rank 5 features should be dropped at this zoom.
+        self.assert_no_matching_feature(
+            z, x, y, 'buildings', {
+                'kind': 'building',
+                'scale_rank': 5,
+            })
+
+    def test_merged_z14(self):
+        # make a row of buildings, check that they get assigned scale
+        # rank and are merged at z14.
+        z, x, y = (14, 0, 0)
+
+        self._setup_row(z, x, y, 10, 50, 10, landuse_kind='retail')
+
+        # should be only 1 building feature now
+        self.assert_n_matching_features(
+            z, x, y, 'buildings', {
+                'kind': 'building',
+                'scale_rank': 4,
+            }, 1)
+
+        # and none with any other scale rank value.
+        self.assert_no_matching_feature(
+            z, x, y, 'buildings', {
+                'scale_rank': (lambda r: r != 4)
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -1254,7 +1254,7 @@ post_process:
       source_layers: [buildings]
       pixel_area: 0.25
 
-  - fn: vectordatasource.transform.merge_building_features
+  - fn: vectordatasource.transform.quantize_height
     params:
       source_layer: buildings
       start_zoom: 13
@@ -1263,6 +1263,12 @@ post_process:
         13: vectordatasource.transform.quantize_height_round_nearest_20_meters
         14: vectordatasource.transform.quantize_height_round_nearest_10_meters
         15: vectordatasource.transform.quantize_height_round_nearest_10_meters
+
+  - fn: vectordatasource.transform.merge_building_features
+    params:
+      source_layer: buildings
+      start_zoom: 13
+      end_zoom: 16
       # todo: keep instead of drop?
       drop:
         - name

--- a/queries.yaml
+++ b/queries.yaml
@@ -1326,7 +1326,7 @@ post_process:
       source_layer: buildings
       start_zoom: 14
       end_zoom: 15
-      where: scale_rank > 3
+      where: scale_rank > 4
 
   - fn: vectordatasource.transform.drop_small_inners
     params:

--- a/queries.yaml
+++ b/queries.yaml
@@ -1278,6 +1278,20 @@ post_process:
       source_layer: buildings
       target_value_type: int
 
+  # fit min zoom onto the scale rank, as we'll be using the scale rank rather
+  # than the min zoom to calculate whether a building should make it into a
+  # tile. having them split separately means we can't merge them together.
+  - fn: vectordatasource.transform.clamp_min_zoom
+    params:
+      layer: buildings
+      start_zoom: 14
+      end_zoom: 16
+      property: scale_rank
+      clamp:
+        5: 15
+        4: 14
+        3: 14
+
   - fn: vectordatasource.transform.merge_building_features
     params:
       source_layer: buildings

--- a/queries.yaml
+++ b/queries.yaml
@@ -1264,6 +1264,20 @@ post_process:
         14: vectordatasource.transform.quantize_height_round_nearest_10_meters
         15: vectordatasource.transform.quantize_height_round_nearest_10_meters
 
+  # assign `scale_rank` - BEFORE merging, as we want to assign this based on
+  # the original area/height/volume of the building before it is possibly
+  # merged with others. clients might use scale_rank for filtering, in which
+  # case they want to see the original value.
+  - fn: vectordatasource.transform.csv_match_properties
+    resources:
+      matcher:
+        type: file
+        init_fn: vectordatasource.transform.CSVMatcher
+        path: spreadsheets/scale_rank/buildings.csv
+    params:
+      source_layer: buildings
+      target_value_type: int
+
   - fn: vectordatasource.transform.merge_building_features
     params:
       source_layer: buildings
@@ -1288,17 +1302,6 @@ post_process:
       end_zoom: 15
       source_layers: [buildings]
       pixel_area: 0.25
-
-  # assign `scale_rank` - AFTER merging, as this changes the area and volume
-  - fn: vectordatasource.transform.csv_match_properties
-    resources:
-      matcher:
-        type: file
-        init_fn: vectordatasource.transform.CSVMatcher
-        path: spreadsheets/scale_rank/buildings.csv
-    params:
-      source_layer: buildings
-      target_value_type: int
 
   - fn: vectordatasource.transform.numeric_min_filter
     params:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3452,6 +3452,42 @@ def _merge_features_by_property(
     return new_features
 
 
+def quantize_height(ctx):
+    """
+    Quantize the height property of features in the layer according to the
+    per-zoom configured quantize function.
+    """
+
+    params = _Params(ctx, 'quantize_height')
+    zoom = ctx.nominal_zoom
+    source_layer = params.required('source_layer')
+    start_zoom = params.optional('start_zoom', default=0, typ=int)
+    end_zoom = params.optional('end_zoom', typ=int)
+    quantize_cfg = params.required('quantize', typ=dict)
+
+    layer = _find_layer(ctx.feature_layers, source_layer)
+    if layer is None:
+        return None
+
+    if zoom < start_zoom:
+        return None
+    if end_zoom is not None and zoom >= end_zoom:
+        return None
+
+    quantize_fn_dotted_name = quantize_cfg.get(zoom)
+    if not quantize_fn_dotted_name:
+        # no changes at this zoom
+        return None
+
+    quantize_height_fn = resolve(quantize_fn_dotted_name)
+    for shape, props, fid in layer['features']:
+        height = props.get('height', None)
+        if height is not None:
+            props['height'] = quantize_height_fn(height)
+
+    return None
+
+
 def merge_building_features(ctx):
     zoom = ctx.nominal_zoom
     source_layer = ctx.params.get('source_layer')
@@ -3476,13 +3512,6 @@ def merge_building_features(ctx):
     # values which retain detail.
     tolerance = min(5, 0.4 * tolerance_for_zoom(zoom))
 
-    quantize_height_fn = None
-    quantize_cfg = ctx.params.get('quantize')
-    if quantize_cfg:
-        quantize_fn_dotted_name = quantize_cfg.get(zoom)
-        if quantize_fn_dotted_name:
-            quantize_height_fn = resolve(quantize_fn_dotted_name)
-
     def _props_pre((shape, props, fid)):
         if exclusions:
             for prop in exclusions:
@@ -3497,11 +3526,6 @@ def merge_building_features(ctx):
         if drop:
             for prop in drop:
                 props.pop(prop, None)
-
-        if quantize_height_fn:
-            height = props.get('height', None)
-            if height is not None:
-                props['height'] = quantize_height_fn(height)
 
         return props
 

--- a/yaml/buildings.yaml
+++ b/yaml/buildings.yaml
@@ -59,8 +59,8 @@ globals:
         not: { "tags->location": "underground" }
   - &z14_area_volume
       any:
-        way_area: { min: 3000 }
-        volume: { min: 100000 }
+        way_area: { min: 500 }
+        volume: { min: 50000 }
   - &z15_area_volume
       way_area: { min: 20 }
   - &z16_area_volume


### PR DESCRIPTION
Made `scale_rank` on buildings meaningful again - based on the properties before merging rather than after.

![zoom animation between z13 and z16](https://user-images.githubusercontent.com/271360/50171136-87c54a00-02e9-11e9-9384-334540f1e551.gif)

Connects to #1732.
