### PR TITLE
Push all but the largest cemeteries down to zoom 13.

### DIFF
--- a/integration-test/1611-cemetery-too-early.py
+++ b/integration-test/1611-cemetery-too-early.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class CemeteryTest(FixtureTest):
+
+    def test_holy_cross(self):
+        import dsl
+
+        z, x, y = (13, 1309, 3169)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/24513384
+            dsl.way(24513384, dsl.box_area(z, x, y, 1312871), {
+                'ALAND': '1323862',
+                'AREAID': '110413857999',
+                'AWATER': '0',
+                'COUNTYFP': '081',
+                'landuse': 'cemetery',
+                'MTFCC': 'K2582',
+                'name': 'Holy Cross Cemetery',
+                'source': 'openstreetmap.org',
+                'STATEFP': '06',
+                'Tiger:MTFCC': 'K2582',
+                'wikidata': 'Q8509540',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 24513384,
+                'kind': 'cemetery',
+                'min_zoom': 13,
+            })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -602,7 +602,16 @@ filters:
   # bridge - no POIs
   # cemetery
   - filter: {landuse: cemetery}
-    min_zoom: { min: [ { max: [ 12, { sum: [ { col: zoom }, 3 ] }, *tier4_min_zoom ] }, 14 ] }
+    min_zoom:
+      lookup:
+        key: { col: way_area }
+        op: '>='
+        table:
+          - [ 12, 3000000 ]
+          - [ 13,  100000 ]
+          - [ 14,   50000 ]
+          - [ 15,    2000 ]
+        default: 16
     output:
       <<: *output_properties
       kind: cemetery


### PR DESCRIPTION
I took the tier 4 `min_zoom` table and adapted it based on the [style YAML in this comment](https://github.com/tilezen/vector-datasource/issues/1611#issuecomment-424154242). Is it also worth merging the `grave_yard` POI into the `cemetery` entry so they both have the same `min_zoom` area thresholds?

Connects to #1611.