### PR TITLE
Remap landuse kinds at mid and low zooms.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -665,7 +665,7 @@ At zoom 12 and below, we consolidate some landuse kinds to reduce the amount of 
 
 The current mappings are:
 
-* `allotments` -> `farmland`
+* `allotments` -> `urban_area`
 * `bare_rock` -> `desert`
 * `cemetery` -> `urban_area`
 * `commercial` -> `urban_area`
@@ -686,7 +686,7 @@ The current mappings are:
 * `school` -> `urban_area`
 * `scree` -> `barren`
 * `shingle` -> `barren`
-* `village_green` -> `grassland`
+* `village_green` -> `urban_area`
 * `vineyard` -> `farmland`
 * `wood` -> `forest`
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -493,6 +493,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `attraction`
 * `aviary`
 * `bare_rock`
+* `barren` - Only used at mid and low zooms, see "Low zoom consolidation" below.
 * `battlefield`
 * `beach` - Where the land meets the sea gradually.
 * `boatyard` - a place for building, fixing, and storing boats.
@@ -609,7 +610,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `tower`
 * `trail_riding_station`
 * `university`
-* `urban_area`
+* `urban_area` - Only used at mid and low zooms, see "Low zoom consolidation" below.
 * `urban`
 * `village_green`
 * `vineyard`
@@ -657,6 +658,37 @@ The value of the OpenStreetMap `wetland` tag. If available, value will be one of
 #### Orchard `kind_detail` values
 
 The tree or shrub type. Values are: `agave_plants`, `almond_trees`, `apple_trees`, `avocado_trees`, `banana_plants`, `cherry_trees`, `coconut_palms`, `coffea_plants`, `date_palms`, `hazel_plants`, `hop_plants`, `kiwi_plants`, `macadamia_trees`, `mango_trees`, `oil_palms`, `olive_trees`, `orange_trees`, `papaya_trees`, `peach_trees`, `persimmon_trees`, `pineapple_plants`, `pitaya_plants`, `plum_trees`, `rubber_trees`, `tea_plants`, and `walnut_trees`.
+
+### Low zoom consolidation
+
+At zoom 12 and below, we consolidate some landuse kinds to reduce the amount of superfluous detail and give adjacent landuse areas a better chance to merge together. This merging allows them to form an appropriately-sized polygon for the zoom level, and avoid the "billion colour patchwork" that comes from keeping each distinct feature.
+
+The current mappings are:
+
+* `allotments` -> `farmland`
+* `bare_rock` -> `desert`
+* `cemetery` -> `urban_area`
+* `commercial` -> `urban_area`
+* `farm` -> `farmland`
+* `grass` -> `grassland`
+* `heath` -> `grassland`
+* `industrial` -> `urban_area`
+* `meadow` -> `grassland`
+* `mud` -> `wetland`
+* `natural_wood` -> `forest`
+* `orchard` -> `farmland`
+* `plant_nursery` -> `farmland`
+* `quarry` -> `barren`
+* `recreation_ground` -> `urban_area`
+* `residential` -> `urban_area`
+* `retail` -> `urban_area`
+* `sand` -> `desert`
+* `school` -> `urban_area`
+* `scree` -> `barren`
+* `shingle` -> `barren`
+* `village_green` -> `grassland`
+* `vineyard` -> `farmland`
+* `wood` -> `forest`
 
 
 ## Places

--- a/integration-test/1779-remap-landuse-mid-zoom.py
+++ b/integration-test/1779-remap-landuse-mid-zoom.py
@@ -27,8 +27,8 @@ class LanduseTest(FixtureTest):
     def test_grassland_landuse_grass(self):
         self._check_remap({'landuse': 'grass'}, 'grassland')
 
-    def test_grassland_landuse_village_green(self):
-        self._check_remap({'landuse': 'village_green'}, 'grassland')
+    def test_urban_area_landuse_village_green(self):
+        self._check_remap({'landuse': 'village_green'}, 'urban_area')
 
     def test_grassland_natural_grassland(self):
         self._check_remap({'natural': 'grassland'}, 'grassland')
@@ -51,8 +51,8 @@ class LanduseTest(FixtureTest):
     def test_farmland_landuse_plant_nursery(self):
         self._check_remap({'landuse': 'plant_nursery'}, 'farmland')
 
-    def test_farmland_landuse_allotments(self):
-        self._check_remap({'landuse': 'allotments'}, 'farmland')
+    def test_urban_area_landuse_allotments(self):
+        self._check_remap({'landuse': 'allotments'}, 'urban_area')
 
     def test_scrub_natural_scrub(self):
         self._check_remap({'natural': 'scrub'}, 'scrub')

--- a/integration-test/1779-remap-landuse-mid-zoom.py
+++ b/integration-test/1779-remap-landuse-mid-zoom.py
@@ -1,0 +1,112 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class LanduseTest(FixtureTest):
+
+    def _check_remap(self, tags, remapped_kind):
+        import dsl
+
+        z, x, y = (12, 0, 0)
+
+        all_tags = tags.copy()
+        all_tags['source'] = 'openstreetmap.org'
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), all_tags),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'kind': remapped_kind,
+            })
+
+    def test_grassland_landuse_meadow(self):
+        self._check_remap({'landuse': 'meadow'}, 'grassland')
+
+    def test_grassland_landuse_grass(self):
+        self._check_remap({'landuse': 'grass'}, 'grassland')
+
+    def test_grassland_landuse_village_green(self):
+        self._check_remap({'landuse': 'village_green'}, 'grassland')
+
+    def test_grassland_natural_grassland(self):
+        self._check_remap({'natural': 'grassland'}, 'grassland')
+
+    def test_grassland_natural_heath(self):
+        self._check_remap({'natural': 'heath'}, 'grassland')
+
+    def test_farmland_landuse_farmland(self):
+        self._check_remap({'landuse': 'farmland'}, 'farmland')
+
+    def test_farmland_landuse_orchard(self):
+        self._check_remap({'landuse': 'orchard'}, 'farmland')
+
+    def test_farmland_landuse_vineyard(self):
+        self._check_remap({'landuse': 'vineyard'}, 'farmland')
+
+    def test_farmland_landuse_farm(self):
+        self._check_remap({'landuse': 'farm'}, 'farmland')
+
+    def test_farmland_landuse_plant_nursery(self):
+        self._check_remap({'landuse': 'plant_nursery'}, 'farmland')
+
+    def test_farmland_landuse_allotments(self):
+        self._check_remap({'landuse': 'allotments'}, 'farmland')
+
+    def test_scrub_natural_scrub(self):
+        self._check_remap({'natural': 'scrub'}, 'scrub')
+
+    def test_forest_landuse_forest(self):
+        self._check_remap({'landuse': 'forest'}, 'forest')
+
+    def test_forest_natural_wood(self):
+        self._check_remap({'natural': 'wood'}, 'forest')
+
+    def test_barren_landuse_quarry(self):
+        self._check_remap({'landuse': 'quarry'}, 'barren')
+
+    def test_barren_natural_scree(self):
+        self._check_remap({'natural': 'scree'}, 'barren')
+
+    def test_barren_natural_shingle(self):
+        self._check_remap({'natural': 'shingle'}, 'barren')
+
+    def test_wetland_natural_wetland(self):
+        self._check_remap({'natural': 'wetland'}, 'wetland')
+
+    def test_wetland_natural_mud(self):
+        self._check_remap({'natural': 'mud'}, 'wetland')
+
+    def test_urban_area_landuse_residential(self):
+        self._check_remap({'landuse': 'residential'}, 'urban_area')
+
+    def test_urban_area_landuse_commercial(self):
+        self._check_remap({'landuse': 'commercial'}, 'urban_area')
+
+    def test_urban_area_landuse_retail(self):
+        self._check_remap({'landuse': 'retail'}, 'urban_area')
+
+    def test_urban_area_landuse_industrial(self):
+        self._check_remap({'landuse': 'industrial'}, 'urban_area')
+
+    def test_urban_area_landuse_cemetery(self):
+        self._check_remap({'landuse': 'cemetery'}, 'urban_area')
+
+    def test_urban_area_landuse_recreation_ground(self):
+        self._check_remap({'landuse': 'recreation_ground'}, 'urban_area')
+
+    def test_urban_area_amenity_school(self):
+        self._check_remap({'amenity': 'school'}, 'urban_area')
+
+    def test_glacier_natural_glacier(self):
+        self._check_remap({'natural': 'glacier'}, 'glacier')
+
+    def test_desert_natural_bare_rock(self):
+        self._check_remap({'natural': 'bare_rock'}, 'desert')
+
+    def test_desert_natural_sand(self):
+        self._check_remap({'natural': 'sand'}, 'desert')
+
+    def test_desert_natural_desert(self):
+        self._check_remap({'natural': 'desert'}, 'desert')

--- a/queries.yaml
+++ b/queries.yaml
@@ -335,6 +335,60 @@ post_process:
       start_zoom: 4
       properties: [barrier]
 
+  # coarsen the landuse kinds at mid & low zooms to help improve merging.
+  #
+  # do this _early_; before we assign sort_rank and to avoid inconsistency when
+  # we join (e.g: roads) onto landuse and wouldn't want the road landuse_kind to
+  # be different from the polygon in case that makes it the wrong colour.
+  #
+  # **NOTE** WE'RE CHANGING THE KINDS HERE!
+  - fn: vectordatasource.transform.remap
+    params:
+      layer: landuse
+      start_zoom: 0
+      end_zoom: 13
+      property: kind
+      # note that we don't need to remap things to themselves, e.g:
+      # kind=desert stays as-is.
+      remap:
+        # barren
+        quarry: barren
+        scree: barren
+        shingle: barren
+
+        # desert
+        bare_rock: desert
+        sand: desert
+
+        # farmland
+        allotments: farmland
+        farm: farmland
+        orchard: farmland
+        plant_nursery: farmland
+        vineyard: farmland
+
+        # forest
+        natural_wood: forest
+        wood: forest
+
+        # grassland
+        grass: grassland
+        heath: grassland
+        meadow: grassland
+        village_green: grassland
+
+        # urban_area
+        cemetery: urban_area
+        commercial: urban_area
+        industrial: urban_area
+        recreation_ground: urban_area
+        residential: urban_area
+        retail: urban_area
+        school: urban_area
+
+        # wetland
+        mud: wetland
+
   # sort key
   - fn: vectordatasource.transform.csv_match_properties
     resources:

--- a/queries.yaml
+++ b/queries.yaml
@@ -361,7 +361,6 @@ post_process:
         sand: desert
 
         # farmland
-        allotments: farmland
         farm: farmland
         orchard: farmland
         plant_nursery: farmland
@@ -375,9 +374,9 @@ post_process:
         grass: grassland
         heath: grassland
         meadow: grassland
-        village_green: grassland
 
         # urban_area
+        allotments: urban_area
         cemetery: urban_area
         commercial: urban_area
         industrial: urban_area
@@ -385,6 +384,7 @@ post_process:
         residential: urban_area
         retail: urban_area
         school: urban_area
+        village_green: urban_area
 
         # wetland
         mud: wetland


### PR DESCRIPTION
Remap `kind` of various `landuse` layer features to give better opportunity for mid and low zoom merging.

Many of the kinds specified in #1779 depend on #1781, and will have to be implemented as part of #1781 when it gets done later.

Additionally, `natural=cliff` is in the `earth` layer, not the `landuse` layer. Because it wouldn't be merged anyway, I left it out. I think if we want to move that to the `landuse` layer (which we might if we want to merge with `landuse=quarry`), we probably have to add that to the v2 wishlist?

Connects to #1779.