### PR TITLE
Add public_transport=station as a synonym for railway=station.

### DIFF
--- a/integration-test/1747-public-transport-station.py
+++ b/integration-test/1747-public-transport-station.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class PublicTransportStationTest(FixtureTest):
+
+    def test_station_node(self):
+        import dsl
+
+        z, x, y = (16, 10522, 25402)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/2160213344
+            dsl.point(2160213344, (-122.197968, 37.464501), {
+                'name': 'Atherton',
+                'network': 'Caltrain',
+                'note': 'Weekend local service only',
+                'opening_hours': 'Sa,Su',
+                'public_transport': 'station',
+                'railway': 'halt',
+                'source': 'openstreetmap.org',
+                'wikidata': 'Q4813588',
+                'wikipedia': 'en:Atherton (Caltrain station)',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2160213344,
+                'kind': 'station',
+            })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -233,7 +233,7 @@ global:
         - natural: [ cave_entrance, peak, volcano, geyser, hot_spring, rock, saddle,
             stone, spring, tree, waterfall ]
         - power: [ pole, tower, generator ]
-        - public_transport: [ platform, station, stop_area ]
+        - public_transport: [ platform, stop_area ]
         - railway: [ halt, level_crossing, platform, stop, subway_entrance, tram_stop ]
         - "health_facility:type": [field_hospital, health_centre]
         - "seamark:building:function": harbour_master

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -233,7 +233,7 @@ global:
         - natural: [ cave_entrance, peak, volcano, geyser, hot_spring, rock, saddle,
             stone, spring, tree, waterfall ]
         - power: [ pole, tower, generator ]
-        - public_transport: [ platform, stop_area ]
+        - public_transport: [ platform, station, stop_area ]
         - railway: [ halt, level_crossing, platform, stop, subway_entrance, tram_stop ]
         - "health_facility:type": [field_hospital, health_centre]
         - "seamark:building:function": harbour_master
@@ -1519,6 +1519,19 @@ filters:
       <<: *transit_properties
       kind: station
       state: {col: tags->state}
+  # also count a public_transport=station as a station, if it has railway-ish
+  # tags.
+  - filter:
+      public_transport: station
+      any:
+        rail: true
+        light_rail: true
+        railway: true
+    min_zoom: 10
+    output:
+      <<: *output_properties
+      <<: *transit_properties
+      kind: station
   - filter:
       railway: [halt, stop, tram_stop]
       # to work around overwriting when using the same key twice (because we


### PR DESCRIPTION
When there's also a `rail`, `light_rail` or `railway` tag, in case a more general-purpose public transport station is tagged this way. For example, a bus station without any rail interconnect.

Connects to #1747.