### PR TITLE
Push substations down a few zooms.

### DIFF
--- a/integration-test/1612-too-many-substations.py
+++ b/integration-test/1612-too-many-substations.py
@@ -1,0 +1,103 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class SubstationTest(FixtureTest):
+
+    def test_substation_14_way(self):
+        import dsl
+
+        z, x, y = (14, 4786, 5898)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/142431633
+            dsl.way(142431633, dsl.box_area(z, x, y, 545185), {
+                'barrier': 'fence',
+                'name': 'Dennison Substation',
+                'power': 'substation',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 142431633,
+                'kind': 'substation',
+                'min_zoom': 14,
+            })
+
+    def test_substation_15_way(self):
+        import dsl
+
+        z, x, y = (15, 9653, 12314)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/108298302
+            dsl.way(108298302, dsl.box_area(z, x, y, 51769), {
+                'frequency': '60',
+                'location': 'outdoor',
+                'name': 'Rainey Substation',
+                'operator': 'Consolidated Edison',
+                'power': 'substation',
+                'source': 'openstreetmap.org',
+                'substation': 'transmission',
+                'voltage': '345000;138000',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 108298302,
+                'kind': 'substation',
+                'min_zoom': 15,
+            })
+
+    def test_substation_16_way(self):
+        import dsl
+
+        z, x, y = (16, 11223, 26160)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/394710539
+            dsl.way(394710539, dsl.box_area(z, x, y, 39876), {
+                'frequency': '60',
+                'location': 'outdoor',
+                'name': 'RECEIVING STATION H',
+                'operator': 'LOS ANGELES DEPARTMENT OF WATER AND POWER',
+                'power': 'substation',
+                'ref': 'H',
+                'source': 'openstreetmap.org',
+                'substation': 'transmission',
+                'voltage': '138000',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 394710539,
+                'kind': 'substation',
+                'min_zoom': 16,
+            })
+
+    def test_substation_17_way(self):
+        import dsl
+
+        z, x, y = (17, 20966, 50660)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/35115839
+            dsl.way(35115839, dsl.box_area(z, x, y, 4869), {
+                'building': 'yes',
+                'height': '36 m',
+                'name': 'Pacific Gas & Electric Mission Substation',
+                'power': 'substation',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 35115839,
+                'kind': 'substation',
+                'min_zoom': 17,
+            })

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -373,8 +373,8 @@ class PredictableLayersPois(FixtureTest):
         self.generate_fixtures(dsl.way(4214350591, wkt_loads('POINT (-122.504766082024 37.7527564602091)'), {u'source': u'openstreetmap.org', u'name': u'Noriega Substation', u'power': u'substation'}))  # noqa
 
         self.assert_has_feature(
-            15, 5233, 12668, 'pois',
-            {'id': 4214350591, 'kind': 'substation', 'min_zoom': 15})
+            16, 10466, 25336, 'pois',
+            {'id': 4214350591, 'kind': 'substation', 'min_zoom': 17})
 
     def test_village_green_way(self):
         # village_green in POIS

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -699,7 +699,15 @@ filters:
       tier: 4
   # substation
   - filter: {power: substation}
-    min_zoom: 15
+    min_zoom:
+      lookup:
+        key: { col: way_area }
+        op: '>='
+        table:
+          - [ 14, 200000 ]
+          - [ 15,  50000 ]
+          - [ 16,  10000 ]
+        default: 17
     output:
       <<: *output_properties
       kind: substation


### PR DESCRIPTION
Adjustments:

1. The [example for zoom 14](https://www.openstreetmap.org/way/240515268)  is [a power plant](https://en.wikipedia.org/wiki/en:Ravenswood%20Generating%20Station), not a substation. Replaced with [Dennison Substation](https://www.openstreetmap.org/way/142431633), the largest I could find.
2. The examples for zoom 14 and 16 were the same object, so I found [a z16 replacement](https://www.openstreetmap.org/way/394710539) that seemed about the right size.

Connects to #1612.