### PR TITLE
Push tram stops, railway stops and halts down to zoom 16.

### DIFF
--- a/integration-test/1218-poni-whitelist.py
+++ b/integration-test/1218-poni-whitelist.py
@@ -308,8 +308,8 @@ class PoniWhitelist(FixtureTest):
         self.generate_fixtures(dsl.way(2382580308, wkt_loads('POINT (-75.130406997023 40.30634839166561)'), {u'source': u'openstreetmap.org', u'railway': u'halt'}))  # noqa
 
         self.assert_has_feature(
-            15, 9545, 12368, 'pois',
-            {'id': 2382580308})
+            16, 19090, 24737, 'pois',
+            {'id': 2382580308, 'kind': 'halt', 'min_zoom': 16})
 
     def test_railway_platform(self):
         self.generate_fixtures(dsl.way(3987143106, wkt_loads('POINT (-72.0929836528225 41.354925008914)'), {u'source': u'openstreetmap.org', u'railway': u'platform'}))  # noqa
@@ -322,16 +322,16 @@ class PoniWhitelist(FixtureTest):
         self.generate_fixtures(dsl.way(1130268570, wkt_loads('POINT (-76.9349771452377 38.9629633645972)'), {u'source': u'openstreetmap.org', u'railway': u'stop', u'rail': u'yes', u'public_transport': u'stop_position'}))  # noqa
 
         self.assert_has_feature(
-            15, 9381, 12527, 'pois',
-            {'id': 1130268570})
+            16, 18762, 25055, 'pois',
+            {'id': 1130268570, 'kind': 'stop', 'min_zoom': 16})
 
     def test_public_transport_stop_position(self):
         # originally from 661-historic-transit-stops.py
         self.generate_fixtures(dsl.way(3721890342, wkt_loads('POINT (-122.15620591773 37.438295280187)'), {u'source': u'openstreetmap.org', u'railway': u'stop', u'network': u'Caltrain', u'public_transport': u'stop_position'}))  # noqa
 
         self.assert_has_feature(
-            13, 1316, 3176, 'pois',
-            {'id': 3721890342})
+            16, 10530, 25408, 'pois',
+            {'id': 3721890342, 'kind': 'stop', 'min_zoom': 16})
 
     def test_railway_subway_entrance(self):
         self.generate_fixtures(dsl.way(3833748147, wkt_loads('POINT (-77.08494522253518 38.89059997067759)'), {u'source': u'openstreetmap.org', u'railway': u'subway_entrance', u'highway': u'elevator', u'subway_entrance': u'elevator'}))  # noqa
@@ -348,7 +348,7 @@ class PoniWhitelist(FixtureTest):
         self.generate_fixtures(dsl.way(1719012916, wkt_loads('POINT (-122.433744377346 37.73245189929369)'), {u'source': u'openstreetmap.org', u'railway': u'tram_stop'}))  # noqa
 
         self.assert_has_feature(
-            15, 5239, 12670, 'pois',
+            16, 10479, 25340, 'pois',
             {'id': 1719012916})
 
     def test_railway_level_crossing(self):

--- a/integration-test/1635-hide-early-tram-stop.py
+++ b/integration-test/1635-hide-early-tram-stop.py
@@ -1,0 +1,68 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class HideEarlyTramStopTest(FixtureTest):
+
+    def test_tram_stop(self):
+        import dsl
+
+        z, x, y = (16, 10482, 25324)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2081705827
+            dsl.point(2081705827, (-122.4196615, 37.8020638), {
+                'name': u'Hyde Street & Lombard Street',
+                'railway': u'tram_stop',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2081705827,
+                'kind': u'tram_stop',
+                'min_zoom': 16,
+            })
+
+    def test_stop(self):
+        import dsl
+
+        z, x, y = (16, 10578, 25372)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/53051770
+            dsl.point(53051770, (-121.8890223, 37.5941573), {
+                'name': u'Sunol',
+                'railway': u'stop',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 53051770,
+                'kind': u'stop',
+                'min_zoom': 16,
+            })
+
+    def test_halt(self):
+        import dsl
+
+        z, x, y = (16, 10715, 25124)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4560580421
+            dsl.point(4560580421, (-121.138147, 38.6654377), {
+                'name': u'Oak Avenue Whistlestop',
+                'railway': u'halt',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4560580421,
+                'kind': u'halt',
+                'min_zoom': 16,
+            })

--- a/integration-test/661-historic-transit-stops.py
+++ b/integration-test/661-historic-transit-stops.py
@@ -58,21 +58,46 @@ class HistoricTransitStops(FixtureTest):
 
         self.assert_has_feature(
             16, 19306, 24648, 'pois',
-            {'id': 2986320002, 'min_zoom': 13})
+            {'id': 2986320002, 'min_zoom': 16})
 
     def test_current_tram_stop(self):
         # Current tram stop
         self.generate_fixtures(dsl.way(257074010, wkt_loads('POINT (-122.413997610771 37.77939210258558)'), {u'name': u'Civic Center', u'wikipedia': u'en:Civic Center / UN Plaza Station', u'source': u'openstreetmap.org', u'operator': u'San Francisco Municipal Railway', u'railway': u'tram_stop', u'network': u'Muni'}))  # noqa
 
         self.assert_has_feature(
-            13, 1310, 3166, 'pois',
-            {'id': 257074010})
+            16, 10483, 25330, 'pois',
+            {'id': 257074010, 'kind': 'tram_stop', 'min_zoom': 16})
 
     def test_current_railway_halt(self):
         # Current railway halt
-        # http://www.openstreetmap.org/node/302735255
-        self.generate_fixtures(dsl.way(302735255, wkt_loads('POINT (16.8020703892136 48.10800269583749)'), {u'railway:ref': u'Reg H1', u'uic_ref': u'8101787', u'name': u'Wildungsmauer', u'railway:position': u'38.0', u'uic_name': u'Wildungsmauer', u'source': u'openstreetmap.org', u'train': u'yes', u'public_transport': u'stop_position', u'operator': u'\xd6BB', u'railway:position:exact': u'37.985', u'railway': u'halt', u'ref': u'1'}))  # noqa
+        import dsl
+
+        z, x, y = (16, 35826, 22751)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/302735255
+            dsl.point(302735255, (16.8020704, 48.1080027), {
+                'name': u'Wildungsmauer',
+                'network': u'VOR',
+                'operator': u'ÖBB-Infrastruktur AG',
+                'public_transport': u'stop_position',
+                'railway': u'halt',
+                'railway:platform_height': u'38',
+                'railway:platform_length': u'142',
+                'railway:position': u'38.0',
+                'railway:position:exact': u'37.985',
+                'railway:ref': u'Reg H1',
+                'ref': u'1',
+                'source': u'openstreetmap.org',
+                'train': u'yes',
+                'uic_name': u'Wildungsmauer',
+                'uic_ref': u'8101787',
+            }),
+        )
 
         self.assert_has_feature(
-            13, 4478, 2843, 'pois',
-            {'id': 302735255})
+            z, x, y, 'pois', {
+                'id': 302735255,
+                'kind': u'halt',
+                'min_zoom': 16,
+            })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -1513,11 +1513,12 @@ filters:
       state: {col: tags->state}
   - filter:
       railway: [halt, stop, tram_stop]
-# to work around overwriting when using the same key twice
+      # to work around overwriting when using the same key twice (because we
+      # want to say "when historic is not present, or is present and is 'no'".)
       any:
         historic: false
         all: {historic: 'no'}
-    min_zoom: 13
+    min_zoom: 16
     output:
       <<: *output_properties
       <<: *transit_properties


### PR DESCRIPTION
I had to swap out one of the examples which has been re-tagged as a station since. Looking around, I see [a handful more places](https://overpass-turbo.eu/?q=LyoKVGhpcyBoYcSGYmVlbiBnxI1lcmF0ZWQgYnkgdGhlIG92xJJwxIlzLXR1cmJvIHdpemFyZC7EgsSdxJ9yaWdpbmFsIHNlxLBjaMSsxIk6CsOiwoDCnHR5cGU6bm9kxJ5hbsSXxJNpbHdheT3EiGx0xYjCnQoqLwpbb3V0Ompzb25dW3RpbWXFqMWqMjVdOwovL8SPxJTEnXIgcmVzdcWfcwooCiAgxb0gcXXEksSaxKNydCBmb3I6IMWIwpzFl8WZxZvFncS8xaDCgMWixo3FkMWSWyLGoMWaeSI9IsWedCLFsCJwdWJsaWNfdMSTbnNwxprGtMaxc3TElGnFrsa1KHt7YsSqeH19KcW7x5XFvMW-cMS3bsaXxoTGhsaICsW2xJjFkXnFuz7Fu8eic2tlxL1xdDs&c=AXo5V-PSxK) where [`public_transport=station` is used](https://taginfo.openstreetmap.org/tags/public_transport=station), and `railway != station`. For our purposes, it's probably a synonym of `railway=station` - should we add it too?

Connects to #1635.
