### PR TITLE
WIP: Prefer forest labels over wilderness

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1079,3 +1079,18 @@ BEGIN
   END IF;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- try to convert a string into an integer, returning null if that fails.
+CREATE OR REPLACE FUNCTION tz_safe_int(t text)
+RETURNS INTEGER AS $$
+DECLARE
+  val INTEGER DEFAULT NULL;
+BEGIN
+  BEGIN
+    val := (t)::INTEGER;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN NULL;
+  END;
+  RETURN val;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -202,8 +202,8 @@ class ForestTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'pois', {
                 'id': 1504622,
-                'kind': 'nature_reserve',
-                'min_zoom': 7,
+                'kind': 'national_park',
+                'min_zoom': 6,
             })
 
     def test_stanislaus_national_forest(self):

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -341,3 +341,119 @@ class ForestTest(FixtureTest):
                 'kind': 'park',
                 'min_zoom': 8,
             })
+
+
+class BlmTest(FixtureTest):
+
+    def test_blm_public_lands(self):
+        import dsl
+
+        z, x, y = (9, 107, 183)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/2517672
+            dsl.way(2517672, dsl.box_area(z, x, y, 1172619201), {
+                'boundary': 'protected_area',
+                'name': 'BLM',
+                'operator': 'US Bureau of Land Management',
+                'ownership': 'national',
+                'protect_class': '27',
+                'protection_title': 'Public Access Land',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 2517672,
+                'kind': 'protected_area',
+                'min_zoom': 9,
+            })
+
+
+class ScientificProtectedAreasTest(FixtureTest):
+
+    def test_cumberland_island_national_seashore(self):
+        import dsl
+
+        z, x, y = (9, 140, 209)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/4269033
+            dsl.way(4269033, dsl.box_area(z, x, y, 202731274), {
+                'boundary': 'protected_area',
+                'name': 'Cumberland Island National Seashore',
+                'protect_class': '1',
+                'protection_title': 'National Seashore',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 4269033,
+                'kind': 'protected_area',
+                'min_zoom': 9,
+            })
+
+    def test_buck_island_reef(self):
+        # NOTE: this is also tagged as a national monument... so should it be
+        # treated as a "strict nature reserve" and held back a few zooms or
+        # promoted as a national monument??? for the moment, i've taken the
+        # view that it should be held back.
+        import dsl
+
+        z, x, y = (9, 164, 230)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/8973739
+            dsl.way(8973739, dsl.box_area(z, x, y, 88094771), {
+                'boundary': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Buck Island Reef National Monument',
+                'operator': 'National Park Service',
+                'protect_class': '1a',
+                'protected_area': 'nature_reserve_strict',
+                'protection_title': 'National Monument',
+                'seamark:name': 'Buck Island Reef NM',
+                'seamark:type': 'protected_area',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+                'website': 'https://www.nps.gov/buis',
+                'wikidata': 'Q999352',
+                'wikipedia': 'en:Buck Island Reef National Monument',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 8973739,
+                'kind': 'nature_reserve',
+                'min_zoom': 9,
+            })
+
+    def test_little_lake_creek_wilderness(self):
+        import dsl
+
+        z, x, y = (10, 239, 420)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/209936201
+            dsl.way(209936201, dsl.box_area(z, x, y, 21727129), {
+                'boundary': 'protected_area',
+                'landuse': 'conservation',
+                'name': 'Little Lake Creek Wilderness',
+                'protect_class': '1b',
+                'source': 'openstreetmap.org',
+                'wikidata': 'Q27973601',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 209936201,
+                'kind': 'protected_area',
+                'min_zoom': 10,
+            })

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -209,7 +209,7 @@ class ForestTest(FixtureTest):
     def test_stanislaus_national_forest(self):
         import dsl
 
-        z, x, y = (7, 21, 49)
+        z, x, y = (8, 42, 98)
 
         self.generate_fixtures(
             # https://www.openstreetmap.org/relation/972008
@@ -236,7 +236,7 @@ class ForestTest(FixtureTest):
             z, x, y, 'pois', {
                 'id': 972008,
                 'kind': 'forest',
-                'min_zoom': 7,
+                'min_zoom': 8,
             })
 
     def test_emigrant_wilderness(self):
@@ -369,6 +369,36 @@ class BlmTest(FixtureTest):
                 'id': 2517672,
                 'kind': 'protected_area',
                 'min_zoom': 9,
+            })
+
+    def test_okanogan_wenatchee_national_forest(self):
+        import dsl
+
+        z, x, y = (8, 42, 89)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/1447414
+            dsl.way(1447414, dsl.box_area(z, x, y, 38300253290), {
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'name': 'Okanogan-Wenatchee National Forest',
+                'operator': 'United States Forest Service',
+                'ownership': 'national',
+                'protect_class': '6',
+                'protected': 'perpetuity',
+                'protection_title': 'National Forest',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+                'website': 'http://www.fs.usda.gov/okawen/',
+                'wikidata': 'Q3079103',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1447414,
+                'kind': 'forest',
+                'min_zoom': 8,
             })
 
 

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -25,14 +25,11 @@ class ForestTest(FixtureTest):
             }),
         )
 
-        # TODO: should be national park, or nature_reserve? on the one hand,
-        # it is tagged as operated by NPS, but its name contains "recreation
-        # area", not "park"?
         self.assert_has_feature(
             z, x, y, 'pois', {
                 'id': 5908558,
-                'kind': 'national_park',
-                'min_zoom': 6,
+                'kind': 'nature_reserve',
+                'min_zoom': 9,
             })
 
     def test_waterton_lakes_national_park(self):

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -145,3 +145,63 @@ class ForestTest(FixtureTest):
                 'kind': 'nature_reserve',
                 'min_zoom': 9,
             })
+
+    def test_desert_national_wildlife_refuge(self):
+        import dsl
+
+        z, x, y = (9, 91, 199)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/5982772
+            dsl.way(5982772, dsl.box_area(z, x, y, 10301141266), {
+                'boundary': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Desert National Wildlife Refuge',
+                'operator': 'US Fish and Wildlife Service',
+                'ownership': 'national',
+                'protect_class': '4',
+                'protection_title': 'National Wildlife Refuge',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+                'wikidata': 'Q5263981',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5982772,
+                'kind': 'nature_reserve',
+                'min_zoom': 9,
+            })
+
+    def test_white_sands_national_monument(self):
+        import dsl
+
+        z, x, y = (9, 104, 206)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/1504622
+            dsl.way(1504622, dsl.box_area(z, x, y, 856339892), {
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'gnis:feature_id': '914261',
+                'leisure': 'nature_reserve',
+                'name': 'White Sands National Monument',
+                'operator': 'National Park Service',
+                'ownership': 'national',
+                'protect_class': '3',
+                'protection_title': 'National Monument',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+                'website': 'http://www.nps.gov/whsa',
+                'wikidata': 'Q1200164',
+                'wikipedia': 'en:White Sands National Monument',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1504622,
+                'kind': 'nature_reserve',
+                'min_zoom': 7,
+            })

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -401,6 +401,35 @@ class BlmTest(FixtureTest):
                 'min_zoom': 8,
             })
 
+    def test_arapahoe_national_forest(self):
+        import dsl
+
+        z, x, y = (8, 52, 97)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/396026
+            dsl.way(396026, dsl.box_area(z, x, y, 3218601885), {
+                'attribution': 'US Forest Service',
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'name': 'Arapaho National Forest',
+                'operator': 'United States Forest Service',
+                'ownership': 'national',
+                'protect_class': '6',
+                'protected': 'perpetuity',
+                'protection_title': 'National Forest',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 396026,
+                'kind': 'forest',
+                'min_zoom': 8,
+            })
+
 
 class ScientificProtectedAreasTest(FixtureTest):
 

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -205,3 +205,139 @@ class ForestTest(FixtureTest):
                 'kind': 'nature_reserve',
                 'min_zoom': 7,
             })
+
+    def test_stanislaus_national_forest(self):
+        import dsl
+
+        z, x, y = (7, 21, 49)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/972008
+            dsl.way(972008, dsl.box_area(z, x, y, 5882440714), {
+                'attribution': 'USDA-Forest Service, Pacific Southwest Region',
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'name': 'Stanislaus National Forest',
+                'name:de': 'Nationalforst Stanislaus',
+                'operator': 'United States Forest Service',
+                'ownership': 'national',
+                'protect_class': '6',
+                'protected': 'perpetuity',
+                'protection_title': 'National Forest',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+                'website': 'http://www.fs.usda.gov/stanislaus',
+                'wikidata': 'Q2898163',
+                'wikipedia': 'en:Stanislaus National Forest',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 972008,
+                'kind': 'forest',
+                'min_zoom': 7,
+            })
+
+    def test_emigrant_wilderness(self):
+        import dsl
+
+        z, x, y = (10, 171, 394)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/5366680
+            dsl.way(5366680, dsl.box_area(z, x, y, 739870504), {
+                'boundary': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Emigrant Wilderness',
+                'operator': 'US Forest Service',
+                'ownership': 'national',
+                'protect_class': '1b',
+                'protection_title': 'Wilderness Area',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5366680,
+                'kind': 'nature_reserve',
+                'min_zoom': 9,
+            })
+
+    def test_hoover_wilderness(self):
+        import dsl
+
+        z, x, y = (10, 172, 394)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/5372299
+            dsl.way(5372299, dsl.box_area(z, x, y, 840685203), {
+                'boundary': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Hoover Wilderness',
+                'operator': 'US Forest Service',
+                'ownership': 'national',
+                'protect_class': '1b',
+                'protection_title': 'Wilderness Area',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+                'wikidata': 'Q6317507',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5372299,
+                'kind': 'nature_reserve',
+                'min_zoom': 9,
+            })
+
+    def test_algonquin_provincial_park(self):
+        # provincial park, although a large one, isn't a national park. so
+        # should appear with other parks around zoom 8.
+        import dsl
+
+        z, x, y = (8, 72, 91)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/910784
+            dsl.way(910784, dsl.box_area(z, x, y, 15694581677), {
+                'boundary': 'national_park',
+                'date:protected': '1893',
+                'governance_type': 'sub-national ministry or agency',
+                'heritage': '2',
+                'heritage:operator': 'hsamboc',
+                'hsamboc:criteria': 'National Historic Site of Canada',
+                'hsamboc:inscription_date': '1992-06-07',
+                'is_in': 'Ontario',
+                'is_in:zone': 'ALGONQUIN',
+                'iucn_level': 'II',
+                'leisure': 'nature_reserve',
+                'name': 'Algonquin Provincial Park',
+                'name:short': 'ALGONQUIN',
+                'operator': 'Ontario Parks',
+                'operator:url': 'www.ontarioparks.com/english/',
+                'protect_class': '2',
+                'protection_title': 'Provincial Park',
+                'ref:hsamboc': '3249',
+                'short_name': 'Algonquin Park',
+                'site_ownership': 'national',
+                'site_status': 'designated',
+                'source': 'openstreetmap.org',
+                'source:type': 'Provincial Park',
+                'type': 'multipolygon',
+                'WDPA_ID:ref': '4167',
+                'website': 'http://www.ontarioparks.com/park/algonquin',
+                'wikidata': 'Q1543478',
+                'wikipedia': 'en:Algonquin Provincial Park',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 910784,
+                'kind': 'park',
+                'min_zoom': 8,
+            })

--- a/integration-test/1608-prefer-forest-labels-over-wilderness.py
+++ b/integration-test/1608-prefer-forest-labels-over-wilderness.py
@@ -1,0 +1,150 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class ForestTest(FixtureTest):
+
+    def test_lake_roosevelt_national_rec_area(self):
+        import dsl
+
+        z, x, y = (9, 87, 177)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/5908558
+            dsl.way(5908558, dsl.box_area(z, x, y, 914801107), {
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Lake Roosevelt National Recreation Area',
+                'operator': 'National Park Service',
+                'ownership': 'national',
+                'protect_class': '5',
+                'protection_title': 'National Recreation Area',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+            }),
+        )
+
+        # TODO: should be national park, or nature_reserve? on the one hand,
+        # it is tagged as operated by NPS, but its name contains "recreation
+        # area", not "park"?
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5908558,
+                'kind': 'national_park',
+                'min_zoom': 6,
+            })
+
+    def test_waterton_lakes_national_park(self):
+        import dsl
+
+        z, x, y = (8, 46, 87)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/6395476
+            dsl.way(6395476, dsl.box_area(z, x, y, 1194507152), {
+                'boundary': 'national_park',
+                'leisure': 'nature_reserve',
+                'name': 'Waterton Lakes National Park',
+                'operator': 'Parks Canada',
+                'protect_class': '2',
+                'protection_title': 'National Park',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+                'wikidata': 'Q902778',
+                'wikipedia': 'en:Waterton Lakes National Park',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 6395476,
+                'kind': 'national_park',
+                'min_zoom': 6,
+            })
+
+    def test_glacier_national_park(self):
+        import dsl
+
+        z, x, y = (6, 11, 22)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/1242641
+            dsl.way(1242641, dsl.box_area(z, x, y, 9350484254), {
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Glacier National Park',
+                'operator': 'United States National Park Service',
+                'ownership': 'national',
+                'protect_id': '2',
+                'protected': 'perpetuity',
+                'protection_title': 'National Park',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+                'wikidata': 'Q373567',
+                'wikipedia': 'en:Glacier National Park (U.S.)',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1242641,
+                'kind': 'national_park',
+                'min_zoom': 6,
+            })
+
+    def test_charles_m_russell_wildlife_refuge(self):
+        import dsl
+
+        z, x, y = (9, 103, 178)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/6059779
+            dsl.way(6059779, dsl.box_area(z, x, y, 8589619557), {
+                'boundary': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Charles M. Russell National Wildlife Refuge',
+                'operator': 'US Fish and Wildlife Service',
+                'ownership': 'national',
+                'protect_class': '4',
+                'protection_title': 'National Wildlife Refuge',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+                'wikidata': 'Q5080495',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 6059779,
+                'kind': 'nature_reserve',
+                'min_zoom': 9,
+            })
+
+    def test_absaroka_beartooth_wilderness(self):
+        import dsl
+
+        z, x, y = (9, 99, 183)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/6003517
+            dsl.way(6003517, dsl.box_area(z, x, y, 7675407331), {
+                'boundary': 'protected_area',
+                'leisure': 'nature_reserve',
+                'name': 'Absaroka-Beartooth Wilderness Area',
+                'operator': 'US Forest Service',
+                'ownership': 'national',
+                'protect_class': '1b',
+                'protection_title': 'Wilderness Area',
+                'source': 'openstreetmap.org',
+                'type': 'boundary',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 6003517,
+                'kind': 'nature_reserve',
+                'min_zoom': 9,
+            })

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -44,7 +44,7 @@ class LanduseTier(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'pois',
             {'kind': 'national_park', 'id': -1453306, 'tier': 1,
-             'min_zoom': 6})
+             'min_zoom': 5})
 
     def test_national_park(self):
         import dsl

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -4,30 +4,77 @@ from . import FixtureTest
 class LanduseTier(FixtureTest):
     def test_large_national_park(self):
         # area 1.75564e+10
-        self.load_fixtures(['http://www.openstreetmap.org/relation/1453306'])
+        import dsl
 
+        z, x, y = (6, 12, 23)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/1453306
+            dsl.way(-1453306, dsl.box_area(z, x, y, 17556377754), {
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'gnis:feature_id': '1609331',
+                'heritage': '1',
+                'heritage:operator': 'whc',
+                'leisure': 'nature_reserve',
+                'name': 'Yellowstone National Park',
+                'name:sk': u'Yellowstonsk\xfd n\xe1rodn\xfd park',
+                'operator': 'United States National Park Service',
+                'ownership': 'national',
+                'protect_id': '2',
+                'protected': 'perpetuity',
+                'protection_title': 'National Park',
+                'ref:whc': '28',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+                'website': 'http://www.nps.gov/yell/',
+                'whc:criteria': '(vii)(viii)(ix)(x)',
+                'whc:inscription_date': '1978',
+                'wikidata': 'Q351',
+                'wikipedia': 'en:Yellowstone National Park',
+            }),
+        )
+
+        # zoom 3
         self.assert_has_feature(
-            4, 3, 5, 'landuse',
+            z-3, x//8, y//8, 'landuse',
             {'kind': 'national_park', 'id': -1453306, 'tier': 1,
              'min_zoom': 3})
 
         self.assert_has_feature(
-            6, 12, 23, 'pois',
+            z, x, y, 'pois',
             {'kind': 'national_park', 'id': -1453306, 'tier': 1,
-             'min_zoom': 3.74})
+             'min_zoom': 6})
 
     def test_national_park(self):
-        # area 30089300
-        self.load_fixtures(['http://www.openstreetmap.org/relation/921675'])
+        import dsl
+
+        z, x, y = (8, 56, 118)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/921675
+            dsl.way(-921675, dsl.box_area(z, x, y, 39749331), {
+                'boundary': 'national_park',
+                'is_in:country': 'Mexico',
+                'iucn_level': '2',
+                'name': 'Parque Nacional El Veladero',
+                'protect_id': '5404',
+                'protection_title': 'National Park',
+                'source': 'openstreetmap.org',
+                'type': 'multipolygon',
+                'wikidata': 'Q9055960',
+                'wikipedia': 'es:Parque Nacional El Veladero',
+            }),
+        )
 
         self.assert_has_feature(
-            8, 56, 115, 'landuse',
+            z, x, y, 'landuse',
             {'kind': 'national_park', 'tier': 1, 'min_zoom': 8})
 
         self.assert_has_feature(
-            8, 56, 115, 'pois',
+            z, x, y, 'pois',
             {'kind': 'national_park', 'id': -921675, 'tier': 1,
-             'min_zoom': 8.33})
+             'min_zoom': 8})
 
     def test_national_forest(self):
         # this is USFS, so demoted to tier 2 :-(

--- a/integration-test/663-combo-outdoor-landuse-pois.py
+++ b/integration-test/663-combo-outdoor-landuse-pois.py
@@ -115,7 +115,7 @@ class ComboOutdoorLandusePois(FixtureTest):
 
         self.assert_has_feature(
             11, 582, 796, 'pois',
-            {'kind': 'battlefield', 'min_zoom': 10.07})
+            {'kind': 'battlefield', 'min_zoom': 10})
 
         self.assert_has_feature(
             11, 582, 796, 'landuse',

--- a/integration-test/742-predictable-layers-pois.py
+++ b/integration-test/742-predictable-layers-pois.py
@@ -67,12 +67,12 @@ class PredictableLayersPois(FixtureTest):
         self.generate_fixtures(dsl.way(375855355, wkt_loads('POLYGON ((-122.925877332767 45.5089216821027, -122.925871583549 45.50933780500298, -122.925655898049 45.5092836021792, -122.925394039144 45.5092535104612, -122.925095079817 45.50922587391108, -122.92477258463 45.50921259073521, -122.924453233547 45.50924475993769, -122.924187242391 45.50928479829319, -122.923901218805 45.50932779542619, -122.923654900754 45.50936481196539, -122.923413074279 45.50937135910589, -122.92298996778 45.50942209941851, -122.922743200572 45.5094516874209, -122.9227501176 45.50889788557148, -122.922981523617 45.50889788557148, -122.923488622595 45.5088976967102, -122.923771681741 45.5088975708025, -122.923843726627 45.5087860165587, -122.923847679214 45.50847080537579, -122.924018987938 45.50847067946721, -122.924253088901 45.50847061651298, -122.924487100033 45.50847061651298, -122.924541537939 45.50847061651298, -122.924534441248 45.5087138713149, -122.924629033848 45.50874786646749, -122.924789113632 45.50880528045639, -122.925022226448 45.50881289787809, -122.92585990545 45.50883770170709, -122.92585756983 45.50892149324138, -122.925877332767 45.5089216821027))'), {u'operator': u'City of Hillsboro', u'source': u'openstreetmap.org', u'landuse': u'forest', u'way_area': u'29977.9', u'name': u'Lexington Estates'}))  # noqa
 
         self.assert_has_feature(
-            14, 2597, 5860, 'pois',
+            15, 5195, 11721, 'pois',
             {'id': 375855355, 'kind': 'forest'})
 
         # Label placement forest in landuse
         self.assert_no_matching_feature(
-            14, 2597, 5860, 'landuse',
+            15, 5195, 11721, 'landuse',
             {'id': 375855355, 'kind': 'forest', 'label_placement': True})
 
     def test_forest_node(self):
@@ -80,8 +80,8 @@ class PredictableLayersPois(FixtureTest):
         self.generate_fixtures(dsl.way(357559979, wkt_loads('POINT (-117.534299580093 41.6832263153935)'), {u'gnis:state_id': u'32', u'name': u'Santa Rosa Ranger District', u'gnis:county_id': u'013', u'ele': u'2187', u'source': u'openstreetmap.org', u'gnis:created': u'05/01/1990', u'gnis:feature_id': u'862882', u'landuse': u'forest'}))  # noqa
 
         self.assert_has_feature(
-            14, 2842, 6101, 'pois',
-            {'id': 357559979, 'kind': 'forest', 'min_zoom': 14})
+            16, 11371, 24405, 'pois',
+            {'id': 357559979, 'kind': 'forest', 'min_zoom': 16})
 
     def test_forest_protect_class(self):
         # Way:432810821 landuse: Forest protect class in POIS
@@ -322,8 +322,8 @@ class PredictableLayersPois(FixtureTest):
         self.generate_fixtures(dsl.way(1462300228, wkt_loads('POINT (11.0625186229689 49.62113429765858)'), {u'source': u'openstreetmap.org', u'boundary': u'protected_area', u'name': u'Tongrube Marloffstein'}))  # noqa
 
         self.assert_has_feature(
-            14, 8695, 5583, 'pois',
-            {'id': 1462300228, 'kind': 'protected_area', 'min_zoom': 14})
+            16, 34781, 22333, 'pois',
+            {'id': 1462300228, 'kind': 'protected_area', 'min_zoom': 16})
 
     def test_quarry_way(self):
         # quarry in POIS

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -639,7 +639,7 @@ class PoisMinZoomTest(unittest.TestCase):
         }
         meta = make_test_metadata()
         out_min_zoom = self.pois.fn(shape, props, None, meta)
-        self.assertEquals(14, out_min_zoom)
+        self.assertEquals(16, out_min_zoom)
 
 
 class RoadsMinZoomTest(unittest.TestCase):

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -175,7 +175,7 @@ KNOWN_FUNCS = {
     'mz_calculate_ferry_level':           'mz_calculate_ferry_level',
     'util.is_building':                   'mz_calculate_is_building_or_part',
     'util.tag_str_to_bool':               'notimplemented',
-    'util.safe_int':                      'notimplemented',
+    'util.safe_int':                      'tz_safe_int',
     'util.true_or_none':                  'notimplemented',
     'tz_looks_like_service_area':         'tz_looks_like_service_area',
     'tz_looks_like_rest_area':            'tz_looks_like_rest_area',

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -118,6 +118,20 @@ global:
         - [ 14,  50000 ]
         - [ 15,   5000 ]
       default: 16
+  - &small_parks_min_zoom
+    lookup:
+      key: { col: way_area }
+      op: '>='
+      table:
+        - [ 8,   400000000 ]
+        - [ 9,    40000000 ]
+        - [ 10,   10000000 ]
+        - [ 11,    4000000 ]
+        - [ 12,    2000000 ]
+        - [ 13,     200000 ]
+        - [ 14,     100000 ]
+        - [ 15,      10000 ]
+      default: 16
   - &us_forest_service
         - United States Forest Service
         - US Forest Service
@@ -133,6 +147,30 @@ global:
         - US National Park Service
         - U.S. National Park Service
         - US National Park service
+  - &not_national_park_protection_title
+        - Conservation Area
+        - Conservation Park
+        - Environmental use
+        - Forest Reserve
+        - National Forest
+        - National Wildlife Refuge
+        - Nature Refuge
+        - Nature Reserve
+        - Protected Site
+        - Provincial Park
+        - Public Access Land
+        - Regional Reserve
+        - Resources Reserve
+        - State Forest
+        - State Game Land
+        - State Park
+        - Watershed Recreation Unit
+        - Wild Forest
+        - Wilderness Area
+        - Wilderness Study Area
+        - Wildlife Management
+        - Wildlife Management Area
+        - Wildlife Sanctuary
   # whitelist for leaf_type
   - &leaftype_kind_detail
     kind_detail:
@@ -262,9 +300,7 @@ filters:
       leisure: nature_reserve
       protect_class: ['4', '5']
       not:
-        any:
-          - operator: *us_forest_service
-          - operator: *us_parks_service
+        - operator: *us_forest_service
     min_zoom: *tier2_min_zoom
     output:
       <<: *output_properties
@@ -297,6 +333,7 @@ filters:
   ############################################################
   - filter:
       historic: battlefield
+      not: {operator: *us_forest_service}
     min_zoom: *tier1_min_zoom
     output:
       <<: *output_properties
@@ -304,10 +341,12 @@ filters:
       tier: 1
   - filter:
       boundary: national_park
+      not:
+        any:
+          - operator: *us_forest_service
+          - protection_title: *not_national_park_protection_title
       any:
-        all:
-          not: { operator: *us_forest_service }
-          protect_class: ['2', '3']
+        protect_class: ['2', '3']
         operator: *us_parks_service
         operator:en: Parks Canada
         designation: national_park
@@ -323,8 +362,15 @@ filters:
   ############################################################
   - filter:
       boundary: national_park
-      not: { operator: *us_forest_service }
-      protect_class: ['2', '3']
+      not:
+        any:
+          - operator: *us_forest_service
+          - protection_title: *not_national_park_protection_title
+      any:
+        protect_class: ['2', '3']
+        protect_title:
+          - National Park
+          - National Monument
     min_zoom: *tier2_min_zoom
     output:
       <<: *output_properties
@@ -341,7 +387,19 @@ filters:
       kind: park
       tier: 2
 
-  - filter: { landuse: forest, operator: *us_forest_service }
+  # forests
+  - filter:
+      landuse: forest
+      protect_class: '6'
+    min_zoom: { max: [ 6, *tier2_min_zoom ] }
+    output:
+      <<: *output_properties
+      kind: forest
+      <<: *leaftype_kind_detail
+      tier: 2
+  - filter:
+      landuse: forest
+      operator: *us_forest_service
     min_zoom: { max: [ 6, *tier2_min_zoom ] }
     output:
       <<: *output_properties
@@ -356,12 +414,34 @@ filters:
       <<: *leaftype_kind_detail
       tier: 2
 
+  # nature reserves
   - filter: {leisure: nature_reserve}
     min_zoom: *tier2_min_zoom
     output:
       <<: *output_properties
       kind: nature_reserve
       tier: 2
+  # Bureau of Land Management protected areas
+  - filter:
+      boundary: protected_area
+      operator:
+        - BLM
+        - US Bureau of Land Management
+    min_zoom: { max: [ 9, *small_parks_min_zoom ] }
+    output:
+      <<: *output_properties
+      kind: protected_area
+      tier: 2
+  # scientific protected areas?
+  - filter:
+      boundary: protected_area
+      protect_class: ['1', '1a', '1b']
+    min_zoom: { max: [ 9, *small_parks_min_zoom ] }
+    output:
+      <<: *output_properties
+      kind: protected_area
+      tier: 2
+  # protected areas
   - filter: {boundary: protected_area}
     min_zoom: *tier2_min_zoom
     output:
@@ -369,7 +449,10 @@ filters:
       kind: protected_area
       tier: 2
 
-  - filter: { landuse: wood, operator: *us_forest_service }
+  # woods
+  - filter:
+      landuse: wood
+      operator: *us_forest_service
     min_zoom: { max: [ 6, *tier2_min_zoom ] }
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -419,6 +419,14 @@ filters:
       <<: *output_properties
       kind: nature_reserve
       tier: 2
+  - filter:
+      leisure: nature_reserve
+      protection_title: National Monument
+    min_zoom: { max: [ 7, *tier2_min_zoom ] }
+    output:
+      <<: *output_properties
+      kind: nature_reserve
+      tier: 2
 
   ############################################################
   # TIER 1
@@ -433,6 +441,7 @@ filters:
       tier: 1
   - filter:
       boundary: national_park
+      not: { protection_title: National Monument }
       any:
         all:
           not: { operator: *us_forest_service }

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -387,7 +387,7 @@ filters:
   - filter:
       boundary: national_park
       operator: *us_forest_service
-    min_zoom: { max: [ 7, *tier2_min_zoom ] }
+    min_zoom: { max: [ 8, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -446,6 +446,7 @@ filters:
   - filter:
       leisure: nature_reserve
       protection_title: National Monument
+      not: { protect_class: ['1', '1a', '1b'] }
     min_zoom: { max: [ 7, *tier2_min_zoom ] }
     output:
       <<: *output_properties
@@ -541,6 +542,26 @@ filters:
     output:
       <<: *output_properties
       kind: nature_reserve
+      tier: 2
+  # Bureau of Land Management protected areas
+  - filter:
+      boundary: protected_area
+      operator:
+        - BLM
+        - US Bureau of Land Management
+    min_zoom: { max: [ 9, *small_parks_min_zoom ] }
+    output:
+      <<: *output_properties
+      kind: protected_area
+      tier: 2
+  # scientific protected areas?
+  - filter:
+      boundary: protected_area
+      protect_class: ['1', '1a', '1b']
+    min_zoom: { max: [ 9, *small_parks_min_zoom ] }
+    output:
+      <<: *output_properties
+      kind: protected_area
       tier: 2
   # protected areas
   - filter: {boundary: protected_area}

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -78,7 +78,8 @@ global:
         - [ 13,    100000 ]
         - [ 14,     50000 ]
         - [ 15,      2000 ]
-      default: 16
+        - [ 16,      1000 ]
+      default: 17
   - &tier2_min_zoom
     lookup:
       key: { col: way_area }
@@ -159,6 +160,23 @@ global:
         - [ 14,     100000 ]
         - [ 15,      10000 ]
       default: 16
+  - &green_areas_min_zoom
+    lookup:
+      key: { col: way_area }
+      op: '>='
+      table:
+        - [ 6,  5000000000 ]
+        - [ 7,  2500000000 ]
+        - [ 8,  1000000000 ]
+        - [ 9,   100000000 ]
+        - [ 10,   50000000 ]
+        - [ 11,   25000000 ]
+        - [ 12,    5000000 ]
+        - [ 13,     200000 ]
+        - [ 14,      50000 ]
+        - [ 15,      10000 ]
+        - [ 16,       1000 ]
+      default: 17
   - &us_forest_service
         - United States Forest Service
         - US Forest Service
@@ -345,7 +363,7 @@ filters:
   - filter:
       boundary: national_park
       operator: *us_forest_service
-    min_zoom: { min: [ { max: [ 7, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 7, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -364,7 +382,7 @@ filters:
       boundary: national_park
       protect_class: '6'
       protection_title: National Forest
-    min_zoom: { min: [ { max: [ 7, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 7, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -373,7 +391,7 @@ filters:
       boundary: national_park
       protect_class: '6'
       protection_title: National Forest
-    min_zoom: { min: [ { max: [ 7, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 7, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -383,7 +401,7 @@ filters:
       any:
         - protect_class: '6'
         - designation: area_of_outstanding_natural_beauty
-    min_zoom: { min: [ { max: [ 9, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 9, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: park
@@ -398,7 +416,7 @@ filters:
         any:
           - operator: *us_forest_service
           - operator: *us_parks_service
-    min_zoom: *tier2_min_zoom
+    min_zoom: { max: [ 9, *green_areas_min_zoom ] }
     output:
       <<: *output_properties
       kind: nature_reserve
@@ -410,7 +428,7 @@ filters:
   - filter:
       historic: battlefield
       not: {operator: *us_forest_service}
-    min_zoom: { min: [ { max: [ 10, { sum: [ { col: zoom }, 4 ] }, *tier1_min_zoom ] }, 17 ] }
+    min_zoom: { max: [ 10, *tier1_min_zoom ] }
     output:
       <<: *output_properties
       kind: battlefield
@@ -425,7 +443,7 @@ filters:
         operator:en: Parks Canada
         designation: national_park
         protection_title: National Park
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 3.5 ] }, *tier1_min_zoom ] }, 10 ] }
+    min_zoom: { max: [ 6, *tier1_min_zoom ] }
     output:
       <<: *output_properties
       kind: national_park
@@ -438,7 +456,7 @@ filters:
       boundary: national_park
       not: { operator: *us_forest_service }
       protect_class: ['2', '3', '5']
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 3.5 ] }, *tier2_min_zoom ] }, 10 ] }
+    min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: national_park
@@ -458,7 +476,7 @@ filters:
   - filter:
       landuse: forest
       protect_class: '6'
-    min_zoom: { min: [ { max: [ 7, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 7, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -466,13 +484,13 @@ filters:
   - filter:
       landuse: forest
       operator: *us_forest_service
-    min_zoom: { min: [ { max: [ 7, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 7, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
       tier: 2
   - filter: {landuse: forest}
-    min_zoom: { min: [ { max: [ 10, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -480,14 +498,14 @@ filters:
 
   # nature reserves
   - filter: {leisure: nature_reserve}
-    min_zoom: *small_parks_min_zoom
+    min_zoom: { max: [ 9, *small_parks_min_zoom ] }
     output:
       <<: *output_properties
       kind: nature_reserve
       tier: 2
   # protected areas
   - filter: {boundary: protected_area}
-    min_zoom: { min: [ { max: [ 7, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 7, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: protected_area
@@ -497,7 +515,7 @@ filters:
   - filter:
       landuse: wood
       operator: *us_forest_service
-    min_zoom: { min: [ { max: [ 9, { sum: [ { col: zoom }, 2 ] }, *tier2_min_zoom ] }, 14 ] }
+    min_zoom: { max: [ 9, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: wood

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -65,20 +65,20 @@ global:
       key: { col: way_area }
       op: '>='
       table:
-        - [ 3,  300000000 ]
-        - [ 4,  300000000 ]
-        - [ 5,  150000000 ]
-        - [ 6,  150000000 ]
-        - [ 7,  100000000 ]
-        - [ 8,   10000000 ]
-        - [ 9,    5000000 ]
-        - [ 10,   1000000 ]
-        - [ 11,    500000 ]
-        - [ 12,    200000 ]
-        - [ 13,    100000 ]
-        - [ 14,     50000 ]
-        - [ 15,      2000 ]
-        - [ 16,      1000 ]
+        - [ 3, 50000000000 ]
+        - [ 4, 25000000000 ]
+        - [ 5, 10000000000 ]
+        - [ 6,   150000000 ]
+        - [ 7,   100000000 ]
+        - [ 8,    10000000 ]
+        - [ 9,     5000000 ]
+        - [ 10,    1000000 ]
+        - [ 11,     500000 ]
+        - [ 12,     200000 ]
+        - [ 13,     100000 ]
+        - [ 14,      50000 ]
+        - [ 15,       2000 ]
+        - [ 16,       1000 ]
       default: 17
   - &tier2_min_zoom
     lookup:
@@ -413,9 +413,7 @@ filters:
       leisure: nature_reserve
       protect_class: ['4', '5']
       not:
-        any:
-          - operator: *us_forest_service
-          - operator: *us_parks_service
+        - operator: *us_forest_service
     min_zoom: { max: [ 9, *green_areas_min_zoom ] }
     output:
       <<: *output_properties
@@ -443,7 +441,7 @@ filters:
         operator:en: Parks Canada
         designation: national_park
         protection_title: National Park
-    min_zoom: { max: [ 6, *tier1_min_zoom ] }
+    min_zoom: { max: [ 5, *tier1_min_zoom ] }
     output:
       <<: *output_properties
       kind: national_park

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -443,15 +443,6 @@ filters:
       <<: *output_properties
       kind: nature_reserve
       tier: 2
-  - filter:
-      leisure: nature_reserve
-      protection_title: National Monument
-      not: { protect_class: ['1', '1a', '1b'] }
-    min_zoom: { max: [ 7, *tier2_min_zoom ] }
-    output:
-      <<: *output_properties
-      kind: nature_reserve
-      tier: 2
 
   ############################################################
   # TIER 1
@@ -529,7 +520,7 @@ filters:
       <<: *output_properties
       kind: forest
       tier: 2
-  - filter: {landuse: forest}
+  - filter: { landuse: forest }
     min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties
@@ -580,7 +571,7 @@ filters:
       <<: *output_properties
       kind: wood
       tier: 2
-  - filter: {landuse: wood}
+  - filter: { landuse: wood }
     min_zoom: 17
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -192,6 +192,30 @@ global:
         - US National Park Service
         - U.S. National Park Service
         - US National Park service
+  - &not_national_park_protection_title
+        - Conservation Area
+        - Conservation Park
+        - Environmental use
+        - Forest Reserve
+        - National Forest
+        - National Wildlife Refuge
+        - Nature Refuge
+        - Nature Reserve
+        - Protected Site
+        - Provincial Park
+        - Public Access Land
+        - Regional Reserve
+        - Resources Reserve
+        - State Forest
+        - State Game Land
+        - State Park
+        - Watershed Recreation Unit
+        - Wild Forest
+        - Wilderness Area
+        - Wilderness Study Area
+        - Wildlife Management
+        - Wildlife Management Area
+        - Wildlife Sanctuary
   - &no_name_okay
         - aerialway: pylon
         - aeroway: [ gate, helipad ]
@@ -441,11 +465,12 @@ filters:
       tier: 1
   - filter:
       boundary: national_park
-      not: { protection_title: National Monument }
+      not:
+        any:
+          - operator: *us_forest_service
+          - protection_title: *not_national_park_protection_title
       any:
-        all:
-          not: { operator: *us_forest_service }
-          protect_class: ['2', '3']
+        protect_class: ['2', '3']
         operator: *us_parks_service
         operator:en: Parks Canada
         designation: national_park
@@ -461,8 +486,15 @@ filters:
   ############################################################
   - filter:
       boundary: national_park
-      not: { operator: *us_forest_service }
-      protect_class: ['2', '3']
+      not:
+        any:
+          - operator: *us_forest_service
+          - protection_title: *not_national_park_protection_title
+      any:
+        protect_class: ['2', '3']
+        protect_title:
+          - National Park
+          - National Monument
     min_zoom: { max: [ 10, *tier2_min_zoom ] }
     output:
       <<: *output_properties

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -406,7 +406,7 @@ filters:
       boundary: national_park
       protect_class: '6'
       protection_title: National Forest
-    min_zoom: { max: [ 7, *tier2_min_zoom ] }
+    min_zoom: { max: [ 8, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -415,7 +415,7 @@ filters:
       boundary: national_park
       protect_class: '6'
       protection_title: National Forest
-    min_zoom: { max: [ 7, *tier2_min_zoom ] }
+    min_zoom: { max: [ 8, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -516,7 +516,7 @@ filters:
   - filter:
       landuse: forest
       protect_class: '6'
-    min_zoom: { max: [ 7, *tier2_min_zoom ] }
+    min_zoom: { max: [ 8, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest
@@ -524,7 +524,7 @@ filters:
   - filter:
       landuse: forest
       operator: *us_forest_service
-    min_zoom: { max: [ 7, *tier2_min_zoom ] }
+    min_zoom: { max: [ 8, *tier2_min_zoom ] }
     output:
       <<: *output_properties
       kind: forest


### PR DESCRIPTION
**NOTE: This is only a partial PR at this point, and only starts to address parts of #1608.**

This was starting to take a while, so I wanted to check with you, @nvkelso, that it's heading in the right direction. And that the examples I'm using for the tests are appropriate. If it looks OK, then let me know and I'll continue porting across the rest of the rules (although perhaps trying to find a better way to say "name includes 'National Park'" that isn't so anglocentric).

Simplify most tier 1 & 2 POI min zooms to area-based thresholds, rather than formulae. This makes it easier for a human to predict what the output will be for a given input feature. Added new area thresholds for green areas which aren't national parks.

Connects to #1608.