### PR TITLE
Estimate capacity for parking lots and garages.

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1051,3 +1051,31 @@ BEGIN
   RETURN 17;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- return the capacity of a parking lot, or estimate it from the area and building levels.
+CREATE OR REPLACE FUNCTION tz_estimate_parking_capacity(capacity TEXT, parking TEXT, levels TEXT, way_area REAL)
+RETURNS INTEGER AS $$
+DECLARE
+  levels_int INTEGER;
+  spaces_per_level INTEGER;
+BEGIN
+  -- if the capacity is set, then use that.
+  IF capacity ~ '^[0-9]+$' THEN
+    RETURN capacity::integer;
+  END IF;
+  -- otherwise, try to use the information we have to guess the capacity
+  spaces_per_level := (way_area / 46.0)::integer;
+  levels_int := CASE
+    WHEN levels ~ '^[0-9]+$' THEN levels::integer
+    WHEN parking = 'multi-storey' THEN 2
+    ELSE 1
+  END;
+  -- if we get a silly answer, don't set that - just return NULL to indicate
+  -- that we're unsure.
+  IF levels_int * spaces_per_level > 0 THEN
+    RETURN levels_int * spaces_per_level;
+  ELSE
+    RETURN NULL;
+  END IF;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/integration-test/1625-parking.py
+++ b/integration-test/1625-parking.py
@@ -27,6 +27,27 @@ class ParkingTest(FixtureTest):
                 'capacity': type(None),  # should _not_ set capacity
             })
 
+    def test_parking_tiny(self):
+        import dsl
+
+        z, x, y = (16, 10466, 25340)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/257593333
+            dsl.way(257593333, dsl.box_area(z, x, y, 678), {
+                'amenity': 'parking',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 257593333,
+                'kind': 'parking',
+                'min_zoom': 17,
+                'capacity': int,
+            })
+
     def test_parking_small(self):
         import dsl
 

--- a/integration-test/1625-parking.py
+++ b/integration-test/1625-parking.py
@@ -87,7 +87,7 @@ class ParkingTest(FixtureTest):
             z, x, y, 'pois', {
                 'id': 162093420,
                 'kind': 'parking',
-                'min_zoom': 17,
+                'min_zoom': 16,
                 'capacity': int,
             })
 

--- a/integration-test/1625-parking.py
+++ b/integration-test/1625-parking.py
@@ -114,7 +114,7 @@ class ParkingTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'pois', {
                 'id': 52175579,
-                'kind': 'parking',
+                'kind': 'parking_garage',
                 'min_zoom': 15,
                 'capacity': int,
             })
@@ -139,7 +139,7 @@ class ParkingTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'pois', {
                 'id': 73540518,
-                'kind': 'parking',
+                'kind': 'parking_garage',
                 'min_zoom': 14,
                 'capacity': int,
             })

--- a/integration-test/1625-parking.py
+++ b/integration-test/1625-parking.py
@@ -1,0 +1,95 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class ParkingTest(FixtureTest):
+
+    def test_parking_node(self):
+        import dsl
+
+        z, x, y = (16, 10477, 25330)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1706619902
+            dsl.point(1706619902, (-122.445233, 37.776196), {
+                'amenity': 'parking',
+                'name': 'Fulton Market Garage',
+                'parking': 'underground',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1706619902,
+                'kind': 'parking_garage',
+                'min_zoom': 18,
+                'capacity': type(None),  # should _not_ set capacity
+            })
+
+    def test_parking_small(self):
+        import dsl
+
+        z, x, y = (16, 10471, 25341)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/506510951
+            dsl.way(506510951, dsl.box_area(z, x, y, 2207), {
+                'amenity': 'parking',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 506510951,
+                'kind': 'parking',
+                'min_zoom': 17,
+                'capacity': int,
+            })
+
+    def test_parking_medium(self):
+        import dsl
+
+        z, x, y = (16, 10471, 25341)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/162093420
+            dsl.way(162093420, dsl.box_area(z, x, y, 6111), {
+                'access': 'destination',
+                'amenity': 'parking',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 162093420,
+                'kind': 'parking',
+                'min_zoom': 16,
+                'capacity': int,
+            })
+
+    def test_parking_huge(self):
+        import dsl
+
+        z, x, y = (15, 5234, 12670)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/32928608
+            dsl.way(32928608, dsl.box_area(z, x, y, 16489), {
+                'amenity': 'parking',
+                'source': 'openstreetmap.org',
+                'tiger:cfcc': 'A41',
+                'tiger:county': 'San Francisco, CA',
+                'tiger:reviewed': 'no',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 32928608,
+                'kind': 'parking',
+                'min_zoom': 15,
+                'capacity': int,
+            })

--- a/integration-test/1625-parking.py
+++ b/integration-test/1625-parking.py
@@ -66,7 +66,7 @@ class ParkingTest(FixtureTest):
             z, x, y, 'pois', {
                 'id': 162093420,
                 'kind': 'parking',
-                'min_zoom': 16,
+                'min_zoom': 17,
                 'capacity': int,
             })
 
@@ -91,5 +91,30 @@ class ParkingTest(FixtureTest):
                 'id': 32928608,
                 'kind': 'parking',
                 'min_zoom': 15,
+                'capacity': int,
+            })
+
+    def test_parking_mega(self):
+        import dsl
+
+        z, x, y = (14, 2950, 6427)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/52175579
+            dsl.way(52175579, dsl.box_area(z, x, y, 16489), {
+                'amenity': 'parking',
+                'source': 'openstreetmap.org',
+                'building':	'yes',
+                'fee': 'yes',
+                'name': 'Aria and Vdara Self Parking',
+                'parking': 'multi-storey',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 52175579,
+                'kind': 'parking',
+                'min_zoom': 14,
                 'capacity': int,
             })

--- a/integration-test/1625-parking.py
+++ b/integration-test/1625-parking.py
@@ -70,7 +70,7 @@ class ParkingTest(FixtureTest):
                 'capacity': int,
             })
 
-    def test_parking_huge(self):
+    def test_parking_huge_1(self):
         import dsl
 
         z, x, y = (15, 5234, 12670)
@@ -94,14 +94,14 @@ class ParkingTest(FixtureTest):
                 'capacity': int,
             })
 
-    def test_parking_mega(self):
+    def test_parking_huge_2(self):
         import dsl
 
-        z, x, y = (14, 2950, 6427)
+        z, x, y = (15, 5900, 12855)
 
         self.generate_fixtures(
             # https://www.openstreetmap.org/way/52175579
-            dsl.way(52175579, dsl.box_area(z, x, y, 16489), {
+            dsl.way(52175579, dsl.box_area(z, x, y, 31611), {
                 'amenity': 'parking',
                 'source': 'openstreetmap.org',
                 'building':	'yes',
@@ -114,6 +114,31 @@ class ParkingTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'pois', {
                 'id': 52175579,
+                'kind': 'parking',
+                'min_zoom': 15,
+                'capacity': int,
+            })
+
+    def test_parking_mega(self):
+        import dsl
+
+        z, x, y = (14, 2950, 6428)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/73540518
+            dsl.way(73540518, dsl.box_area(z, x, y, 55615), {
+                'amenity': 'parking',
+                'source': 'openstreetmap.org',
+                'building':	'yes',
+                'fee': 'yes',
+                'name': 'MGM Grand Self Parking',
+                'parking': 'multi-storey',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 73540518,
                 'kind': 'parking',
                 'min_zoom': 14,
                 'capacity': int,

--- a/vectordatasource/meta/function.py
+++ b/vectordatasource/meta/function.py
@@ -401,3 +401,41 @@ def tz_looks_like_rest_area(name):
             min_zoom = 13
 
     return min_zoom
+
+
+def tz_estimate_parking_capacity(capacity, parking, levels, way_area):
+    try:
+        # if the tags tell us what capacity is, then we should respect that.
+        capacity = int(capacity)
+        return capacity
+
+    except (ValueError, TypeError):
+        # sometimes people don't put integers in the capacity, which is kind of
+        # annoying. it means we just have to fall back to estimating.
+        pass
+
+    # estimate capacity based on way area fitting. looks like roughly 46 square
+    # mercator meters per space?
+    spaces_per_level = int(way_area / 46.0)
+
+    try:
+        levels = int(levels)
+
+    except (ValueError, TypeError):
+        # levels either not present, or non-numeric. try and guess from the
+        # parking type.
+        if parking == 'multi-storey':
+            # at least 2, but let's be conservative.
+            levels = 2
+        else:
+            # mainly surface, but also other types such as "underground"
+            levels = 1
+
+    capacity = spaces_per_level * levels
+
+    # if we get a silly answer, don't set that - just return None to indicate
+    # that we're unsure.
+    if capacity > 0:
+        return capacity
+    else:
+        return None

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -179,6 +179,7 @@ KNOWN_FUNCS = {
     'util.true_or_none':                  'notimplemented',
     'tz_looks_like_service_area':         'tz_looks_like_service_area',
     'tz_looks_like_rest_area':            'tz_looks_like_rest_area',
+    'tz_estimate_parking_capacity':       'tz_estimate_parking_capacity',
 }
 
 

--- a/vectordatasource/util.py
+++ b/vectordatasource/util.py
@@ -20,7 +20,7 @@ def to_float(x):
 
 def calculate_way_area(shape):
     result = 0
-    if shape.type in ('MultiPolygon', 'Polygon'):
+    if shape and shape.type in ('MultiPolygon', 'Polygon'):
         result = shape.area
     return result
 

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -956,12 +956,6 @@ filters:
           - [ 16,  100 ]
           - [ 17,   10 ]
         default: 18
-
-
- - [ 15, 1000 ]    # was 350
-           - [ 16,   200 ]    # was 130
-           - [ 17,      45 ]    # no change, seems fine
-
     output:
       <<: *output_properties
       kind:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -951,9 +951,9 @@ filters:
         key:  { call: { func: tz_estimate_parking_capacity, args: [ { col: capacity }, { col: 'parking' }, { col: 'building:levels' }, { col: 'way_area' } ] } }
         op: '>='
         table:
-          - [ 15, 350 ]
-          - [ 16, 130 ]
-          - [ 17, 45 ]
+          - [ 15, 1000 ]
+          - [ 16,  200 ]
+          - [ 17,   45 ]
         default: 18
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -952,10 +952,16 @@ filters:
         op: '>='
         table:
           - [ 14, 2000 ]
-          - [ 15, 1000 ]
-          - [ 16,  200 ]
-          - [ 17,   45 ]
+          - [ 15,  350 ]
+          - [ 16,  100 ]
+          - [ 17,   10 ]
         default: 18
+
+
+ - [ 15, 1000 ]    # was 350
+           - [ 16,   200 ]    # was 130
+           - [ 17,      45 ]    # no change, seems fine
+
     output:
       <<: *output_properties
       kind:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -951,6 +951,7 @@ filters:
         key:  { call: { func: tz_estimate_parking_capacity, args: [ { col: capacity }, { col: 'parking' }, { col: 'building:levels' }, { col: 'way_area' } ] } }
         op: '>='
         table:
+          - [ 14, 2000 ]
           - [ 15, 1000 ]
           - [ 16,  200 ]
           - [ 17,   45 ]

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -946,7 +946,15 @@ filters:
   ############################################################
   # parking
   - filter: {amenity: parking}
-    min_zoom: 17
+    min_zoom:
+      lookup:
+        key:  { call: { func: tz_estimate_parking_capacity, args: [ { col: capacity }, { col: 'parking' }, { col: 'building:levels' }, { col: 'way_area' } ] } }
+        op: '>='
+        table:
+          - [ 15, 350 ]
+          - [ 16, 130 ]
+          - [ 17, 45 ]
+        default: 18
     output:
       <<: *output_properties
       kind:
@@ -956,6 +964,7 @@ filters:
             then: 'parking_garage'
           - else: 'parking'
       tier: 6
+      capacity:  { call: { func: tz_estimate_parking_capacity, args: [ { col: capacity }, { col: 'parking' }, { col: 'building:levels' }, { col: 'way_area' } ] } }
 
   ############################################################
   # NOT IN ANY TIER


### PR DESCRIPTION
If the feature provides a `capacity` tag, then use that as long as it's a valid integer (some aren't, such as `capacity=limited`). If that doesn't work, try to estimate the number of spaces from the area and, where possible, the number of levels. From fitting the area to features with a capacity, it looks like 46 square Mercator "meters" isn't too far off a reasonable value per parking space.

Once we've estimated the capacity, use that to figure out what the min zoom should be.

Connects to #1625.
