### PR TITLE
Merge polygons in landuse layer.

### DIFF
--- a/integration-test/1721-reduce-landuse-layer-size.py
+++ b/integration-test/1721-reduce-landuse-layer-size.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class LanduseMergingTest(FixtureTest):
+
+    def test_grass(self):
+        # we'll generate a patchwork of completely contiguous shapes with
+        # varying areas. this is to make sure that different min zooms are
+        # calculated for all of them.
+
+        from shapely.ops import transform
+        from tilequeue.tile import coord_to_mercator_bounds
+        from tilequeue.tile import reproject_mercator_to_lnglat
+        from ModestMaps.Core import Coordinate
+        from shapely.geometry import box
+        import dsl
+
+        z, x, y = (10, 528, 332)
+
+        props = {
+            'source': 'openstreetmap.org',
+            'landuse': 'grass',
+        }
+
+        bounds = coord_to_mercator_bounds(Coordinate(zoom=z, column=x, row=y))
+
+        # define tile-internal coordinate system. note that we're squashing
+        # the features into a smaller square, since we want fairly small
+        # features and don't want to fill the tile with them.
+        ox = 0.5 * (bounds[2] + bounds[0])
+        w = 0.1 * (bounds[2] - bounds[0])
+        oy = 0.5 * (bounds[3] + bounds[1])
+        h = 0.1 * (bounds[3] - bounds[1])
+
+        way_id = 1
+        ways = []
+        splits = 8
+        swidth = 2 ** splits
+
+        for sx in xrange(splits):
+            for sy in xrange(splits):
+                minx = ox + w * (0.5 * float(1 << sx) / swidth)
+                maxx = ox + w * (float(1 << sx) / swidth)
+                miny = oy + h * (0.5 * float(1 << sy) / swidth)
+                maxy = oy + h * (float(1 << sy) / swidth)
+
+                merc_shape = box(minx, miny, maxx, maxy)
+                latlng_shape = transform(
+                    reproject_mercator_to_lnglat, merc_shape)
+
+                ways.append(dsl.way(way_id, latlng_shape, props))
+                way_id += 1
+
+        self.generate_fixtures(*ways)
+
+        with self.features_in_tile_layer(z, x, y, 'landuse') as features:
+            # have to use assertTrue here rather than the more natural
+            # assertEqual so that when this is run as --download-only the test
+            # case class can skip this test.
+            self.assertTrue(len(features) == 1)

--- a/queries.yaml
+++ b/queries.yaml
@@ -1387,7 +1387,7 @@ post_process:
   - fn: vectordatasource.transform.drop_small_inners
     params:
       end_zoom: 14
-      source_layers: [landuse, water]
+      source_layers: [water]
       pixel_area: 0.1
 
   # drop this layer before simplify_and_clip - we don't want it in the output,
@@ -1421,12 +1421,64 @@ post_process:
       where: >-
         landuse_kind in ('residential', 'industrial')
 
-  # merge any remaining polygons by their properties.
+  # drop osm_relation tag, used to indicate that shapes came from OSM relations.
+  # however, it interferes with merging.
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: landuse
+      start_zoom: 4
+      end_zoom: 15
+      properties:
+        - osm_relation
+
+  # drop names on landuse areas at mid and low zooms. it interferes with
+  # merging, and anything that we would have labelled would have become a
+  # label by now anyway (see handle_label_placement around line 716-ish).
+  - fn: vectordatasource.transform.drop_names
+    params:
+      source_layer: landuse
+      start_zoom: 4
+      end_zoom: 13
+
+  # drop small inners before merge, as not having to consider these can speed up
+  # the buffer & clipping algorithms.
+  - fn: vectordatasource.transform.drop_small_inners
+    params:
+      end_zoom: 15
+      source_layers: [landuse]
+      pixel_area: 0.8
+
+  # merge at mid and low zooms, buffering to try and eliminate small gaps
+  # between adjacent polygons.
   - fn: vectordatasource.transform.merge_polygon_features
     params:
       source_layer: landuse
       start_zoom: 4
       end_zoom: 13
+      merge_min_zooms: true
+      buffer_merge: true
+      # this formula seems to give a good balance between larger values, which
+      # merge more but can merge everything into a blob if too large, and small
+      # values which retain detail.
+      buffer_merge_tolerance: >-
+        min(150, 0.6 * tolerance_for_zoom)
+
+  # merge at high-ish zooms without buffering - but we still want to merge
+  # multiple small polygons together to get file size savings.
+  - fn: vectordatasource.transform.merge_polygon_features
+    params:
+      source_layer: landuse
+      start_zoom: 13
+      end_zoom: 15
+      merge_min_zooms: true
+
+  # drop small inners after merge, as small inners could have been introduced
+  # by the merge algorithm.
+  - fn: vectordatasource.transform.drop_small_inners
+    params:
+      end_zoom: 15
+      source_layers: [landuse]
+      pixel_area: 0.8
 
   # first, merge linestrings together where the properties are the same, and
   # make sure we merge across junctions. this will create a set of non-simple

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -971,7 +971,7 @@ class MergeBuildingTest(unittest.TestCase):
 
     def test_merge_buildings(self):
         from shapely.wkb import loads
-        from vectordatasource.transform import _merge_buildings
+        from vectordatasource.transform import _merge_polygons_with_buffer
 
         mp = loads(
             '01060000000200000001030000000100000005000000295C8FC2F57A9040'
@@ -983,7 +983,7 @@ class MergeBuildingTest(unittest.TestCase):
             '8FC2F528439040713D0A070C6B5941'.decode('hex')
         )
         tolerance = 1.9109257071294063
-        result = _merge_buildings(mp, tolerance)
+        result = _merge_polygons_with_buffer(mp, tolerance)
 
         self.assertEquals(len(result), 1)
         self.assertTrue(result[0].is_valid)


### PR DESCRIPTION
This merges polygons in the landuse layer to improve tile size. Two different types of merging are used; at higher zooms we try to merge into as large a multipolygon as possible and at mid and low zooms we also do a dilate/erode step to try and blend together adjacent polygons. This can be extremely effective when merging large polygons separated by small spaces, such as paths within a forest.

For example, tile `9/263/166` near [Groningen, the Netherlands](https://tile.nextzen.org/preview.html#lat=53.2143&lng=5.9917&z=10) originally had a 663kB `landuse` layer, but this reduced to 84kB, a drop of 87%. The total tile size went from 859kB to 280kB, a drop of 67%. Of the remaining size,  155kB is roads.

The vast majority of the features in this tile came from `kind: grass` polygons:

![original grass polygons](https://user-images.githubusercontent.com/271360/51188515-08219f80-18d6-11e9-89bf-a6ebd6925e99.png)

It looks as if each individual field has been mapped as a separate feature (or rather, [imported](https://wiki.openstreetmap.org/wiki/3dShapes)). There are many small gaps between adjacent polygons, often for [small water courses or paths](https://www.openstreetmap.org/way/64306504). This means it's hard enough to merge the geometries - and on top of that, the different sizes of adjacent features means that wildly different `min_zoom` values get set.

Re-using the buffering merge implemented earlier for buildings in #1698 and allowing different `min_zoom`s to be merged together (it's generally purely area-based, unlike buildings), gives:

![merged grass polygons](https://user-images.githubusercontent.com/271360/51189228-816dc200-18d7-11e9-82fb-1625b9877c05.png)

Which still shows a lot of detail in the boundary, but has almost entirely removed small gaps and voids.

The irony is that the `grass` landuse kind doesn't even seem to be rendered by Bubble Wrap at zoom 10, so here's a screenshot of a slightly modified style:

![bubble wrap with extra grass](https://user-images.githubusercontent.com/271360/51189729-87b06e00-18d8-11e9-83dc-7dee096ea0f9.png)

Connects to #1721.
