### PR TITLE
Add script to output all the kinds in the YAML files.

### DIFF
--- a/scripts/all_the_kinds.py
+++ b/scripts/all_the_kinds.py
@@ -179,7 +179,6 @@ def parse_item(layer_name, item, sort_rank):
             all_kinds = parse_filter_for_col(kind['col'], item['filter'])
 
         elif kind.keys() == ['case']:
-            # TODO: figure this out
             all_kinds = parse_case_for_kinds(kind['case'])
 
         else:

--- a/scripts/all_the_kinds.py
+++ b/scripts/all_the_kinds.py
@@ -1,0 +1,288 @@
+from collections import namedtuple
+
+
+# we don't have data to evaluate the function, so this just looks up the
+# minimum possible value the function could return.
+KNOWN_FUNCS = {
+    'mz_calculate_path_major_route': 8,
+    'mz_get_min_zoom_highway_level_gate': 14,
+    'tz_looks_like_service_area': 13,
+    'tz_looks_like_rest_area': 13,
+    'mz_calculate_ferry_level': 8,
+}
+
+
+# structures to return data from the parsing functions. basically a key->value
+# mapping where the keys are (layer, kind) tuples and the values are the other
+# stuff we parsed out of the various YAML/CSV files.
+KindKey = namedtuple('KindKey', 'layer kind')
+KindInfo = namedtuple('KindInfo', 'min_zoom sort_rank')
+
+
+# parses the values for a column out of a filter definition. this is used when
+# the output defines "kind: {col: some_column}", and we want to find out what
+# values "some_column" could have.
+#
+# this is most often seen in things such as:
+#
+#  - filter:
+#      amenity: [bus_station, car_rental, recycling, shelter]
+#    min_zoom: 16
+#    output:
+#      <<: *output_properties
+#      kind: {col: amenity}
+#
+# where we've white-listed the amenity values in the filter, so we know all the
+# possible values that the kind can have.
+#
+# theoretically, this can be arbitrarily complex, but it turns out that in all
+# the cases we have at the time of writing, the whitelist is available at the
+# top level of the filter! lucky us :-)
+def parse_filter_for_col(col, filter_defn):
+    if col.startswith('tags->'):
+        raise AssertionError("Output kind column starts with deprecated "
+                             "'tags->' prefix: %r" % (col,))
+
+    if col in filter_defn:
+        value = filter_defn[col]
+        if isinstance(value, list):
+            return filter_defn[col]
+        elif isinstance(value, (str, unicode)):
+            return [value]
+        else:
+            raise ValueError("Don't know what to do with value of type "
+                             "%s in %r" % (type(value), value))
+    else:
+        # complex case if we're not filtering on the column that we're using
+        # as the output kind... hopefully it doesn't happen very much?
+        raise ValueError("Don't know what to do with kind %r where it doesn't "
+                         "appear in the filter %r" % (col, filter_defn))
+
+
+# parse a "case" statement to get all the possible values. we use this
+# sometimes to set the kind, e.g:
+#
+#  - filter: {leisure: sports_centre}
+#    min_zoom: ...
+#    output:
+#      <<: *output_properties
+#      kind:
+#        case:
+#          - when:
+#              sport: ['fitness', 'gym']
+#            then: 'fitness'
+#          - else: 'sports_centre'
+#
+# which means the kind could be either "fitness" or "sports_centre", and should
+# return both.
+def parse_case_for_kinds(case_stmt):
+    all_kinds = []
+    for case in case_stmt:
+        if case.keys() == ['else']:
+            all_kinds.append(case['else'])
+        else:
+            assert sorted(case.keys()) == ['then', 'when']
+            value = case['then']
+            assert isinstance(value, (str, unicode))
+            all_kinds.append(value)
+
+    return all_kinds
+
+
+def parse_start_zoom(expr):
+    """
+    Parse the min zoom expression to find the minimum min_zoom at which the
+    feature could appear.
+    """
+
+    if isinstance(expr, (int, float)):
+        start_zoom = expr
+
+    elif isinstance(expr, dict):
+        if expr.keys() == ['col']:
+            # if this is the special "zoom" column, then we know it's based on
+            # area, and theoretically could be zero???
+            if expr['col'] == 'zoom':
+                start_zoom = 0
+            else:
+                # this could come from anywhere, so we don't have a clue what
+                # it might be. therefore, return a value which means unknown.
+                start_zoom = None
+
+        elif expr.keys() == ['lookup']:
+            table = expr['lookup']['table']
+            start_zoom = min(row[0] for row in table)
+
+        elif expr.keys() == ['case']:
+            # take the min of all the branches
+            branches = []
+            for case in expr['case']:
+                if case.keys() == ['else']:
+                    branches.append(parse_start_zoom(case['else']))
+
+                else:
+                    assert sorted(case.keys()) == ['then', 'when']
+                    branches.append(parse_start_zoom(case['then']))
+
+            start_zoom = min(*branches)
+
+        elif expr.keys() == ['min']:
+            start_zoom = min(parse_start_zoom(item) for item in expr['min'])
+
+        elif expr.keys() == ['max']:
+            start_zoom = max(parse_start_zoom(item) for item in expr['max'])
+
+        elif expr.keys() == ['clamp']:
+            clamp = expr['clamp']
+            start_zoom = min(parse_start_zoom(clamp['min']),
+                             parse_start_zoom(clamp['value']))
+
+        elif expr.keys() == ['sum']:
+            start_zoom = sum(parse_start_zoom(item) for item in expr['sum'])
+
+        elif expr.keys() == ['mul']:
+            start_zoom = 1
+            for item in expr['mul']:
+                start_zoom *= parse_start_zoom(item)
+
+        elif expr.keys() == ['call']:
+            # we can perhaps figure this out for some functions and stash the
+            # results as constants?
+            func = expr['call']['func']
+            start_zoom = KNOWN_FUNCS.get(func)
+
+        else:
+            raise AssertionError("Unknown min zoom expression %r in %r"
+                                 % (expr.keys(), expr))
+
+    else:
+        raise AssertionError("Unknown min zoom expression type %s in %r"
+                             % (type(expr), expr))
+
+    return start_zoom
+
+
+# need this to pass into the CSVMatcher, which expects a Shapely geometry.
+FakeShape = namedtuple('FakeShape', 'type')
+
+
+def parse_item(layer_name, item, sort_rank):
+    kind = item['output'].get('kind')
+    if not kind:
+        return {}
+
+    if isinstance(kind, (str, unicode)):
+        all_kinds = [kind]
+
+    elif isinstance(kind, dict):
+        if kind.keys() == ['col']:
+            all_kinds = parse_filter_for_col(kind['col'], item['filter'])
+
+        elif kind.keys() == ['case']:
+            # TODO: figure this out
+            all_kinds = parse_case_for_kinds(kind['case'])
+
+        else:
+            raise ValueError("Don't understand dict kind with keys %r in %r"
+                             % (kind.keys(), kind))
+
+    else:
+        raise ValueError("Don't understand kind %s in %r" % (type(kind), kind))
+
+    values = {}
+    for k in all_kinds:
+        key = KindKey(layer_name, k)
+
+        # we need to fake up some of this data, so the sort ranks might not be
+        # exactly correct...
+        shape = FakeShape(None)
+        props = {'kind': k}
+        zoom = 16
+        result = sort_rank(shape, props, zoom)
+        if result is None:
+            sort_rank_val = None
+        else:
+            sort_rank_key, sort_rank_val = result
+            assert sort_rank_key == 'sort_rank'
+            sort_rank_val = int(sort_rank_val)
+
+        info = KindInfo(parse_start_zoom(item['min_zoom']), sort_rank_val)
+
+        values[key] = info
+
+    return values
+
+
+def merge_info(a, b):
+    if a.min_zoom <= b.min_zoom:
+        return a
+    else:
+        return b
+
+
+# default sort_rank function, for when we have no information
+def no_matcher(shape, props, zoom):
+    return None
+
+
+def parse_all_kinds(yaml_path, sort_rank_path):
+    from glob import glob
+    from os.path import join, split, exists
+    from yaml import load as yaml_load
+    from vectordatasource.transform import CSVMatcher
+
+    all_kinds = {}
+    for yaml_file in glob(join(yaml_path, '*.yaml')):
+        layer_name = split(yaml_file)[1][:-5]
+        with open(yaml_file, 'r') as fh:
+            yaml_data = yaml_load(fh)
+
+        # by default, we don't have any sort_rank information
+        sort_rank = no_matcher
+
+        # look for a spreadsheet for sort_rank
+        csv_file = join(yaml_path, '..', 'spreadsheets', 'sort_rank',
+                        '%s.csv' % layer_name)
+        if exists(csv_file):
+            with open(csv_file, 'r') as fh:
+                sort_rank = CSVMatcher(fh)
+
+        for item in yaml_data['filters']:
+            kinds = parse_item(layer_name, item, sort_rank)
+            for k, v in kinds.iteritems():
+                prev_v = all_kinds.get(k)
+                if prev_v is not None:
+                    v = merge_info(prev_v, v)
+                all_kinds[k] = v
+
+    return all_kinds
+
+
+if __name__ == '__main__':
+    from vectordatasource.meta import find_yaml_path
+    import argparse
+    import os.path
+
+    yaml_path = find_yaml_path()
+    sort_rank_path = os.path.join(
+        os.path.split(yaml_path)[0], 'spreadsheets', 'sort_rank')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--yaml-path', help='Directory containing YAML',
+                        default=yaml_path)
+    parser.add_argument('--sort-rank-path', help='Directory containing sort '
+                        'rank CSVs.', default=sort_rank_path)
+    args = parser.parse_args()
+
+    if args.yaml_path:
+        yaml_path = args.yaml_path
+
+    if args.sort_rank_path:
+        sort_rank_path = args.sort_rank_path
+
+    all_kinds = parse_all_kinds(yaml_path, sort_rank_path)
+
+    print "%12s %30s %8s %s" % ("LAYER", "KIND", "MIN_ZOOM", "SORT_RANK")
+    for k in sorted(all_kinds):
+        v = all_kinds[k]
+        print "%12s %30s %8s %r" % (k.layer, k.kind, repr(v.min_zoom),
+                                    v.sort_rank)

--- a/scripts/all_the_kinds.py
+++ b/scripts/all_the_kinds.py
@@ -134,7 +134,7 @@ def parse_start_zoom(expr):
 
         elif expr.keys() == ['clamp']:
             clamp = expr['clamp']
-            start_zoom = min(parse_start_zoom(clamp['min']),
+            start_zoom = max(parse_start_zoom(clamp['min']),
                              parse_start_zoom(clamp['value']))
 
         elif expr.keys() == ['sum']:

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -313,33 +313,33 @@ class PlacesTest(unittest.TestCase):
     def test_wof_is_landuse_aoi(self):
         meta = _make_metadata('wof')
 
-        props = dict(is_landuse_aoi=True)
+        props = dict(is_landuse_aoi=True, placetype='neighbourhood')
         out_props = self.places.fn(None, props, None, meta)
         self.assertTrue(out_props.get('is_landuse_aoi'))
 
-        props = dict(is_landuse_aoi=False)
+        props = dict(is_landuse_aoi=False, placetype='neighbourhood')
         out_props = self.places.fn(None, props, None, meta)
         self.assertIsNone(out_props.get('is_landuse_aoi'))
 
-        props = dict(is_landuse_aoi=None)
+        props = dict(is_landuse_aoi=None, placetype='neighbourhood')
         out_props = self.places.fn(None, props, None, meta)
         self.assertIsNone(out_props.get('is_landuse_aoi'))
 
-        props = dict()
+        props = dict(placetype='neighbourhood')
         out_props = self.places.fn(None, props, None, meta)
         self.assertIsNone(out_props.get('is_landuse_aoi'))
 
     def test_wof_area(self):
         meta = _make_metadata('wof')
 
-        props = dict(area=3.14159)
+        props = dict(area=3.14159, placetype='neighbourhood')
         out_props = self.places.fn(None, props, None, meta)
         area = out_props.get('area')
         self.assertIsNotNone(area)
         self.assertTrue(isinstance(area, int))
         self.assertEquals(3, area)
 
-        props = dict(area=None)
+        props = dict(area=None, placetype='neighbourhood')
         out_props = self.places.fn(None, props, None, meta)
         self.assertIsNone(out_props.get('area'))
 

--- a/yaml/buildings.yaml
+++ b/yaml/buildings.yaml
@@ -56,7 +56,7 @@ globals:
         any:
           way_area: { min: 5000 }
           volume: { min: 150000 }
-        not: { "tags->location": "underground" }
+        not: { location: "underground" }
   - &z14_area_volume
       any:
         way_area: { min: 500 }

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -39,7 +39,13 @@ global:
       default: 10
 
 filters:
-  - filter: {meta.source: wof}
+  - filter:
+      meta.source: wof
+      placetype:
+        - neighbourhood
+        - microhood
+        - macrohood
+        - borough
     min_zoom: {col: min_zoom}
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -33,7 +33,7 @@ global:
   - &cycle_parking_properties
     access: {col: access}
     operator: {col: operator}
-    capacity: {col: tags->capacity}
+    capacity: {col: capacity}
     covered:
       case:
         - when:
@@ -50,8 +50,8 @@ global:
               fee: ['no', 'Free', 'free', '0', 'No', 'none']
           then: true
         - else: false
-    cyclestreets_id: {col: tags->cyclestreets_id}
-    maxstay: {col: tags->maxstay}
+    cyclestreets_id: {col: cyclestreets_id}
+    maxstay: {col: maxstay}
     surveillance:
       case:
         - when:
@@ -252,15 +252,15 @@ global:
         - "health_facility:type": [field_hospital, health_centre]
         - "seamark:building:function": harbour_master
         - "seamark:small_craft_facility:category": fuel_station
-        - tags->icn_ref: true
-        - tags->iwn_ref: true
-        - tags->lcn_ref: true
-        - tags->lwn_ref: true
-        - tags->ncn_ref: true
-        - tags->nwn_ref: true
-        - tags->rcn_ref: true
-        - tags->rwn_ref: true
-        - tags->whitewater: [ egress, hazard, put_in, put_in;egress, rapid ]
+        - icn_ref: true
+        - iwn_ref: true
+        - lcn_ref: true
+        - lwn_ref: true
+        - ncn_ref: true
+        - nwn_ref: true
+        - rcn_ref: true
+        - rwn_ref: true
+        - whitewater: [ egress, hazard, put_in, put_in;egress, rapid ]
         - tourism: [ alpine_hut, information, picnic_site, viewpoint, wilderness_hut ]
         - waterway:
           - boat_lift
@@ -1049,7 +1049,7 @@ filters:
       <<: *output_properties
       <<: *transit_properties
       kind: station
-      state: {col: tags->state}
+      state: {col: state}
   - filter: {natural: spring}
     min_zoom: 14
     output:
@@ -1254,7 +1254,7 @@ filters:
 
   - filter:
       any:
-        tags->rental: ski
+        rental: ski
         amenity: ski_rental
     min_zoom: { clamp: { min: 13, max: 17, value: { sum: [ { col: zoom }, 1.27 ] } } }
     output:
@@ -1311,11 +1311,11 @@ filters:
       <<: *output_properties
       kind: monument
   - filter:
-      tags->zoo: [enclosure, petting_zoo, aviary]
+      zoo: [enclosure, petting_zoo, aviary]
     min_zoom: 17
     output:
       <<: *output_properties
-      kind: {col: tags->zoo}
+      kind: {col: zoo}
   - filter:
       any:
         - {waterway: waterfall}
@@ -1384,7 +1384,7 @@ filters:
     min_zoom: 17
     output:
       <<: *output_properties
-      kind: {col: tags->healthcare}
+      kind: {col: healthcare}
       <<: *health_facility_type_kind_detail
   - filter: {healthcare: alternative}
     min_zoom: 17
@@ -1586,7 +1586,7 @@ filters:
       <<: *output_properties
       <<: *transit_properties
       kind: station
-      state: {col: tags->state}
+      state: {col: state}
   # also count a public_transport=station as a station, if it has railway-ish
   # tags.
   - filter:
@@ -1624,19 +1624,19 @@ filters:
       <<: *output_properties
       <<: *transit_properties
       kind: bus_stop
-  - filter: {public_transport: platform, tags->rail: 'yes'}
+  - filter: {public_transport: platform, rail: 'yes'}
     min_zoom: 17
     output:
       <<: *output_properties
       <<: *transit_properties
       kind: platform
-  - filter: {public_transport: platform, tags->light_rail: 'yes'}
+  - filter: {public_transport: platform, light_rail: 'yes'}
     min_zoom: 17
     output:
       <<: *output_properties
       <<: *transit_properties
       kind: platform
-  - filter: {public_transport: platform, tags->bus: 'yes'}
+  - filter: {public_transport: platform, bus: 'yes'}
     min_zoom: 18
     output:
       <<: *output_properties
@@ -1654,7 +1654,7 @@ filters:
       <<: *output_properties
       <<: *transit_properties
       kind: stop_area
-  - filter: {tags->site: stop_area}
+  - filter: {site: stop_area}
     min_zoom: 15
     output:
       <<: *output_properties
@@ -1754,68 +1754,68 @@ filters:
       <<: *output_properties
       kind: ranger_station
   - filter:
-      tags->icn_ref: true
+      icn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: bicycle_junction
-      ref: {col: tags->icn_ref}
+      ref: {col: icn_ref}
       bicycle_network: icn
   - filter:
-      tags->ncn_ref: true
+      ncn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: bicycle_junction
-      ref: {col: tags->ncn_ref}
+      ref: {col: ncn_ref}
       bicycle_network: ncn
   - filter:
-      tags->rcn_ref: true
+      rcn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: bicycle_junction
-      ref: {col: tags->rcn_ref}
+      ref: {col: rcn_ref}
       bicycle_network: rcn
   - filter:
-      tags->lcn_ref: true
+      lcn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: bicycle_junction
-      ref: {col: tags->lcn_ref}
+      ref: {col: lcn_ref}
       bicycle_network: lcn
   - filter:
-      tags->iwn_ref: true
+      iwn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: walking_junction
-      ref: {col: tags->iwn_ref}
+      ref: {col: iwn_ref}
       walking_network: iwn
   - filter:
-      tags->nwn_ref: true
+      nwn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: walking_junction
-      ref: {col: tags->nwn_ref}
+      ref: {col: nwn_ref}
       walking_network: nwn
   - filter:
-      tags->rwn_ref: true
+      rwn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: walking_junction
-      ref: {col: tags->rwn_ref}
+      ref: {col: rwn_ref}
       walking_network: rwn
   - filter:
-      tags->lwn_ref: true
+      lwn_ref: true
     min_zoom: 16
     output:
       <<: *output_properties
       kind: walking_junction
-      ref: {col: tags->lwn_ref}
+      ref: {col: lwn_ref}
       walking_network: lwn
   - filter: {tourism: camp_site}
     min_zoom: { clamp: { min: 13, max: 16, value: { sum: [ { col: zoom }, 4.9 ] } } }
@@ -1945,9 +1945,9 @@ filters:
     output:
       <<: *output_properties
       kind: bicycle_rental_station
-      network:  {col: tags->network}
+      network:  {col: network}
       operator: {col: operator}
-      capacity: {col: tags->capacity}
+      capacity: {col: capacity}
       ref: {col: ref}
   - filter:
       amenity: motorcycle_parking
@@ -2132,23 +2132,23 @@ filters:
     output:
       <<: *output_properties
       kind: trailhead
-  - filter: {tags->whitewater: put_in;egress}
+  - filter: {whitewater: put_in;egress}
     min_zoom: 14
     output:
       <<: *output_properties
       kind: put_in_egress
   - filter:
-      tags->whitewater: [put_in, egress]
+      whitewater: [put_in, egress]
     min_zoom: 14
     output:
       <<: *output_properties
-      kind: {col: tags->whitewater}
+      kind: {col: whitewater}
   - filter:
-      tags->whitewater: [hazard, rapid]
+      whitewater: [hazard, rapid]
     min_zoom: 15
     output:
       <<: *output_properties
-      kind: {col: tags->whitewater}
+      kind: {col: whitewater}
   - filter: {shop: gas}
     min_zoom: 18
     output:

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -325,7 +325,7 @@ filters:
   #
   #############################################################
   - filter:
-      "tags->whitewater": portage_way
+      "whitewater": portage_way
     min_zoom: { clamp: { min: 0, max: 13, value: { call: { func: mz_calculate_path_major_route, args: [ { col: fid }, { col: meta.relations } ] } } } }
     table: osm
     output:
@@ -421,8 +421,8 @@ filters:
         - {bicycle: designated}
         - {foot: designated}
         - {horse: designated}
-        - {tags->snowmobile: designated}
-        - {tags->ski: designated}
+        - {snowmobile: designated}
+        - {ski: designated}
     min_zoom: { clamp: { min: 0, max: 13, value: { call: { func: mz_calculate_path_major_route, args: [ { col: fid }, { col: meta.relations } ] } } } }
     table: osm
     output:
@@ -431,7 +431,7 @@ filters:
       <<: *osm_footway_properties
       kind: path
       kind_detail: footway
-      footway: {col: tags->footway}
+      footway: {col: footway}
   - filter:
       highway: steps
       all:
@@ -440,8 +440,8 @@ filters:
           - {bicycle: designated}
           - {foot: designated}
           - {horse: designated}
-          - {tags->snowmobile: designated}
-          - {tags->ski: designated}
+          - {snowmobile: designated}
+          - {ski: designated}
     min_zoom: { clamp: { min: 0, max: 13, value: { call: { func: mz_calculate_path_major_route, args: [ { col: fid }, { col: meta.relations } ] } } } }
     table: osm
     output:
@@ -450,10 +450,10 @@ filters:
       <<: *osm_footway_properties
       kind: path
       kind_detail: steps
-      footway: {col: tags->footway}
+      footway: {col: footway}
   - filter:
       highway: footway
-      tags->footway: [sidewalk, crossing]
+      footway: [sidewalk, crossing]
     min_zoom: { clamp: { min: 0, max: 15, value: { call: { func: mz_calculate_path_major_route, args: [ { col: fid }, { col: meta.relations } ] } } } }
     table: osm
     output:
@@ -462,7 +462,7 @@ filters:
       <<: *osm_footway_properties
       kind: path
       kind_detail: footway
-      footway: {col: tags->footway}
+      footway: {col: footway}
   - filter:
       highway: [footway, steps]
     min_zoom: { clamp: { min: 0, max: 14, value: { call: { func: mz_calculate_path_major_route, args: [ { col: fid }, { col: meta.relations } ] } } } }
@@ -473,7 +473,7 @@ filters:
       <<: *osm_footway_properties
       kind: path
       kind_detail: {col: highway}
-      footway: {col: tags->footway}
+      footway: {col: footway}
   - filter: {highway: corridor}
     min_zoom: 16
     table: osm
@@ -764,7 +764,7 @@ filters:
   #
   #############################################################
   - filter:
-      "tags->piste:type":
+      "piste:type":
         - nordic
         - downhill
         - sleigh
@@ -775,15 +775,15 @@ filters:
         - snow_park
         - playground
         - ski_jump
-      not: {"tags->piste:abandoned": "yes"}
-      "tags->piste:name": true
+      not: {"piste:abandoned": "yes"}
+      "piste:name": true
     min_zoom: 13
     table: osm
     output:
       <<: *osm_piste_properties
-      name: {col: "tags->piste:name"}
+      name: {col: "piste:name"}
   - filter:
-      "tags->piste:type":
+      "piste:type":
         - nordic
         - downhill
         - sleigh
@@ -794,7 +794,7 @@ filters:
         - snow_park
         - playground
         - ski_jump
-      not: {"tags->piste:abandoned": "yes"}
+      not: {"piste:abandoned": "yes"}
     min_zoom: 13
     table: osm
     output:

--- a/yaml/transit.yaml
+++ b/yaml/transit.yaml
@@ -60,17 +60,17 @@ filters:
     output:
       <<: *output_properties
       kind: bus_stop
-  - filter: {public_transport: platform, tags->rail: 'yes'}
+  - filter: {public_transport: platform, rail: 'yes'}
     min_zoom: 15
     output:
       <<: *output_properties
       kind: platform
-  - filter: {public_transport: platform, tags->light_rail: 'yes'}
+  - filter: {public_transport: platform, light_rail: 'yes'}
     min_zoom: 15
     output:
       <<: *output_properties
       kind: platform
-  - filter: {public_transport: platform, tags->bus: 'yes'}
+  - filter: {public_transport: platform, bus: 'yes'}
     min_zoom: 17
     output:
       <<: *output_properties
@@ -91,7 +91,7 @@ filters:
     output:
       <<: *output_properties
       kind: {col: railway}
-  - filter: {tags->site: stop_area}
+  - filter: {site: stop_area}
     min_zoom: 15
     output:
       <<: *output_properties


### PR DESCRIPTION
It will also read the `sort_rank` spreadsheet CSVs and output the sort rank information where available.

The output is a table of the layer, kind, start zoom and sort rank (or `None` where those last two aren't available). The "start zoom" is the minimum `min_zoom` at which the feature could possibly appear. For some features where we use an area-based scaling rule, this could theoretically be zero if the feature were large enough - but this doesn't happen in practice. However, it indicates that we could need to put a `clamp` on the range to prevent them from showing up at unexpectedly low zooms. The start zoom can be `None` if the information is obtained externally, e.g: from an external table such as WOF or NE.

Additionally, did some cleanup to the YAML files:

1. The WOF layers didn't explicitly mention their `placetype`, so that has been whitelisted now. In practice, these were the only `placetype`s values in the database, but it's helpful to be able to know that by looking at the YAML and not having to dig into the database.
2. There were many instances of a `tags->` prefix on column names, which is a holdover from when we used to have OSM tables which were partially column-based and partly hstore-based. These aren't needed any more, so I removed them.

Related to https://github.com/tilezen/vector-datasource/issues/988#issuecomment-450453906.