### PR TITLE
Make sure Henry Coe State Park is marked as a park

### DIFF
--- a/integration-test/1728-henry-coe-state-park.py
+++ b/integration-test/1728-henry-coe-state-park.py
@@ -1,0 +1,89 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class ParkTest(FixtureTest):
+
+    def test_henry_coe_state_park(self):
+        import dsl
+
+        z, x, y = (11, 333, 795)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/318202
+            dsl.way(318202, dsl.box_area(z, x, y, 560913461), {
+                'attribution': 'CASIL CSP_Opbdys072008',
+                'boundary': 'national_park',
+                'csp:globalid': '{4BE5C08F-9239-4491-9400-5B776F304A18}',
+                'csp:unitcode': '432',
+                'leisure': 'nature_reserve',
+                'name': 'Henry W. Coe State Park',
+                'park:type': 'state_park',
+                'protect_class': '5',
+                'short_name': 'Coe Park',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+                'wikidata': 'Q5729631',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 318202,
+                'kind': 'park',
+            })
+
+    def test_lake_district_national_park(self):
+        import dsl
+
+        z, x, y = (9, 251, 163)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/287917
+            dsl.way(287917, dsl.box_area(z, x, y, 6990909071), {
+                'area': 'yes',
+                'boundary': 'national_park',
+                'designation': 'national_park',
+                'name': 'Lake District National Park',
+                'name:cy': 'Parc Cenedlaethol Ardal y Llynnoedd',
+                'name:en': 'Lake District National Park',
+                'ref:gss': 'E26000003',
+                'source': 'openstreetmap.org',
+                'source:ref:gss': 'ONS_OpenData',
+                'type': 'boundary',
+                'wikidata': 'Q211778',
+            }),
+        )
+
+        # this is a national park, and should be tagged as such.
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 287917,
+                'kind': 'national_park',
+            })
+
+    def test_north_pennines_aonb(self):
+        import dsl
+
+        z, x, y = (9, 252, 162)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/6576894
+            dsl.way(6576894, dsl.box_area(z, x, y, 5946792285), {
+                'boundary': 'national_park',
+                'designation': 'area_of_outstanding_natural_beauty',
+                'name': 'North Pennines AONB',
+                'note': 'not a true national park',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+                'wikidata': 'Q1332452',
+            }),
+        )
+
+        # this is a large AONB - but not technically a national park, as the
+        # helpful note in the OSM data points out.
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 6576894,
+                'kind': 'park',
+            })

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -307,7 +307,7 @@ filters:
       any:
         all:
           not: { operator: *us_forest_service }
-          protect_class: ['2', '3', '5']
+          protect_class: ['2', '3']
         operator: *us_parks_service
         operator:en: Parks Canada
         designation: national_park
@@ -324,7 +324,7 @@ filters:
   - filter:
       boundary: national_park
       not: { operator: *us_forest_service }
-      protect_class: ['2', '3', '5']
+      protect_class: ['2', '3']
     min_zoom: *tier2_min_zoom
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -420,7 +420,7 @@ filters:
       any:
         all:
           not: { operator: *us_forest_service }
-          protect_class: ['2', '3', '5']
+          protect_class: ['2', '3']
         operator: *us_parks_service
         operator:en: Parks Canada
         designation: national_park
@@ -437,7 +437,7 @@ filters:
   - filter:
       boundary: national_park
       not: { operator: *us_forest_service }
-      protect_class: ['2', '3', '5']
+      protect_class: ['2', '3']
     min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 3.5 ] }, *tier2_min_zoom ] }, 10 ] }
     output:
       <<: *output_properties


### PR DESCRIPTION
Henry Coe State Park was being assigned a `kind: national_park` on the basis of its `protect_class=5`, so I've removed that as a criterion for selection. However, it looks like `protect_class=5` was included explicitly when we specified the filter for national parks in https://github.com/tilezen/vector-datasource/issues/987#issuecomment-242509891.

I had a look around for other things tagged `boundary=national_park` and `protect_class=5` (but without all the [other qualifiers we use](https://github.com/tilezen/vector-datasource/blob/2ebf1ee16f9bf87bcfddb116b90a52ef4cd39344/yaml/landuse.yaml#L311-L314)), but there aren't many that look like they should be real national parks. [Curecanti National Recreation Area](https://www.openstreetmap.org/relation/395555), perhaps?

If that's the case, then perhaps the original `5` was required back in August 2016 and the data has improved since then? We should be on the lookout for any national parks dropping back to plain parks as a result of this and make tests for them.

Connects to #1728.
