### PR TITLE
Add common to POIs YAML from landuse.

### DIFF
--- a/integration-test/1082-common.py
+++ b/integration-test/1082-common.py
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class CommonTest(FixtureTest):
+
+    def test_blithedale_summit_landuse(self):
+        import dsl
+
+        z, x, y = (13, 1307, 3162)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/297452972
+            dsl.way(297452972, dsl.box_area(z, x, y, 4142889), {
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'leisure': 'common',
+                'name': 'Blithedale Summit Open Space Preserve',
+                'operator': 'Marin County Parks',
+                'protect_class': '5',
+                'protection_title': 'Open Space Preserve',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 297452972,
+                'kind': 'common',
+            })
+
+    def test_blithedale_summit_poi(self):
+        import dsl
+
+        z, x, y = (13, 1307, 3162)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/297452972
+            dsl.way(297452972, dsl.box_area(z, x, y, 4142889), {
+                'boundary': 'national_park',
+                'boundary:type': 'protected_area',
+                'leisure': 'common',
+                'name': 'Blithedale Summit Open Space Preserve',
+                'operator': 'Marin County Parks',
+                'protect_class': '5',
+                'protection_title': 'Open Space Preserve',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 297452972,
+                'kind': 'common',
+            })

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -445,6 +445,27 @@ filters:
       tier: 2
 
   ############################################################
+  # TIER 6 OVERRIDES
+  #
+  # These are things which are "more specific" than things in
+  # tier 1, so they should match first.
+  ############################################################
+  # common
+  - filter:
+      boundary:type: protected_area
+      leisure: common
+      protect_class: '5'
+      not:
+        any:
+          - operator: *us_forest_service
+          - operator: *us_parks_service
+    min_zoom: *tier6_min_zoom
+    output:
+      <<: *output_properties
+      kind: common
+      tier: 6
+
+  ############################################################
   # TIER 1
   ############################################################
   - filter:


### PR DESCRIPTION
Looks like we had added an override for `landuse=common` to the landuse YAML, but not replicated that in the POIs YAML, leading to POI with a different `kind` than the polygon. Adding the override in POIs to match landuse seems to have fixed it.

Connects to #1082.
