### PR TITLE
Bump PyYAML version for CVE-2017-18342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ psycopg2==2.7.3.2
 pyclipper==1.0.6
 pycountry==17.9.23
 python-dateutil==2.6.1
-PyYAML==3.12
+PyYAML==4.2b4
 redis==2.10.6
 Shapely==1.6.2.post1
 simplejson==3.12.0


### PR DESCRIPTION
Although we only load YAML from within this repository so we're probably not directly affected.
