### PR TITLE
Add wetland POIs with kind_detail.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1253,6 +1253,7 @@ Common values include `pit_latrine`, ` flush`, ` chemical`, ` pour_flush`, ` buc
 Common values include: `drinkable_powered`, `drinkable_manual`, `drinkable_no_pump`, `drinkable`, `not_drinkable_powered`, `not_drinkable_manual`, `not_drinkable_no_pump`, `not_drinkable`.
 
 #### Wetland `kind_detail` values
+
 The value of the OpenStreetMap `wetland` tag. If available, value will be one of: `bog`, `fen`, `mangrove`, `marsh`, `mud`, `reedbed`, `saltern`, `saltmarsh`, `string_bog`, `swamp`, `tidalflat`, `wet_meadow`.
 
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1191,6 +1191,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `watermill` - A structure for using water power to do work. Note that this is different from a modern structure to generate electric power from water, which would be a `generator`. Abandoned or disused features are not shown unless they are attractions, landmarks or other kinds.
 * `waterway_fuel`
 * `wayside_cross`
+* `wetland` with `kind_detail` property.
 * `wharf` with mooring property.
 * `wilderness_hut`
 * `wildlife_park`
@@ -1250,6 +1251,9 @@ Common values include `pit_latrine`, ` flush`, ` chemical`, ` pour_flush`, ` buc
 #### **water_well** `kind_detail` values:
 
 Common values include: `drinkable_powered`, `drinkable_manual`, `drinkable_no_pump`, `drinkable`, `not_drinkable_powered`, `not_drinkable_manual`, `not_drinkable_no_pump`, `not_drinkable`.
+
+#### Wetland `kind_detail` values
+The value of the OpenStreetMap `wetland` tag. If available, value will be one of: `bog`, `fen`, `mangrove`, `marsh`, `mud`, `reedbed`, `saltern`, `saltmarsh`, `string_bog`, `swamp`, `tidalflat`, `wet_meadow`.
 
 
 ## Roads (Transportation)

--- a/integration-test/1253-wetland-kind-detail.py
+++ b/integration-test/1253-wetland-kind-detail.py
@@ -1,0 +1,121 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class WetlandTest(FixtureTest):
+
+    def test_landuse_saltmarsh(self):
+        import dsl
+
+        z, x, y = (16, 19323, 24662)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/50977043
+            dsl.way(50977043, dsl.box_area(z, x, y, 122442), {
+                'boundary': 'national_park',
+                'landuse': 'meadow',
+                'natural': 'wetland',
+                'place': 'island',
+                'source': 'openstreetmap.org',
+                'wetland': 'saltmarsh',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 50977043,
+                'kind': 'wetland',
+                'kind_detail': 'saltmarsh',
+            })
+
+    def test_yellow_bar_hassock(self):
+        import dsl
+
+        z, x, y = (16, 19325, 24665)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/50976996
+            dsl.way(50976996, dsl.box_area(z, x, y, 930605), {
+                'boundary': 'national_park',
+                'ele': '0',
+                'gnis:county_id': '047',
+                'gnis:created': '01/23/1980',
+                'gnis:feature_id': '971817',
+                'gnis:state_id': '36',
+                'name': 'Yellow Bar Hassock',
+                'natural': 'wetland',
+                'place': 'island',
+                'source': 'openstreetmap.org',
+                'wetland': 'saltmarsh',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 50976996,
+                'kind': 'wetland',
+                'kind_detail': 'saltmarsh',
+            })
+
+    def test_ruffle_bar(self):
+        # sounds like candy...
+        import dsl
+
+        z, x, y = (16, 19322, 24667)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/110163359
+            dsl.way(110163359, dsl.box_area(z, x, y, 900561), {
+                'boundary': 'national_park',
+                'ele': '4',
+                'gnis:county_id': '047',
+                'gnis:created': '01/23/1980',
+                'gnis:feature_id': '963071',
+                'gnis:state_id': '36',
+                'name': 'Ruffle Bar',
+                'natural': 'wetland',
+                'place': 'island',
+                'source': 'openstreetmap.org',
+                'wetland': 'saltmarsh',
+                'wikidata': 'Q15273739',
+                'wikipedia': 'en:Ruffle Bar',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 110163359,
+                'kind': 'wetland',
+                'kind_detail': 'saltmarsh',
+            })
+
+    def test_big_egg_marsh(self):
+        import dsl
+
+        z, x, y = (16, 19327, 24668)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/50977027
+            dsl.way(50977027, dsl.box_area(z, x, y, 254547), {
+                'addr:state': 'NY',
+                'boundary': 'national_park',
+                'ele': '0',
+                'gnis:county_name': 'Queens',
+                'gnis:created': '01/23/1980',
+                'gnis:feature_id': '943878',
+                'gnis:feature_type': 'Swamp',
+                'name': 'Big Egg Marsh',
+                'natural': 'wetland',
+                'place': 'island',
+                'source': 'openstreetmap.org',
+                'wetland': 'saltmarsh',
+                'wikidata': 'Q34642571',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 50977027,
+                'kind': 'wetland',
+                'kind_detail': 'saltmarsh',
+            })

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -240,6 +240,15 @@ filters:
     output:
       <<: *output_properties
       kind: fort
+  - filter: {natural: wetland}
+    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
+    output:
+      <<: *output_properties
+      kind: wetland
+      kind_detail:
+        case:
+          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
+            then: {col: wetland}
 
   ############################################################
   # TIER 2 OVERRIDES
@@ -1073,15 +1082,6 @@ filters:
     output:
       <<: *output_properties
       kind: scrub
-  - filter: {natural: wetland}
-    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
-    output:
-      <<: *output_properties
-      kind: wetland
-      kind_detail:
-        case:
-          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
-            then: {col: wetland}
   - filter: {natural: park}
     min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
     output:

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -240,15 +240,6 @@ filters:
     output:
       <<: *output_properties
       kind: fort
-  - filter: {natural: wetland}
-    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
-    output:
-      <<: *output_properties
-      kind: wetland
-      kind_detail:
-        case:
-          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
-            then: {col: wetland}
 
   ############################################################
   # TIER 2 OVERRIDES
@@ -385,6 +376,27 @@ filters:
       <<: *output_properties
       kind: national_park
       tier: 2
+
+  ############################################################
+  # mid-tier 2 overrides
+  #
+  # the boundary=national_park appears to get used for a ton of
+  # stuff that isn't actually a national park, so we match a
+  # few things in advance which seem to be more specific.
+  ############################################################
+  - filter: {natural: wetland}
+    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
+    output:
+      <<: *output_properties
+      kind: wetland
+      kind_detail:
+        case:
+          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
+            then: {col: wetland}
+
+  ############################################################
+  # TIER 2 (continued...)
+  ############################################################
   - filter:
       any:
         leisure: park

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -377,15 +377,6 @@ filters:
     output:
       <<: *output_properties
       kind: observatory
-  - filter: {natural: wetland}
-    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
-    output:
-      <<: *output_properties
-      kind: wetland
-      kind_detail:
-        case:
-          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
-            then: {col: wetland}
 
   ############################################################
   # TIER 2 OVERRIDES
@@ -501,6 +492,27 @@ filters:
       <<: *output_properties
       kind: national_park
       tier: 2
+
+  ############################################################
+  # mid-tier 2 overrides
+  #
+  # the boundary=national_park appears to get used for a ton of
+  # stuff that isn't actually a national park, so we match a
+  # few things in advance which seem to be more specific.
+  ############################################################
+  - filter: {natural: wetland}
+    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
+    output:
+      <<: *output_properties
+      kind: wetland
+      kind_detail:
+        case:
+          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
+            then: {col: wetland}
+
+  ############################################################
+  # TIER 2 (continued...)
+  ############################################################
   - filter:
       any:
         leisure: park

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -377,6 +377,15 @@ filters:
     output:
       <<: *output_properties
       kind: observatory
+  - filter: {natural: wetland}
+    min_zoom: { clamp: { max: 16, min: 9, value: { col: zoom } } }
+    output:
+      <<: *output_properties
+      kind: wetland
+      kind_detail:
+        case:
+          - when: { wetland: [bog, fen, mangrove, marsh, mud, reedbed, saltern, saltmarsh, string_bog, swamp, tidalflat, wet_meadow] }
+            then: {col: wetland}
 
   ############################################################
   # TIER 2 OVERRIDES


### PR DESCRIPTION
Wetland landuse areas already existed, but for many of the examples in #1253 were being overridden by the `boundary=national_park`. I've swapped that around, so that `natural=wetland` matches first (as long as it doesn't have a `protect_class` or `protect_title` that would make us think it's a national park), and added it as a POI type to match.

Connects to #1253.
