### PR TITLE
Merge the cemetery and grave_yard kind filters

### DIFF
--- a/integration-test/1780-merge-graveyard-cemetery-zoom-ranges.py
+++ b/integration-test/1780-merge-graveyard-cemetery-zoom-ranges.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class GraveyardCemeteryTest(FixtureTest):
+
+    def test_forest_lawn_memorial_park(self):
+        import dsl
+
+        z, x, y = (13, 1409, 3276)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/24019957
+            dsl.way(24019957, dsl.box_area(z, x, y, 872976), {
+                'amenity': 'grave_yard',
+                'name': 'Forest Lawn Memorial Park',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 24019957,
+                'kind': 'grave_yard',
+                'min_zoom': 13,
+            })
+
+    def test_willits_cemetery(self):
+        # despite the name, it has been tagged as a graveyard. the two terms
+        # appear to be near-synonyms anyway (apparently a cemetery is
+        # independent of any single church, and a graveyard isn't - but i had
+        # to look that up, it wasn't obvious to me).
+        import dsl
+
+        z, x, y = (14, 2577, 6237)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/368713224
+            dsl.way(368713224, dsl.box_area(z, x, y, 74278), {
+                'amenity': 'grave_yard',
+                'ele': '467',
+                'gnis:county_id': '045',
+                'gnis:created': '01/19/1981',
+                'gnis:feature_id': '237866',
+                'gnis:state_id': '06',
+                'name': 'Willits Cemetery',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 368713224,
+                'kind': 'grave_yard',
+                'min_zoom': 14,
+            })

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -603,12 +603,19 @@ filters:
   ############################################################
   # TIER 4
   ############################################################
-  # cemetery
-  - filter: {landuse: cemetery}
+  # cemetery & grave_yard
+  - filter:
+      any:
+        landuse: cemetery
+        amenity: grave_yard
     min_zoom: *tier4_min_zoom
     output:
       <<: *output_properties
-      kind: cemetery
+      kind:
+        case:
+          - when: { landuse: cemetery }
+            then: cemetery
+          - else: grave_yard
       tier: 4
       kind_detail: { col: religion }
       denomination: { col: denomination }
@@ -1295,13 +1302,6 @@ filters:
     output:
       <<: *output_properties
       kind: gate
-  - filter: {amenity: grave_yard}
-    min_zoom: { clamp: { min: 13, max: 17, value: { sum: [ { col: zoom }, 3 ] } } }
-    output:
-      <<: *output_properties
-      kind: grave_yard
-      kind_detail: { col: religion }
-      denomination: { col: denomination }
   - filter:
       man_made: crane
       geom_type: line

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -669,8 +669,11 @@ filters:
   ############################################################
   # breakwater - no POIs
   # bridge - no POIs
-  # cemetery
-  - filter: {landuse: cemetery}
+  # cemetery & grave_yard
+  - filter:
+      any:
+        landuse: cemetery
+        amenity: grave_yard
     min_zoom:
       lookup:
         key: { col: way_area }
@@ -683,7 +686,11 @@ filters:
         default: 16
     output:
       <<: *output_properties
-      kind: cemetery
+      kind:
+        case:
+          - when: { landuse: cemetery }
+            then: cemetery
+          - else: grave_yard
       tier: 4
       kind_detail: { col: religion }
       denomination: { col: denomination }
@@ -2390,13 +2397,6 @@ filters:
       <<: *output_properties
       kind: picnic_site
 
-  - filter: {amenity: grave_yard}
-    min_zoom: { clamp: { min: 13, max: 17, value: { sum: [ { col: zoom }, 3 ] } } }
-    output:
-      <<: *output_properties
-      kind: grave_yard
-      kind_detail: { col: religion }
-      denomination: { col: denomination }
   - filter: {landuse: quarry}
     min_zoom: { clamp: { min: 12, max: 14, value: { sum: [ { col: zoom }, 3 ] } } }
     output:


### PR DESCRIPTION
This preserves separate kinds for `cemetery` and `grave_yard`, but shares the same filter definition and zoom ranges. Since cemeteries and grave yards are very similar things (and it's not uncommon to find both `landuse=cemetery` and `amenity=grave_yard` on a feature), it seems reasonable to have the same zoom ranges for both.

Connects to #1780.
