### PR TITLE
Hide early gardens, allotments, university

### DIFF
--- a/integration-test/1636-hide-early-no-area-garden.py
+++ b/integration-test/1636-hide-early-no-area-garden.py
@@ -1,0 +1,97 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class HideEarlyNoAreaGardenTest(FixtureTest):
+
+    def test_allotments_node(self):
+        import dsl
+
+        z, x, y = (16, 32683, 21719)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1271465901
+            dsl.point(1271465901, (-0.4660196, 51.7557019), {
+                'landuse': u'allotments',
+                'name': u'Midland Hill Allotments',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1271465901,
+                'kind': u'allotments',
+                'min_zoom': 16,
+            })
+
+    def test_allotments_way(self):
+        import dsl
+
+        z, x, y = (16, 32748, 21779)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/32055218
+            dsl.way(32055218, dsl.tile_box(z, x, y), {
+                'landuse': u'allotments',
+                'name': u'Arvon Road allotments',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        # should have point in POIs
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 32055218,
+                'kind': u'allotments',
+                'min_zoom': 16,
+            })
+
+        # and polygon in landuse
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 32055218,
+                'kind': u'allotments',
+            })
+
+    def test_garden_node(self):
+        import dsl
+
+        z, x, y = (16, 10473, 25332)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2969748430
+            dsl.point(2969748430, (-122.469992, 37.767533), {
+                'leisure': u'garden',
+                'name': u'South Africa Garden',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2969748430,
+                'kind': u'garden',
+                'min_zoom': 16,
+            })
+
+    def test_university_node(self):
+        import dsl
+
+        z, x, y = (16, 10484, 25327)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/4628353540
+            dsl.point(4628353540, (-122.404460, 37.790842), {
+                'amenity': u'university',
+                'name': u'Academy of Arts University',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4628353540,
+                'kind': u'university',
+                'min_zoom': 16,
+            })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -838,7 +838,8 @@ filters:
   # allotments
   - filter:
       landuse: allotments
-    min_zoom: 16
+      not: { access: [ "private", "no" ] }
+    min_zoom: { min: [ { max: [ 16, { col: zoom }, *tier6_min_zoom ] }, 17 ] }
     output:
       <<: *output_properties
       kind: allotments
@@ -857,7 +858,7 @@ filters:
   - filter:
       leisure: garden
       not: { access: [ "private", "no" ] }
-    min_zoom: { min: [ { max: [ 12, { col: zoom }, *tier6_min_zoom ] }, 16 ] }
+    min_zoom: { min: [ { max: [ 12, { col: zoom }, *tier6_min_zoom ] }, 17 ] }
     output:
       <<: *output_properties
       kind: garden

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -548,7 +548,7 @@ filters:
       tier: 3
   # university
   - filter: {amenity: university}
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 2.55 ] }, *tier3_min_zoom ] }, 15 ] }
+    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 2.55 ] }, *tier3_min_zoom ] }, 16 ] }
     output:
       <<: *output_properties
       kind: university
@@ -835,7 +835,14 @@ filters:
   ############################################################
   # TIER 6
   ############################################################
-  # allotments - no POI
+  # allotments
+  - filter:
+      landuse: allotments
+    min_zoom: 16
+    output:
+      <<: *output_properties
+      kind: allotments
+      tier: 6
   # artwork, hanami
   - filter:
       tourism: [artwork, hanami, trail_riding_station]


### PR DESCRIPTION
Hide early point (no area) gardens, universities. Add allotments as a POI type (was already landuse).

Gardens without an area should already have been allocated a [`min_zoom` of 16](https://github.com/tilezen/vector-datasource/blob/fac4f71a526f4eada6144f08783b8d2e3d98c589/yaml/pois.yaml#L853).

Connects to #1636.