### PR TITLE
Use a Jinja filter to provide repr in test templates.

### DIFF
--- a/scripts/mktest.py
+++ b/scripts/mktest.py
@@ -105,11 +105,27 @@ def _make_ident(s):
     return s.lower().translate(None, ':-')
 
 
+def _almost_repr(value):
+    # we'd prefer not to have all the u'' stuff everywhere unless it's
+    # necessary, so try to see if we can return a plain str, if the string
+    # is all ASCII anyway.
+    if isinstance(value, unicode):
+        try:
+            value = value.encode('ascii')
+        except UnicodeEncodeError:
+            # just use the original
+            pass
+
+    return repr(value)
+
+
 def _render_template(name, args):
+    from jinja2 import Environment, FileSystemLoader
+
     d = os.path.dirname(os.path.realpath(__file__))
-    template_file = os.path.join(d, 'templates', '%s.jinja2' % (name,))
-    with open(template_file) as fh:
-        template = Template(fh.read())
+    env = Environment(loader=FileSystemLoader(os.path.join(d, 'templates')))
+    env.filters['repr'] = _almost_repr
+    template = env.get_template('%s.jinja2' % (name,))
 
     output = template.render(**args)
     return output

--- a/scripts/mktest.py
+++ b/scripts/mktest.py
@@ -2,7 +2,6 @@ import requests
 import xml.etree.ElementTree as ET
 import tilequeue.tile as tile
 from ModestMaps.Core import Coordinate
-from jinja2 import Template
 import os
 from contextlib import contextmanager
 

--- a/scripts/templates/overpass_test.jinja2
+++ b/scripts/templates/overpass_test.jinja2
@@ -8,7 +8,7 @@
             # https://www.openstreetmap.org/{{elt_type}}/{{elt_id}}
             {{geom_fn_name}}({{elt_id}}, {{geom_fn_arg}}, {
         {%- for k, v in tags|dictsort %}
-                '{{k}}': u'{{v}}',
+                {{k|repr}}: {{v|repr}},
         {%- endfor %}
             }),
         )
@@ -18,7 +18,7 @@
                 'id': {{elt_id}},
         {%- if expect is not none %}
         {%-   for k, v in expect|dictsort %}
-                '{{k}}': u'{{v}}',
+                {{k|repr}}: {{v|repr}},
         {%-   endfor %}
         {%- endif %}
             })


### PR DESCRIPTION
Previously, was just quoting everything as a unicode string, which was good enough in 99% of cases. However, sometimes it's nice to be able to round-trip values from the command line `--expect`, which takes a JSON-encoded `dict`, and the test. For example, not having it quote `min_zoom` as a string when I specified it as a number.

As a bonus, I also de-unicode strings where they can be specified as plain `str`, which is the case for all the keys and most of the values that we have in our tests, and makes the output slightly more readable.