### PR TITLE
Add collision rank

### DIFF
--- a/integration-test/988-add-collision-rank.py
+++ b/integration-test/988-add-collision-rank.py
@@ -174,6 +174,52 @@ class CollisionRankTest(FixtureTest):
             layer='landuse', kind='grass',
             rank=2866)
 
+    def test_non_maritime_boundary(self):
+        import dsl
+
+        z, x, y = (8, 44, 88)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'source': 'tilezen.org',
+                'maritime_boundary': True,
+                'min_zoom': 0,
+                'kind': 'maritime',
+            }),
+            dsl.way(2, dsl.tile_diagonal(z, x, y), {
+                'source': 'openstreetmap.org',
+                'boundary': 'administrative',
+                'admin_level': '2',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'country',
+                'maritime_boundary': type(None),
+                'collision_rank': 772,
+            })
+
+    def test_maritime_boundary(self):
+        import dsl
+
+        z, x, y = (8, 44, 88)
+
+        self.generate_fixtures(
+            dsl.way(2, dsl.tile_diagonal(z, x, y), {
+                'source': 'openstreetmap.org',
+                'boundary': 'administrative',
+                'admin_level': '2',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'country',
+                'maritime_boundary': True,
+                'collision_rank': 2340,
+            })
+
 
 # helper class to make it easier to write CollisionOrderTest.
 #

--- a/integration-test/988-add-collision-rank.py
+++ b/integration-test/988-add-collision-rank.py
@@ -96,7 +96,7 @@ class CollisionRankTest(FixtureTest):
             {'railway': 'station'},
             geom_type='polygon',
             layer='transit', kind='station',
-            rank=3735)
+            rank=3712)
 
     def test_pois_aviary(self):
         self._check_rank(
@@ -108,7 +108,7 @@ class CollisionRankTest(FixtureTest):
         self._check_rank(
             {'office': 'travel_agent'},
             layer='pois', kind='travel_agent',
-            rank=3733)
+            rank=3710)
 
     def test_pois_aerodrome(self):
         self._check_rank(
@@ -147,13 +147,13 @@ class CollisionRankTest(FixtureTest):
         self._check_rank(
             {'shop': 'tobacco'},
             layer='pois', kind='tobacco',
-            rank=3731)
+            rank=3708)
 
     def test_pois_healthcare_centre(self):
         self._check_rank(
             {'healthcare': 'centre'},
             layer='pois', kind='healthcare_centre',
-            rank=3411)
+            rank=3410)
 
     def test_pois_generator(self):
         self._check_rank(
@@ -165,7 +165,7 @@ class CollisionRankTest(FixtureTest):
         self._check_rank(
             {'amenity': 'post_box'},
             layer='pois', kind='post_box',
-            rank=4308)
+            rank=4283)
 
     def test_landuse_grass(self):
         self._check_rank(

--- a/integration-test/988-add-collision-rank.py
+++ b/integration-test/988-add-collision-rank.py
@@ -226,6 +226,18 @@ class ItemList(object):
                     assert fid not in items
                     items[fid] = rank
 
+        self.test_instance.assertTrue(items, msg="Expected some items, but "
+                                      "received an empty tile.")
+        # note that we only get inside this "if" statement if we're in
+        # "download only" mode, as it short-circuits the assertions.
+        # otherwise a genuinely empty tile would have triggered the assertion
+        # already.
+        #
+        # i'm really looking forward to the day when we remove all
+        # non-generative fixtures, and we can remove this hack too!
+        if not items:
+            return
+
         rank = 0
         for item_fid in order:
             self.test_instance.assertTrue(

--- a/integration-test/988-add-collision-rank.py
+++ b/integration-test/988-add-collision-rank.py
@@ -46,133 +46,133 @@ class CollisionRankTest(FixtureTest):
         self._check_rank(
             {'place': 'continent'},
             zoom=1, layer='earth',
-            kind='continent', rank=303)
+            kind='continent', rank=300)
 
     def test_transit_subway(self):
         self._check_rank(
             {'route': 'subway'},
             geom_type='line',
             layer='transit',
-            kind='subway', rank=768)
+            kind='subway', rank=730)
 
     def test_pois_swimming_area(self):
         self._check_rank(
             {'leisure': 'swimming_area'},
             layer='pois',
-            kind='swimming_area', rank=3174)
+            kind='swimming_area', rank=3064)
 
     def test_pois_battlefield(self):
         self._check_rank(
             {'historic': 'battlefield'},
             layer='pois',
-            kind='battlefield', rank=529)
+            kind='battlefield', rank=511)
 
     def test_pois_picnic_site(self):
         self._check_rank(
             {'tourism': 'picnic_site'},
             layer='pois', kind='picnic_site',
-            rank=3172)
+            rank=3062)
 
     def test_water_ocean(self):
         self._check_rank(
             {'place': 'ocean'},
             layer='water', kind='ocean',
-            rank=304)
+            rank=301)
 
     def test_pois_doityourself(self):
         self._check_rank(
             {'shop': 'doityourself'},
             layer='pois', kind='doityourself',
-            rank=1088)
+            rank=1038)
 
     def test_pois_shelter(self):
         self._check_rank(
             {'amenity': 'shelter'},
             layer='pois', kind='shelter',
-            rank=3199)
+            rank=3088)
 
     def test_transit_station(self):
         self._check_rank(
             {'railway': 'station'},
             geom_type='polygon',
             layer='transit', kind='station',
-            rank=3869)
+            rank=3735)
 
     def test_pois_aviary(self):
         self._check_rank(
             {'zoo': 'aviary'},
             layer='pois', kind='aviary',
-            rank=3389)
+            rank=3274)
 
     def test_pois_travel_agent(self):
         self._check_rank(
             {'office': 'travel_agent'},
             layer='pois', kind='travel_agent',
-            rank=3867)
+            rank=3733)
 
     def test_pois_aerodrome(self):
         self._check_rank(
             {'aeroway': 'aerodrome'},
             layer='pois', kind='aerodrome',
-            rank=472)
+            rank=458)
 
     def test_pois_caravan_site(self):
         self._check_rank(
             {'tourism': 'caravan_site'},
             layer='pois', kind='caravan_site',
-            rank=1273)
+            rank=1218)
 
     def test_water_riverbank(self):
         self._check_rank(
             {'waterway': 'riverbank'},
             geom_type='line',
             layer='water', kind='riverbank',
-            rank=2415)
+            rank=2337)
 
     def test_pois_wood(self):
         self._check_rank(
             {'landuse': 'wood'},
             geom_type='polygon',
             layer='pois', kind='wood',
-            rank=479)
+            rank=465)
 
     def test_landuse_industrial(self):
         self._check_rank(
             {'landuse': 'industrial'},
             geom_type='polygon',
             layer='landuse', kind='industrial',
-            rank=2916)
+            rank=2814)
 
     def test_pois_tobacco(self):
         self._check_rank(
             {'shop': 'tobacco'},
             layer='pois', kind='tobacco',
-            rank=3865)
+            rank=3731)
 
     def test_pois_healthcare_centre(self):
         self._check_rank(
             {'healthcare': 'centre'},
             layer='pois', kind='healthcare_centre',
-            rank=3531)
+            rank=3411)
 
     def test_pois_generator(self):
         self._check_rank(
             {'power': 'generator'},
             layer='pois', kind='generator',
-            rank=2767)
+            rank=2668)
 
     def test_pois_post_box(self):
         self._check_rank(
             {'amenity': 'post_box'},
             layer='pois', kind='post_box',
-            rank=4453)
+            rank=4307)
 
     def test_landuse_grass(self):
         self._check_rank(
             {'landuse': 'grass'},
             geom_type='polygon',
             layer='landuse', kind='grass',
-            rank=2972)
+            rank=2866)
 
 
 # helper class to make it easier to write CollisionOrderTest.

--- a/integration-test/988-add-collision-rank.py
+++ b/integration-test/988-add-collision-rank.py
@@ -1,0 +1,259 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+# test that features get assigned the correct collision rank.
+#
+# note that the collision rank system has been designed to make changing ranks
+# and re-arranging / re-ordering very easy. in turn, this might make these
+# tests very fragile because they check the exact number which is assigned as
+# the rank.
+#
+# if updating these after every change becomes onerous, consider only testing
+# important salient values (e.g: the first ones after an important reserved
+# block) and switching the other tests to relative, as in CollisionOrderTest
+#
+class CollisionRankTest(FixtureTest):
+
+    def _check_rank(self, tags, zoom=16, source='openstreetmap.org',
+                    layer='pois', kind=None, rank=None, geom_type='point'):
+        import dsl
+
+        z, x, y = (zoom, 0, 0)
+
+        all_tags = tags.copy()
+        all_tags['source'] = source
+        if 'name' not in all_tags:
+            all_tags['name'] = 'Some name'
+
+        assert geom_type in ('point', 'line', 'polygon')
+        if geom_type == 'point':
+            shape = dsl.tile_centre_shape(z, x, y)
+        elif geom_type == 'line':
+            shape = dsl.tile_diagonal(z, x, y)
+        elif geom_type == 'polygon':
+            shape = dsl.tile_box(z, x, y)
+
+        self.generate_fixtures(dsl.way(1, shape, all_tags))
+
+        self.assert_has_feature(
+            z, x, y, layer, {
+                'kind': kind,
+                'collision_rank': rank,
+            })
+
+    def test_continent(self):
+        self._check_rank(
+            {'place': 'continent'},
+            zoom=1, layer='earth',
+            kind='continent', rank=303)
+
+    def test_transit_subway(self):
+        self._check_rank(
+            {'route': 'subway'},
+            geom_type='line',
+            layer='transit',
+            kind='subway', rank=768)
+
+    def test_pois_swimming_area(self):
+        self._check_rank(
+            {'leisure': 'swimming_area'},
+            layer='pois',
+            kind='swimming_area', rank=3174)
+
+    def test_pois_battlefield(self):
+        self._check_rank(
+            {'historic': 'battlefield'},
+            layer='pois',
+            kind='battlefield', rank=529)
+
+    def test_pois_picnic_site(self):
+        self._check_rank(
+            {'tourism': 'picnic_site'},
+            layer='pois', kind='picnic_site',
+            rank=3172)
+
+    def test_water_ocean(self):
+        self._check_rank(
+            {'place': 'ocean'},
+            layer='water', kind='ocean',
+            rank=304)
+
+    def test_pois_doityourself(self):
+        self._check_rank(
+            {'shop': 'doityourself'},
+            layer='pois', kind='doityourself',
+            rank=1088)
+
+    def test_pois_shelter(self):
+        self._check_rank(
+            {'amenity': 'shelter'},
+            layer='pois', kind='shelter',
+            rank=3199)
+
+    def test_transit_station(self):
+        self._check_rank(
+            {'railway': 'station'},
+            geom_type='polygon',
+            layer='transit', kind='station',
+            rank=3869)
+
+    def test_pois_aviary(self):
+        self._check_rank(
+            {'zoo': 'aviary'},
+            layer='pois', kind='aviary',
+            rank=3389)
+
+    def test_pois_travel_agent(self):
+        self._check_rank(
+            {'office': 'travel_agent'},
+            layer='pois', kind='travel_agent',
+            rank=3867)
+
+    def test_pois_aerodrome(self):
+        self._check_rank(
+            {'aeroway': 'aerodrome'},
+            layer='pois', kind='aerodrome',
+            rank=472)
+
+    def test_pois_caravan_site(self):
+        self._check_rank(
+            {'tourism': 'caravan_site'},
+            layer='pois', kind='caravan_site',
+            rank=1273)
+
+    def test_water_riverbank(self):
+        self._check_rank(
+            {'waterway': 'riverbank'},
+            geom_type='line',
+            layer='water', kind='riverbank',
+            rank=2415)
+
+    def test_pois_wood(self):
+        self._check_rank(
+            {'landuse': 'wood'},
+            geom_type='polygon',
+            layer='pois', kind='wood',
+            rank=479)
+
+    def test_landuse_industrial(self):
+        self._check_rank(
+            {'landuse': 'industrial'},
+            geom_type='polygon',
+            layer='landuse', kind='industrial',
+            rank=2916)
+
+    def test_pois_tobacco(self):
+        self._check_rank(
+            {'shop': 'tobacco'},
+            layer='pois', kind='tobacco',
+            rank=3865)
+
+    def test_pois_healthcare_centre(self):
+        self._check_rank(
+            {'healthcare': 'centre'},
+            layer='pois', kind='healthcare_centre',
+            rank=3531)
+
+    def test_pois_generator(self):
+        self._check_rank(
+            {'power': 'generator'},
+            layer='pois', kind='generator',
+            rank=2767)
+
+    def test_pois_post_box(self):
+        self._check_rank(
+            {'amenity': 'post_box'},
+            layer='pois', kind='post_box',
+            rank=4453)
+
+    def test_landuse_grass(self):
+        self._check_rank(
+            {'landuse': 'grass'},
+            geom_type='polygon',
+            layer='landuse', kind='grass',
+            rank=2972)
+
+
+# helper class to make it easier to write CollisionOrderTest.
+#
+# creates items, identified by their unique ID, and makes a tile based on them.
+# the tile is then checked to make sure the collision_rank assigned each
+# feature is the same as the order of IDs passed in from the test.
+class ItemList(object):
+
+    def __init__(self, test_instance, zoom=16, x=0, y=0):
+        self.test_instance = test_instance
+        self.items = []
+        self.id_counter = 1
+        self.z = zoom
+        self.x = x
+        self.y = y
+
+    def append(self, tags={}, source='openstreetmap.org', layer='pois',
+               geom_type='point'):
+        import dsl
+
+        all_tags = tags.copy()
+        all_tags['source'] = source
+        if 'name' not in all_tags:
+            all_tags['name'] = 'Some name'
+
+        assert geom_type in ('point', 'line', 'polygon')
+        if geom_type == 'point':
+            shape = dsl.tile_centre_shape(self.z, self.x, self.y)
+        elif geom_type == 'line':
+            shape = dsl.tile_diagonal(self.z, self.x, self.y)
+        elif geom_type == 'polygon':
+            shape = dsl.tile_box(self.z, self.x, self.y)
+
+        item_fid = self.id_counter
+        self.id_counter += 1
+
+        self.items.append(dsl.way(item_fid, shape, all_tags))
+        return item_fid
+
+    def assert_order(self, order):
+        self.test_instance.generate_fixtures(*self.items)
+
+        items = {}
+
+        with self.test_instance.tile(self.z, self.x, self.y) as layers:
+            for layer_name, features in layers.iteritems():
+                for feature in features:
+                    fid = feature['properties']['id']
+                    rank = feature['properties']['collision_rank']
+                    assert fid not in items
+                    items[fid] = rank
+
+        rank = 0
+        for item_fid in order:
+            self.test_instance.assertTrue(
+                item_fid in items, msg="Item %d missing from items seen in "
+                "tile (%r), perhaps it wasn't correctly matched?"
+                % (item_fid, items.keys()))
+            item_rank = items[item_fid]
+            self.test_instance.assertTrue(
+                item_rank > rank, msg="Item ranks lower than previous items "
+                "in the list. (%d <= %d)" % (item_rank, rank))
+            rank = item_rank
+
+
+# a more robust way to do the tests: rather than check the exact value of the
+# collision_rank, we can check that one kind has a rank value more or less than
+# another. this is closer to a long term meaning of collision priority; that
+# some features should be displayed in preference to others.
+#
+class CollisionOrderTest(FixtureTest):
+
+    # example of a more robust test: it doesn't matter exactly what the
+    # collision_rank of fuel or police is, what matters is that fuel's rank
+    # is less than police's.
+    def test_fuel_before_police(self):
+        items = ItemList(self)
+
+        # set up all the test items
+        police = items.append(tags={'amenity': 'police'})
+        fuel = items.append(tags={'amenity': 'fuel'})
+
+        items.assert_order([fuel, police])

--- a/integration-test/988-add-collision-rank.py
+++ b/integration-test/988-add-collision-rank.py
@@ -165,7 +165,7 @@ class CollisionRankTest(FixtureTest):
         self._check_rank(
             {'amenity': 'post_box'},
             layer='pois', kind='post_box',
-            rank=4307)
+            rank=4308)
 
     def test_landuse_grass(self):
         self._check_rank(

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -1265,8 +1265,11 @@ def expand_bbox(bounds, padding):
 
 class EmptyContext(object):
 
+    def __init__(self, factory=list):
+        self.factory = factory
+
     def __enter__(self):
-        return []
+        return self.factory()
 
     def __exit__(self, type, value, traceback):
         pass
@@ -1388,7 +1391,7 @@ class DownloadOnlyInstance(object):
         return EmptyContext()
 
     def tile(self, z, x, y):
-        return EmptyContext()
+        return EmptyContext(dict)
 
     def features_in_mvt_layer(self, z, x, y, layer):
         return EmptyContext()
@@ -1443,7 +1446,7 @@ class CollectTilesInstance(object):
 
     def tile(self, z, x, y):
         self._add_tile(z, x, y)
-        return EmptyContext()
+        return EmptyContext(dict)
 
     def features_in_mvt_layer(self, z, x, y, layer):
         self._add_tile(z, x, y)

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -1088,6 +1088,12 @@ class FixtureFeatureFetcher(object):
             yield tile_layers.keys()
         return inner(z, x, y)
 
+    def tile(self, z, x, y):
+        @contextmanager
+        def inner(z, x, y):
+            yield self._generate_tile(z, x, y)
+        return inner(z, x, y)
+
     def features_in_mvt_layer(self, z, x, y, layer):
         @contextmanager
         def inner(z, x, y, layer):
@@ -1330,6 +1336,9 @@ class RunTestInstance(object):
     def layers_in_tile(self, z, x, y):
         return self.assertions.ff.layers_in_tile(z, x, y)
 
+    def tile(self, z, x, y):
+        return self.assertions.ff.tile(z, x, y)
+
     def features_in_mvt_layer(self, z, x, y, layer):
         return self.assertions.ff.features_in_mvt_layer(z, x, y, layer)
 
@@ -1376,6 +1385,9 @@ class DownloadOnlyInstance(object):
         return EmptyContext()
 
     def layers_in_tile(self, z, x, y):
+        return EmptyContext()
+
+    def tile(self, z, x, y):
         return EmptyContext()
 
     def features_in_mvt_layer(self, z, x, y, layer):
@@ -1426,6 +1438,10 @@ class CollectTilesInstance(object):
         return EmptyContext()
 
     def layers_in_tile(self, z, x, y):
+        self._add_tile(z, x, y)
+        return EmptyContext()
+
+    def tile(self, z, x, y):
         self._add_tile(z, x, y)
         return EmptyContext()
 
@@ -1485,6 +1501,9 @@ class FixtureTest(unittest.TestCase):
 
     def layers_in_tile(self, z, x, y):
         return self.test_instance.layers_in_tile(z, x, y)
+
+    def tile(self, z, x, y):
+        return self.test_instance.tile(z, x, y)
 
     def features_in_mvt_layer(self, z, x, y, layer):
         return self.test_instance.features_in_mvt_layer(z, x, y, layer)

--- a/queries.yaml
+++ b/queries.yaml
@@ -1595,6 +1595,15 @@ post_process:
 
   # collision rank
   - fn: vectordatasource.transform.add_collision_rank
+    params:
+      where: >-
+        layer_name == 'pois' or
+        _has_name or
+        ref is not None or
+        shield_text is not None or
+        bicycle_shield_text is not None or
+        bus_shield_text is not None or
+        walking_shield_text is not None
     resources:
       ranker:
         type: file

--- a/queries.yaml
+++ b/queries.yaml
@@ -1592,3 +1592,11 @@ post_process:
   - fn: vectordatasource.transform.max_zoom_filter
     params:
       layers: [places]
+
+  # collision rank
+  - fn: vectordatasource.transform.add_collision_rank
+    resources:
+      ranker:
+        type: file
+        init_fn: vectordatasource.transform.load_collision_ranker
+        path: spreadsheets/collision_rank.yaml

--- a/spreadsheets/collision_rank.yaml
+++ b/spreadsheets/collision_rank.yaml
@@ -1,6 +1,943 @@
-- layer: earth
-  kind: continent
-- layer: water
-  kind: ocean
-- layer: places
-  kind: country
+# reserved for UX/UI
+- _reserved: {from: 1, to: 100}
+# reserved for house theme overlays
+- _reserved: {from: 101, to: 201}
+# reserved for data overlays
+- _reserved: {from: 202, to: 302}
+- {layer: 'earth', kind: 'continent'}
+- {layer: 'water', kind: 'ocean'}
+- {layer: 'places', kind: 'country'}
+# reserved for population_rank
+- _reserved: {from: 306, to: 325}
+- {layer: 'places', kind: 'locality'}
+# reserved for population_rank; guess the pop from kind_detail ala
+# _default_min_zoom_for_place_kind() : city, farm, hamlet, isolated_dwelling,
+# locality, scientific_station, town, village,
+- _reserved: {from: 327, to: 346}
+- {layer: 'pois', kind: 'national_park'}
+- {layer: 'places', kind: 'region'}
+# reserved for population_rank
+- _reserved: {from: 349, to: 368}
+- {layer: 'water', kind: 'sea'}
+- {layer: 'pois', kind: 'nature_reserve'}
+- {layer: 'water', kind: 'lake'}
+# for shields & etc
+- _reserved: {from: 372, to: 382}
+- {layer: 'roads', kind: 'highway', kind_detail: 'motorway'}
+# for shields & etc
+- _reserved: {from: 384, to: 394}
+# for shields & etc
+- _reserved: {from: 395, to: 405}
+- {layer: 'roads', kind: 'highway', kind_detail: 'motorway_link'}
+# for shields & etc
+- _reserved: {from: 407, to: 417}
+# for shields & etc
+- _reserved: {from: 418, to: 428}
+- {layer: 'roads', kind: 'highway', kind_detail: 'trunk'}
+# for shields & etc
+- _reserved: {from: 430, to: 440}
+# for shields & etc
+- _reserved: {from: 441, to: 451}
+- {layer: 'roads', kind: 'highway'}
+# for shields & etc
+- _reserved: {from: 453, to: 463}
+- {layer: 'pois', kind: 'forest'}
+- {layer: 'earth', kind: 'island'}
+- {layer: 'water', kind: 'water'}
+- {layer: 'pois', kind: 'protected_area'}
+- {layer: 'water', kind: 'bay'}
+- {layer: 'water', kind: 'fjord'}
+- {layer: 'water', kind: 'strait'}
+- {layer: 'water', kind: 'playa'}
+- {layer: 'pois', kind: 'aerodrome'}
+- {layer: 'pois', kind: 'military'}
+- {layer: 'pois', kind: 'naval_base'}
+- {layer: 'pois', kind: 'airport'}
+- {layer: 'pois', kind: 'airfield'}
+- {layer: 'pois', kind: 'park'}
+- {layer: 'pois', kind: 'volcano'}
+- {layer: 'pois', kind: 'wood'}
+# reserve for kind_details
+- _reserved: {from: 480, to: 490}
+- {layer: 'pois', kind: 'peak'}
+- {layer: 'water', kind: 'river'}
+# for shields & etc
+- _reserved: {from: 493, to: 503}
+- {layer: 'transit', kind: 'train'}
+# for shields & etc
+- _reserved: {from: 505, to: 515}
+- {layer: 'pois', kind: 'beach'}
+# reserve for kind_details
+- _reserved: {from: 517, to: 527}
+- {layer: 'pois', kind: 'university'}
+- {layer: 'pois', kind: 'battlefield'}
+# for shields & etc
+- _reserved: {from: 530, to: 540}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'primary'}
+# for shields & etc
+- _reserved: {from: 542, to: 552}
+# for shields & etc
+- _reserved: {from: 553, to: 563}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'primary_link'}
+# for shields & etc
+- _reserved: {from: 565, to: 575}
+# for shields & etc
+- _reserved: {from: 576, to: 586}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'secondary'}
+# for shields & etc
+- _reserved: {from: 588, to: 598}
+# for shields & etc
+- _reserved: {from: 599, to: 609}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'secondary_link'}
+# for shields & etc
+- _reserved: {from: 611, to: 621}
+# for shields & etc
+- _reserved: {from: 622, to: 632}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'tertiary'}
+# for shields & etc
+- _reserved: {from: 634, to: 644}
+# for shields & etc
+- _reserved: {from: 645, to: 655}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'tertiary_link'}
+# for shields & etc
+- _reserved: {from: 657, to: 667}
+# for shields & etc
+- _reserved: {from: 668, to: 678}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'trunk'}
+# for shields & etc
+- _reserved: {from: 680, to: 690}
+# for shields & etc
+- _reserved: {from: 691, to: 701}
+- {layer: 'roads', kind: 'major_road', kind_detail: 'trunk_link'}
+# for shields & etc
+- _reserved: {from: 703, to: 713}
+# for shields & etc
+- _reserved: {from: 714, to: 724}
+- {layer: 'roads', kind: 'major_road'}
+# for shields & etc
+- _reserved: {from: 726, to: 736}
+- {layer: 'water', kind: 'reef'}
+# reserve for kind_details
+- _reserved: {from: 738, to: 748}
+- {layer: 'water', kind: 'canal'}
+- {layer: 'earth', kind: 'archipelago'}
+- {layer: 'pois', kind: 'ferry_terminal'}
+- {layer: 'pois', kind: 'rest_area'}
+- {layer: 'pois', kind: 'service_area'}
+- {layer: 'pois', kind: 'stadium'}
+- {layer: 'pois', kind: 'station'}
+- {layer: 'pois', kind: 'zoo'}
+# for shields & etc
+- _reserved: {from: 757, to: 767}
+- {layer: 'transit', kind: 'subway'}
+# for shields & etc
+- _reserved: {from: 769, to: 779}
+- {layer: 'boundaries', kind: 'aboriginal_lands'}
+# reserve for kind_details
+- _reserved: {from: 781, to: 801}
+- {layer: 'boundaries', kind: 'county'}
+- {layer: 'boundaries', kind: 'region'}
+- {layer: 'boundaries', kind: 'macroregion'}
+- {layer: 'boundaries', kind: 'map_unit'}
+- {layer: 'boundaries', kind: 'indefinite'}
+- {layer: 'boundaries', kind: 'indeterminate'}
+- {layer: 'boundaries', kind: 'lease_limit'}
+- {layer: 'boundaries', kind: 'overlay_limit'}
+- {layer: 'boundaries', kind: 'line_of_control'}
+- {layer: 'boundaries', kind: 'disputed'}
+- {layer: 'boundaries', kind: 'country'}
+- {layer: 'pois', kind: 'college'}
+- {layer: 'pois', kind: 'hospital'}
+# reserve for kind_details
+- _reserved: {from: 815, to: 835}
+- {layer: 'pois', kind: 'landmark'}
+- {layer: 'pois', kind: 'mall'}
+- {layer: 'pois', kind: 'museum'}
+- {layer: 'pois', kind: 'winter_sports'}
+- {layer: 'pois', kind: 'casino'}
+- {layer: 'pois', kind: 'golf_course'}
+- {layer: 'pois', kind: 'marina'}
+- {layer: 'pois', kind: 'sports_centre'}
+- {layer: 'pois', kind: 'garden'}
+- {layer: 'pois', kind: 'recreation_ground'}
+- {layer: 'pois', kind: 'waterfall'}
+# for shields & etc
+- _reserved: {from: 847, to: 857}
+- {layer: 'roads', kind: 'ferry'}
+# for shields & etc
+- _reserved: {from: 859, to: 869}
+# for shields & etc
+- _reserved: {from: 870, to: 880}
+- {layer: 'transit', kind: 'light_rail'}
+# for shields & etc
+- _reserved: {from: 882, to: 892}
+- {layer: 'pois', kind: 'townhall'}
+# for shields & etc
+- _reserved: {from: 894, to: 904}
+- {layer: 'transit', kind: 'tram'}
+# for shields & etc
+- _reserved: {from: 906, to: 916}
+- {layer: 'pois', kind: 'cemetery'}
+# reserve for kind_details
+- _reserved: {from: 918, to: 968}
+- {layer: 'pois', kind: 'dam'}
+- {layer: 'pois', kind: 'motorway_junction'}
+- {layer: 'pois', kind: 'place_of_worship'}
+- {layer: 'pois', kind: 'plant'}
+- {layer: 'pois', kind: 'port_terminal'}
+- {layer: 'pois', kind: 'quarry'}
+- {layer: 'pois', kind: 'wastewater_plant'}
+- {layer: 'pois', kind: 'water_works'}
+- {layer: 'pois', kind: 'works'}
+- {layer: 'places', kind: 'borough'}
+# for shields, kind_detail & etc
+- _reserved: {from: 979, to: 1029}
+- {layer: 'roads', kind: 'path'}
+# for shields, kind_detail & etc
+- _reserved: {from: 1031, to: 1081}
+- {layer: 'pois', kind: 'camp_site'}
+- {layer: 'pois', kind: 'chemist'}
+- {layer: 'pois', kind: 'community_centre'}
+- {layer: 'pois', kind: 'cosmetics'}
+- {layer: 'pois', kind: 'danger_area'}
+- {layer: 'pois', kind: 'department_store'}
+- {layer: 'pois', kind: 'doityourself'}
+- {layer: 'pois', kind: 'fort'}
+- {layer: 'pois', kind: 'garden_centre'}
+- {layer: 'pois', kind: 'golf'}
+- {layer: 'pois', kind: 'grave_yard'}
+# reserve for kind_details
+- _reserved: {from: 1093, to: 1143}
+- {layer: 'pois', kind: 'hotel'}
+- {layer: 'pois', kind: 'marketplace'}
+- {layer: 'pois', kind: 'motel'}
+- {layer: 'pois', kind: 'music'}
+- {layer: 'pois', kind: 'pet'}
+- {layer: 'pois', kind: 'pharmacy'}
+# reserve for kind_details
+- _reserved: {from: 1150, to: 1170}
+- {layer: 'pois', kind: 'range'}
+- {layer: 'pois', kind: 'school'}
+- {layer: 'pois', kind: 'shoes'}
+- {layer: 'pois', kind: 'ski'}
+- {layer: 'pois', kind: 'supermarket'}
+- {layer: 'pois', kind: 'theme_park'}
+- {layer: 'pois', kind: 'toys'}
+- {layer: 'pois', kind: 'variety_store'}
+- {layer: 'pois', kind: 'water_park'}
+- {layer: 'pois', kind: 'winery'}
+- {layer: 'pois', kind: 'alcohol'}
+- {layer: 'pois', kind: 'alpine_hut'}
+- {layer: 'pois', kind: 'brewery'}
+- {layer: 'pois', kind: 'charity'}
+- {layer: 'pois', kind: 'coffee'}
+- {layer: 'pois', kind: 'confectionery'}
+- {layer: 'pois', kind: 'deli'}
+- {layer: 'pois', kind: 'electronics'}
+- {layer: 'pois', kind: 'furniture'}
+- {layer: 'pois', kind: 'hardware'}
+- {layer: 'pois', kind: 'ice_cream'}
+- {layer: 'pois', kind: 'kindergarten'}
+- {layer: 'pois', kind: 'wine'}
+- {layer: 'pois', kind: 'gardener'}
+- {layer: 'pois', kind: 'sports'}
+- {layer: 'earth', kind: 'valley'}
+- {layer: 'boundaries', kind: 'locality'}
+- {layer: 'pois', kind: 'handicraft'}
+- {layer: 'pois', kind: 'ski_school'}
+- {layer: 'pois', kind: 'veterinary'}
+# reserve for kind_details
+- _reserved: {from: 1201, to: 1221}
+# for shields & etc
+- _reserved: {from: 1222, to: 1232}
+- {layer: 'roads', kind: 'portage_way'}
+# for shields & etc
+- _reserved: {from: 1234, to: 1244}
+- {layer: 'pois', kind: 'dressmaker'}
+- {layer: 'pois', kind: 'dry_cleaning'}
+- {layer: 'pois', kind: 'fishmonger'}
+- {layer: 'pois', kind: 'laundry'}
+- {layer: 'pois', kind: 'prison'}
+- {layer: 'water', kind: 'dock'}
+- {layer: 'pois', kind: 'container_terminal'}
+- {layer: 'pois', kind: 'electrician'}
+- {layer: 'pois', kind: 'hvac'}
+- {layer: 'pois', kind: 'metal_construction'}
+- {layer: 'pois', kind: 'offshore_platform'}
+- {layer: 'pois', kind: 'painter'}
+- {layer: 'pois', kind: 'photographer'}
+- {layer: 'pois', kind: 'photographic_laboratory'}
+- {layer: 'pois', kind: 'plumber'}
+- {layer: 'pois', kind: 'pottery'}
+- {layer: 'pois', kind: 'sawmill'}
+- {layer: 'pois', kind: 'shoemaker'}
+- {layer: 'pois', kind: 'ski_rental'}
+- {layer: 'pois', kind: 'stonemason'}
+- {layer: 'pois', kind: 'tailor'}
+- {layer: 'pois', kind: 'trade'}
+- {layer: 'pois', kind: 'waterway_fuel'}
+- {layer: 'pois', kind: 'carpenter'}
+- {layer: 'places', kind: 'macrohood'}
+- {layer: 'pois', kind: 'aquarium'}
+- {layer: 'pois', kind: 'bank'}
+- {layer: 'pois', kind: 'beach_resort'}
+- {layer: 'pois', kind: 'caravan_site'}
+- {layer: 'pois', kind: 'cinema'}
+- {layer: 'pois', kind: 'fuel'}
+- {layer: 'pois', kind: 'library'}
+- {layer: 'pois', kind: 'resort'}
+- {layer: 'pois', kind: 'summer_camp'}
+- {layer: 'landuse', kind: 'ferry_terminal'}
+- {layer: 'landuse', kind: 'aerodrome'}
+- {layer: 'pois', kind: 'fire_station'}
+- {layer: 'pois', kind: 'ranger_station'}
+- {layer: 'pois', kind: 'fitness'}
+- {layer: 'pois', kind: 'embassy'}
+- {layer: 'water', kind: 'basin'}
+- {layer: 'water', kind: 'stream'}
+# for shields & etc
+- _reserved: {from: 1287, to: 1337}
+- {layer: 'roads', kind: 'piste'}
+# for shields & etc
+- _reserved: {from: 1339, to: 1389}
+# for shields, kind_detail & etc
+- _reserved: {from: 1390, to: 1440}
+- {layer: 'roads', kind: 'aerialway'}
+# for shields, kind_detail & etc
+- _reserved: {from: 1442, to: 1492}
+# for shields & etc
+- _reserved: {from: 1493, to: 1503}
+- {layer: 'roads', kind: 'aeroway', kind_detail: 'runway'}
+# for shields & etc
+- _reserved: {from: 1505, to: 1515}
+# for shields & etc
+- _reserved: {from: 1516, to: 1526}
+- {layer: 'roads', kind: 'aeroway', kind_detail: 'taxiway'}
+# for shields & etc
+- _reserved: {from: 1528, to: 1538}
+# for shields & etc
+- _reserved: {from: 1539, to: 1549}
+- {layer: 'roads', kind: 'aeroway'}
+# for shields & etc
+- _reserved: {from: 1551, to: 1561}
+- {layer: 'pois', kind: 'courthouse'}
+- {layer: 'pois', kind: 'lighthouse'}
+- {layer: 'pois', kind: 'obelisk'}
+# reserve for kind_details
+- _reserved: {from: 1565, to: 1575}
+- {layer: 'pois', kind: 'police'}
+- {layer: 'pois', kind: 'post_office'}
+- {layer: 'pois', kind: 'ruins'}
+# reserve for kind_details
+- _reserved: {from: 1579, to: 1589}
+- {layer: 'pois', kind: 'watermill'}
+- {layer: 'pois', kind: 'windmill'}
+- {layer: 'places', kind: 'neighbourhood'}
+- {layer: 'pois', kind: 'border_control'}
+- {layer: 'pois', kind: 'customs'}
+- {layer: 'earth', kind: 'ridge'}
+- {layer: 'pois', kind: 'boatyard'}
+- {layer: 'pois', kind: 'shipyard'}
+- {layer: 'pois', kind: 'spring'}
+- {layer: 'pois', kind: 'substation'}
+- {layer: 'pois', kind: 'gate'}
+# reserve for kind_details
+- _reserved: {from: 1601, to: 1611}
+- {layer: 'pois', kind: 'horse_riding'}
+- {layer: 'pois', kind: 'wharf'}
+- {layer: 'pois', kind: 'adult_gaming_centre'}
+- {layer: 'pois', kind: 'egress'}
+- {layer: 'pois', kind: 'parking'}
+- {layer: 'pois', kind: 'parking_garage'}
+- {layer: 'pois', kind: 'put_in'}
+- {layer: 'pois', kind: 'put_in_egress'}
+- {layer: 'pois', kind: 'quay'}
+- {layer: 'pois', kind: 'saddle'}
+- {layer: 'pois', kind: 'arts_centre'}
+- {layer: 'pois', kind: 'bar'}
+# reserve for kind_details
+- _reserved: {from: 1624, to: 1724}
+- {layer: 'pois', kind: 'bicycle'}
+- {layer: 'pois', kind: 'biergarten'}
+# reserve for kind_details
+- _reserved: {from: 1727, to: 1827}
+- {layer: 'pois', kind: 'cafe'}
+# reserve for kind_details
+- _reserved: {from: 1829, to: 1929}
+- {layer: 'pois', kind: 'fast_food'}
+# reserve for kind_details
+- _reserved: {from: 1931, to: 2031}
+- {layer: 'pois', kind: 'field_hospital'}
+# reserve for kind_details
+- _reserved: {from: 2033, to: 2053}
+- {layer: 'pois', kind: 'gallery'}
+- {layer: 'pois', kind: 'health_centre'}
+# reserve for kind_details
+- _reserved: {from: 2056, to: 2076}
+- {layer: 'pois', kind: 'nightclub'}
+# reserve for kind_details
+- _reserved: {from: 2078, to: 2178}
+- {layer: 'pois', kind: 'observatory'}
+- {layer: 'pois', kind: 'outdoor'}
+- {layer: 'pois', kind: 'pub'}
+# reserve for kind_details
+- _reserved: {from: 2182, to: 2282}
+- {layer: 'pois', kind: 'restaurant'}
+# reserve for kind_details
+- _reserved: {from: 2284, to: 2384}
+- {layer: 'pois', kind: 'theatre'}
+- {layer: 'pois', kind: 'toll_booth'}
+- {layer: 'pois', kind: 'trailhead'}
+- {layer: 'pois', kind: 'viewpoint'}
+- {layer: 'pois', kind: 'water_tower'}
+- {layer: 'pois', kind: 'wilderness_hut'}
+- {layer: 'pois', kind: 'nursing_home'}
+# reserve for kind_details
+- _reserved: {from: 2392, to: 2412}
+- {layer: 'pois', kind: 'telescope'}
+- {layer: 'landuse', kind: 'city_wall'}
+- {layer: 'water', kind: 'riverbank'}
+- {layer: 'earth', kind: 'cliff'}
+- {layer: 'earth', kind: 'arete'}
+- {layer: 'boundaries', kind: 'maritime'}
+# for shields & etc
+- _reserved: {from: 2419, to: 2429}
+- {layer: 'roads', kind: 'minor_road', kind_detail: 'unclassified'}
+# for shields & etc
+- _reserved: {from: 2431, to: 2441}
+# for shields & etc
+- _reserved: {from: 2442, to: 2452}
+- {layer: 'roads', kind: 'minor_road', kind_detail: 'living_street'}
+# for shields & etc
+- _reserved: {from: 2454, to: 2464}
+# for shields & etc
+- _reserved: {from: 2465, to: 2475}
+- {layer: 'roads', kind: 'minor_road', kind_detail: 'residential'}
+# for shields & etc
+- _reserved: {from: 2477, to: 2487}
+# for shields & etc
+- _reserved: {from: 2488, to: 2498}
+- {layer: 'roads', kind: 'minor_road', kind_detail: 'road'}
+# for shields & etc
+- _reserved: {from: 2500, to: 2510}
+# for shields & etc
+- _reserved: {from: 2511, to: 2521}
+- {layer: 'roads', kind: 'minor_road', kind_detail: 'service'}
+# for shields & etc
+- _reserved: {from: 2523, to: 2533}
+# for shields & etc
+- _reserved: {from: 2534, to: 2544}
+- {layer: 'roads', kind: 'minor_road', kind_detail: 'raceway'}
+# for shields & etc
+- _reserved: {from: 2546, to: 2556}
+# for shields & etc
+- _reserved: {from: 2557, to: 2567}
+- {layer: 'roads', kind: 'minor_road'}
+# for shields & etc
+- _reserved: {from: 2569, to: 2579}
+# for shields & etc
+- _reserved: {from: 2580, to: 2630}
+- {layer: 'roads', kind: 'racetrack'}
+# for shields & etc
+- _reserved: {from: 2632, to: 2682}
+# for shields & etc
+- _reserved: {from: 2683, to: 2703}
+- {layer: 'roads', kind: 'rail'}
+# for shields & etc
+- _reserved: {from: 2705, to: 2725}
+# for shields & etc
+- _reserved: {from: 2726, to: 2736}
+- {layer: 'transit', kind: 'monorail'}
+# for shields & etc
+- _reserved: {from: 2738, to: 2748}
+- {layer: 'transit', kind: 'funicular'}
+# for shields & etc
+- _reserved: {from: 2750, to: 2760}
+- {layer: 'pois', kind: 'beacon'}
+- {layer: 'pois', kind: 'cave_entrance'}
+- {layer: 'pois', kind: 'communications_tower'}
+- {layer: 'pois', kind: 'cross'}
+- {layer: 'pois', kind: 'dune'}
+- {layer: 'pois', kind: 'farm'}
+- {layer: 'pois', kind: 'generator'}
+# reserve for kind_details
+- _reserved: {from: 2768, to: 2788}
+- {layer: 'pois', kind: 'geyser'}
+- {layer: 'pois', kind: 'hazard'}
+- {layer: 'pois', kind: 'lock'}
+- {layer: 'pois', kind: 'mineshaft'}
+- {layer: 'pois', kind: 'monument'}
+- {layer: 'pois', kind: 'power_wind'}
+- {layer: 'pois', kind: 'rapid'}
+- {layer: 'pois', kind: 'sinkhole'}
+- {layer: 'landuse', kind: 'cutting'}
+- {layer: 'landuse', kind: 'ditch'}
+- {layer: 'landuse', kind: 'gate'}
+- {layer: 'landuse', kind: 'grave_yard'}
+# reserve for kind_details
+- _reserved: {from: 2801, to: 2851}
+- {layer: 'landuse', kind: 'guard_rail'}
+- {layer: 'landuse', kind: 'harbour'}
+- {layer: 'landuse', kind: 'kerb'}
+- {layer: 'landuse', kind: 'orchard'}
+# reserve for kind_details
+- _reserved: {from: 2856, to: 2906}
+- {layer: 'landuse', kind: 'plant_nursery'}
+- {layer: 'landuse', kind: 'port'}
+- {layer: 'landuse', kind: 'scree'}
+- {layer: 'landuse', kind: 'urban_area'}
+- {layer: 'landuse', kind: 'urban'}
+- {layer: 'landuse', kind: 'rural'}
+- {layer: 'landuse', kind: 'protected_area'}
+- {layer: 'landuse', kind: 'national_park'}
+- {layer: 'landuse', kind: 'residential'}
+- {layer: 'landuse', kind: 'industrial'}
+- {layer: 'landuse', kind: 'nature_reserve'}
+- {layer: 'landuse', kind: 'park'}
+- {layer: 'landuse', kind: 'battlefield'}
+- {layer: 'landuse', kind: 'rock'}
+- {layer: 'landuse', kind: 'stone'}
+- {layer: 'landuse', kind: 'glacier'}
+- {layer: 'landuse', kind: 'wood'}
+- {layer: 'landuse', kind: 'forest'}
+# reserve for kind_details
+- _reserved: {from: 2925, to: 2935}
+- {layer: 'landuse', kind: 'natural_park'}
+# reserve for kind_details
+- _reserved: {from: 2937, to: 2947}
+- {layer: 'landuse', kind: 'natural_forest'}
+# reserve for kind_details
+- _reserved: {from: 2949, to: 2959}
+- {layer: 'landuse', kind: 'natural_wood'}
+# reserve for kind_details
+- _reserved: {from: 2961, to: 2971}
+- {layer: 'landuse', kind: 'grass'}
+- {layer: 'landuse', kind: 'meadow'}
+- {layer: 'landuse', kind: 'scrub'}
+- {layer: 'landuse', kind: 'winter_sports'}
+- {layer: 'landuse', kind: 'farm'}
+- {layer: 'landuse', kind: 'farmland'}
+- {layer: 'landuse', kind: 'university'}
+- {layer: 'landuse', kind: 'college'}
+- {layer: 'landuse', kind: 'rest_area'}
+- {layer: 'landuse', kind: 'service_area'}
+- {layer: 'landuse', kind: 'commercial'}
+- {layer: 'landuse', kind: 'retail'}
+- {layer: 'landuse', kind: 'military'}
+- {layer: 'landuse', kind: 'naval_base'}
+- {layer: 'landuse', kind: 'danger_area'}
+- {layer: 'landuse', kind: 'range'}
+- {layer: 'landuse', kind: 'prison'}
+- {layer: 'landuse', kind: 'fort'}
+- {layer: 'landuse', kind: 'theme_park'}
+- {layer: 'landuse', kind: 'wildlife_park'}
+- {layer: 'landuse', kind: 'winery'}
+- {layer: 'landuse', kind: 'zoo'}
+- {layer: 'landuse', kind: 'resort'}
+- {layer: 'landuse', kind: 'trail_riding_station'}
+- {layer: 'landuse', kind: 'hospital'}
+- {layer: 'landuse', kind: 'aquarium'}
+- {layer: 'landuse', kind: 'golf_course'}
+- {layer: 'landuse', kind: 'boatyard'}
+- {layer: 'landuse', kind: 'shipyard'}
+- {layer: 'landuse', kind: 'container_terminal'}
+- {layer: 'landuse', kind: 'port_terminal'}
+- {layer: 'landuse', kind: 'wharf'}
+- {layer: 'landuse', kind: 'quay'}
+- {layer: 'landuse', kind: 'recreation_ground'}
+- {layer: 'landuse', kind: 'caravan_site'}
+- {layer: 'landuse', kind: 'recreation_track'}
+- {layer: 'landuse', kind: 'airfield'}
+- {layer: 'landuse', kind: 'stadium'}
+- {layer: 'landuse', kind: 'sports_centre'}
+- {layer: 'landuse', kind: 'village_green'}
+- {layer: 'landuse', kind: 'common'}
+- {layer: 'landuse', kind: 'railway'}
+- {layer: 'landuse', kind: 'quarry'}
+- {layer: 'landuse', kind: 'place_of_worship'}
+- {layer: 'landuse', kind: 'cemetery'}
+# reserve for kind_details
+- _reserved: {from: 3017, to: 3067}
+- {layer: 'landuse', kind: 'school'}
+- {layer: 'landuse', kind: 'fuel'}
+- {layer: 'landuse', kind: 'cinema'}
+- {layer: 'landuse', kind: 'library'}
+- {layer: 'landuse', kind: 'theatre'}
+- {layer: 'landuse', kind: 'aviary'}
+- {layer: 'landuse', kind: 'petting_zoo'}
+- {layer: 'landuse', kind: 'camp_site'}
+- {layer: 'landuse', kind: 'beach'}
+# reserve for kind_details
+- _reserved: {from: 3077, to: 3087}
+- {layer: 'landuse', kind: 'garden'}
+- {layer: 'landuse', kind: 'dog_park'}
+- {layer: 'landuse', kind: 'pedestrian'}
+- {layer: 'landuse', kind: 'playground'}
+- {layer: 'landuse', kind: 'attraction'}
+- {layer: 'landuse', kind: 'water_park'}
+- {layer: 'landuse', kind: 'wilderness_hut'}
+- {layer: 'landuse', kind: 'tower'}
+- {layer: 'landuse', kind: 'footway'}
+- {layer: 'landuse', kind: 'mud'}
+- {layer: 'pois', kind: 'wetland'}
+# reserve for kind_details
+- _reserved: {from: 3099, to: 3119}
+- {layer: 'landuse', kind: 'wetland'}
+# reserve for kind_details
+- _reserved: {from: 3121, to: 3141}
+- {layer: 'landuse', kind: 'land'}
+- {layer: 'landuse', kind: 'dam'}
+- {layer: 'landuse', kind: 'groyne'}
+- {layer: 'landuse', kind: 'dike'}
+- {layer: 'landuse', kind: 'pier'}
+- {layer: 'landuse', kind: 'bridge'}
+- {layer: 'pois', kind: 'stop_area'}
+- {layer: 'places', kind: 'microhood'}
+- {layer: 'pois', kind: 'aeroway_gate'}
+- {layer: 'pois', kind: 'bicycle_rental'}
+- {layer: 'pois', kind: 'boat_rental'}
+- {layer: 'pois', kind: 'bus_station'}
+- {layer: 'pois', kind: 'camera'}
+- {layer: 'pois', kind: 'car_rental'}
+- {layer: 'pois', kind: 'copyshop'}
+- {layer: 'pois', kind: 'dive_centre'}
+- {layer: 'pois', kind: 'dog_park'}
+- {layer: 'pois', kind: 'fishing'}
+- {layer: 'pois', kind: 'fishing_area'}
+- {layer: 'pois', kind: 'funeral_directors'}
+- {layer: 'pois', kind: 'harbourmaster'}
+- {layer: 'pois', kind: 'helipad'}
+- {layer: 'pois', kind: 'heliport'}
+- {layer: 'pois', kind: 'hot_spring'}
+- {layer: 'pois', kind: 'hunting'}
+- {layer: 'pois', kind: 'information'}
+- {layer: 'earth', kind: 'islet'}
+- {layer: 'pois', kind: 'mini_roundabout'}
+- {layer: 'pois', kind: 'miniature_golf'}
+- {layer: 'pois', kind: 'photo'}
+- {layer: 'pois', kind: 'picnic_site'}
+- {layer: 'pois', kind: 'snow_cannon'}
+- {layer: 'pois', kind: 'swimming_area'}
+- {layer: 'pois', kind: 'tyres'}
+- {layer: 'pois', kind: 'block'}
+- {layer: 'pois', kind: 'bunker'}
+# reserve for kind_details
+- _reserved: {from: 3178, to: 3198}
+- {layer: 'pois', kind: 'shelter'}
+- {layer: 'pois', kind: 'recreation_track'}
+- {layer: 'pois', kind: 'recycling'}
+- {layer: 'pois', kind: 'adit'}
+- {layer: 'pois', kind: 'allotments'}
+- {layer: 'pois', kind: 'archaeological_site'}
+- {layer: 'pois', kind: 'bicycle_junction'}
+- {layer: 'pois', kind: 'boat_lift'}
+- {layer: 'pois', kind: 'pitch'}
+# reserve for kind_details
+- _reserved: {from: 3208, to: 3308}
+- {layer: 'pois', kind: 'bollard'}
+- {layer: 'pois', kind: 'cattle_grid'}
+- {layer: 'pois', kind: 'crane'}
+# reserve for kind_details
+- _reserved: {from: 3312, to: 3322}
+- {layer: 'pois', kind: 'ford'}
+- {layer: 'pois', kind: 'halt'}
+- {layer: 'pois', kind: 'plaque'}
+- {layer: 'pois', kind: 'power_tower'}
+- {layer: 'pois', kind: 'stop'}
+- {layer: 'pois', kind: 'tram_stop'}
+- {layer: 'pois', kind: 'tree'}
+- {layer: 'pois', kind: 'walking_junction'}
+- {layer: 'pois', kind: 'wayside_cross'}
+- {layer: 'landuse', kind: 'taxiway'}
+- {layer: 'landuse', kind: 'runway'}
+- {layer: 'landuse', kind: 'wastewater_plant'}
+- {layer: 'landuse', kind: 'water_works'}
+- {layer: 'landuse', kind: 'works'}
+- {layer: 'landuse', kind: 'enclosure'}
+- {layer: 'landuse', kind: 'roller_coaster'}
+- {layer: 'landuse', kind: 'allotments'}
+- {layer: 'landuse', kind: 'generator'}
+- {layer: 'landuse', kind: 'maze'}
+- {layer: 'landuse', kind: 'hanami'}
+- {layer: 'landuse', kind: 'amusement_ride'}
+- {layer: 'landuse', kind: 'picnic_site'}
+- {layer: 'landuse', kind: 'crane'}
+# reserve for kind_details
+- _reserved: {from: 3346, to: 3356}
+- {layer: 'landuse', kind: 'embankment'}
+- {layer: 'transit', kind: 'halt'}
+- {layer: 'transit', kind: 'stop'}
+- {layer: 'transit', kind: 'tram_stop'}
+- {layer: 'pois', kind: 'accountant'}
+- {layer: 'pois', kind: 'administrative'}
+- {layer: 'pois', kind: 'advertising_agency'}
+- {layer: 'pois', kind: 'ambulatory_care'}
+# reserve for kind_details
+- _reserved: {from: 3365, to: 3385}
+- {layer: 'pois', kind: 'architect'}
+- {layer: 'pois', kind: 'art'}
+- {layer: 'pois', kind: 'association'}
+- {layer: 'pois', kind: 'aviary'}
+- {layer: 'pois', kind: 'baby_hatch'}
+- {layer: 'pois', kind: 'bakery'}
+- {layer: 'pois', kind: 'beauty'}
+- {layer: 'pois', kind: 'bed_and_breakfast'}
+- {layer: 'pois', kind: 'blood'}
+- {layer: 'pois', kind: 'blood_bank'}
+- {layer: 'pois', kind: 'books'}
+- {layer: 'pois', kind: 'butcher'}
+- {layer: 'pois', kind: 'car'}
+- {layer: 'pois', kind: 'carousel'}
+- {layer: 'pois', kind: 'chalet'}
+- {layer: 'pois', kind: 'childcare'}
+- {layer: 'pois', kind: 'chiropractor'}
+# reserve for kind_details
+- _reserved: {from: 3403, to: 3423}
+- {layer: 'pois', kind: 'clinic'}
+# reserve for kind_details
+- _reserved: {from: 3425, to: 3445}
+- {layer: 'pois', kind: 'clothes'}
+- {layer: 'pois', kind: 'company'}
+- {layer: 'pois', kind: 'computer'}
+- {layer: 'pois', kind: 'consulting'}
+- {layer: 'pois', kind: 'convenience'}
+- {layer: 'pois', kind: 'craft'}
+- {layer: 'pois', kind: 'dentist'}
+# reserve for kind_details
+- _reserved: {from: 3453, to: 3473}
+- {layer: 'pois', kind: 'dispensary'}
+# reserve for kind_details
+- _reserved: {from: 3475, to: 3495}
+- {layer: 'pois', kind: 'doctors'}
+# reserve for kind_details
+- _reserved: {from: 3497, to: 3517}
+- {layer: 'pois', kind: 'educational_institution'}
+- {layer: 'pois', kind: 'employment_agency'}
+- {layer: 'pois', kind: 'estate_agent'}
+- {layer: 'pois', kind: 'fashion'}
+- {layer: 'pois', kind: 'financial'}
+- {layer: 'pois', kind: 'florist'}
+- {layer: 'pois', kind: 'foundation'}
+- {layer: 'pois', kind: 'gift'}
+- {layer: 'pois', kind: 'government'}
+- {layer: 'pois', kind: 'greengrocer'}
+- {layer: 'pois', kind: 'grocery'}
+- {layer: 'pois', kind: 'guest_house'}
+- {layer: 'pois', kind: 'hairdresser'}
+- {layer: 'pois', kind: 'healthcare_centre'}
+# reserve for kind_details
+- _reserved: {from: 3532, to: 3552}
+- {layer: 'pois', kind: 'hifi'}
+- {layer: 'pois', kind: 'hospice'}
+# reserve for kind_details
+- _reserved: {from: 3555, to: 3575}
+- {layer: 'pois', kind: 'hostel'}
+- {layer: 'pois', kind: 'jewelry'}
+- {layer: 'pois', kind: 'karaoke'}
+- {layer: 'pois', kind: 'lawyer'}
+- {layer: 'pois', kind: 'midwife'}
+# reserve for kind_details
+- _reserved: {from: 3581, to: 3601}
+- {layer: 'pois', kind: 'mobile_phone'}
+- {layer: 'pois', kind: 'motorcycle'}
+- {layer: 'pois', kind: 'newsagent'}
+- {layer: 'pois', kind: 'newspaper'}
+- {layer: 'pois', kind: 'ngo'}
+- {layer: 'pois', kind: 'notary'}
+- {layer: 'pois', kind: 'optician'}
+- {layer: 'pois', kind: 'paediatrics'}
+# reserve for kind_details
+- _reserved: {from: 3610, to: 3630}
+- {layer: 'pois', kind: 'optometrist_paediatrics'}
+# reserve for kind_details
+- _reserved: {from: 3632, to: 3652}
+- {layer: 'pois', kind: 'perfumery'}
+- {layer: 'pois', kind: 'petting_zoo'}
+- {layer: 'pois', kind: 'physician'}
+# reserve for kind_details
+- _reserved: {from: 3656, to: 3676}
+- {layer: 'pois', kind: 'physiotherapist_physiotherapy'}
+# reserve for kind_details
+- _reserved: {from: 3678, to: 3698}
+- {layer: 'pois', kind: 'physiotherapist'}
+# reserve for kind_details
+- _reserved: {from: 3700, to: 3720}
+- {layer: 'pois', kind: 'playground'}
+- {layer: 'pois', kind: 'psychotherapist'}
+# reserve for kind_details
+- _reserved: {from: 3723, to: 3743}
+- {layer: 'pois', kind: 'podiatrist'}
+# reserve for kind_details
+- _reserved: {from: 3745, to: 3765}
+- {layer: 'pois', kind: 'political_party'}
+- {layer: 'pois', kind: 'rehabilitation'}
+# reserve for kind_details
+- _reserved: {from: 3768, to: 3788}
+- {layer: 'pois', kind: 'religion'}
+- {layer: 'pois', kind: 'research'}
+- {layer: 'pois', kind: 'sanitary_dump_station'}
+- {layer: 'pois', kind: 'scuba_diving'}
+- {layer: 'pois', kind: 'snowmobile'}
+- {layer: 'pois', kind: 'social_facility'}
+# reserve for kind_details
+- _reserved: {from: 3795, to: 3815}
+- {layer: 'pois', kind: 'speech_therapist'}
+# reserve for kind_details
+- _reserved: {from: 3817, to: 3837}
+- {layer: 'pois', kind: 'speech'}
+- {layer: 'pois', kind: 'stationery'}
+- {layer: 'pois', kind: 'studio'}
+# reserve for kind_details
+- _reserved: {from: 3841, to: 3861}
+- {layer: 'pois', kind: 'tax_advisor'}
+- {layer: 'pois', kind: 'telecommunication'}
+- {layer: 'pois', kind: 'therapist'}
+- {layer: 'pois', kind: 'tobacco'}
+- {layer: 'pois', kind: 'travel_agency'}
+- {layer: 'pois', kind: 'travel_agent'}
+- {layer: 'pois', kind: 'wildlife_park'}
+- {layer: 'transit', kind: 'station'}
+- {layer: 'transit', kind: 'stop_area'}
+- {layer: 'transit', kind: 'platform'}
+- {layer: 'buildings', kind: 'building'}
+# reserve for kind_details
+- _reserved: {from: 3873, to: 4073}
+- {layer: 'pois', kind: 'atv'}
+- {layer: 'pois', kind: 'bicycle_rental_station'}
+- {layer: 'pois', kind: 'boat_storage'}
+- {layer: 'pois', kind: 'bookmaker'}
+- {layer: 'pois', kind: 'bureau_de_change'}
+- {layer: 'pois', kind: 'car_parts'}
+- {layer: 'pois', kind: 'donation'}
+- {layer: 'pois', kind: 'hanami'}
+- {layer: 'pois', kind: 'healthcare_alternative'}
+# reserve for kind_details
+- _reserved: {from: 4083, to: 4103}
+- {layer: 'pois', kind: 'it'}
+- {layer: 'pois', kind: 'midwife_occupational'}
+- {layer: 'pois', kind: 'occupational_therapist'}
+# reserve for kind_details
+- _reserved: {from: 4107, to: 4127}
+- {layer: 'pois', kind: 'money_transfer'}
+- {layer: 'pois', kind: 'roller_coaster'}
+- {layer: 'pois', kind: 'amusement_ride'}
+- {layer: 'pois', kind: 'animal'}
+- {layer: 'pois', kind: 'artwork'}
+- {layer: 'pois', kind: 'attraction'}
+- {layer: 'pois', kind: 'bicycle_parking'}
+- {layer: 'pois', kind: 'car_repair'}
+- {layer: 'pois', kind: 'healthcare_laboratory'}
+# reserve for kind_details
+- _reserved: {from: 4137, to: 4157}
+- {layer: 'pois', kind: 'insurance'}
+- {layer: 'pois', kind: 'car_wash'}
+- {layer: 'pois', kind: 'subway_entrance'}
+- {layer: 'pois', kind: 'gambling'}
+- {layer: 'pois', kind: 'office'}
+- {layer: 'pois', kind: 'car_sharing'}
+- {layer: 'pois', kind: 'charging_station'}
+- {layer: 'pois', kind: 'enclosure'}
+- {layer: 'pois', kind: 'lottery'}
+- {layer: 'pois', kind: 'ship_chandler'}
+- {layer: 'pois', kind: 'slipway'}
+- {layer: 'pois', kind: 'summer_toboggan'}
+- {layer: 'pois', kind: 'industrial'}
+- {layer: 'pois', kind: 'shop'}
+- {layer: 'pois', kind: 'slaughterhouse'}
+- {layer: 'pois', kind: 'stone'}
+- {layer: 'pois', kind: 'trail_riding_station'}
+- {layer: 'pois', kind: 'turning_circle'}
+- {layer: 'pois', kind: 'turning_loop'}
+- {layer: 'pois', kind: 'water_slide'}
+- {layer: 'pois', kind: 'water_well'}
+# reserve for kind_details
+- _reserved: {from: 4179, to: 4199}
+- {layer: 'pois', kind: 'defibrillator'}
+- {layer: 'pois', kind: 'elevator'}
+- {layer: 'pois', kind: 'emergency_phone'}
+- {layer: 'pois', kind: 'fitness_station'}
+- {layer: 'pois', kind: 'hunting_stand'}
+- {layer: 'pois', kind: 'karaoke_box'}
+- {layer: 'pois', kind: 'lifeguard_tower'}
+- {layer: 'pois', kind: 'mast'}
+- {layer: 'pois', kind: 'maze'}
+- {layer: 'pois', kind: 'memorial'}
+- {layer: 'pois', kind: 'mooring'}
+# reserve for kind_details
+- _reserved: {from: 4211, to: 4231}
+- {layer: 'pois', kind: 'motorcycle_parking'}
+- {layer: 'pois', kind: 'petroleum_well'}
+- {layer: 'pois', kind: 'platform'}
+- {layer: 'pois', kind: 'pylon'}
+- {layer: 'pois', kind: 'rock'}
+- {layer: 'earth', kind: 'earth'}
+- {layer: 'landuse', kind: 'apron'}
+- {layer: 'landuse', kind: 'substation'}
+- {layer: 'landuse', kind: 'summer_toboggan'}
+- {layer: 'landuse', kind: 'plant'}
+- {layer: 'landuse', kind: 'pitch'}
+- {layer: 'landuse', kind: 'animal'}
+- {layer: 'landuse', kind: 'artwork'}
+- {layer: 'landuse', kind: 'carousel'}
+- {layer: 'landuse', kind: 'water_slide'}
+- {layer: 'landuse', kind: 'parking'}
+- {layer: 'water', kind: 'fountain'}
+- {layer: 'water', kind: 'ditch'}
+- {layer: 'water', kind: 'drain'}
+- {layer: 'water', kind: 'swimming_pool'}
+- {layer: 'landuse', kind: 'breakwater'}
+- {layer: 'landuse', kind: 'cutline'}
+- {layer: 'landuse', kind: 'hedge'}
+- {layer: 'landuse', kind: 'tree_row'}
+- {layer: 'landuse', kind: 'retaining_wall'}
+- {layer: 'landuse', kind: 'snow_fence'}
+- {layer: 'landuse', kind: 'fence'}
+# reserve for kind_details
+- _reserved: {from: 4259, to: 4309}
+- {layer: 'landuse', kind: 'wall'}
+# reserve for kind_details
+- _reserved: {from: 4311, to: 4331}
+- {layer: 'landuse', kind: 'power_minor_line'}
+- {layer: 'landuse', kind: 'power_line'}
+- {layer: 'transit', kind: 'bus_stop'}
+- {layer: 'buildings', kind: 'building_part'}
+# reserve for kind_details
+- _reserved: {from: 4336, to: 4386}
+- {layer: 'pois', kind: 'atm'}
+- {layer: 'pois', kind: 'bus_stop'}
+- {layer: 'pois', kind: 'firepit'}
+- {layer: 'pois', kind: 'life_ring'}
+- {layer: 'pois', kind: 'picnic_table'}
+- {layer: 'pois', kind: 'shower'}
+- {layer: 'pois', kind: 'taxi'}
+- {layer: 'pois', kind: 'telephone'}
+- {layer: 'pois', kind: 'toilets'}
+# reserve for kind_details
+- _reserved: {from: 4396, to: 4406}
+- {layer: 'pois', kind: 'waste_disposal'}
+- {layer: 'pois', kind: 'bbq'}
+- {layer: 'pois', kind: 'bicycle_repair_station'}
+- {layer: 'pois', kind: 'cycle_barrier'}
+- {layer: 'pois', kind: 'drinking_water'}
+- {layer: 'pois', kind: 'phone'}
+- {layer: 'buildings', kind: 'address'}
+- {layer: 'pois', kind: 'bench'}
+- {layer: 'buildings', kind: 'entrance'}
+# reserve for kind_details
+- _reserved: {from: 4416, to: 4436}
+- {layer: 'buildings', kind: 'exit'}
+# reserve for kind_details
+- _reserved: {from: 4438, to: 4448}
+- {layer: 'pois', kind: 'fire_hydrant'}
+- {layer: 'pois', kind: 'gas_canister'}
+- {layer: 'pois', kind: 'level_crossing'}
+- {layer: 'pois', kind: 'love_hotel'}
+- {layer: 'pois', kind: 'post_box'}
+- {layer: 'pois', kind: 'power_pole'}
+- {layer: 'pois', kind: 'street_lamp'}
+- {layer: 'pois', kind: 'traffic_signals'}
+- {layer: 'pois', kind: 'waste_basket'}
+- {layer: 'pois', kind: 'water_point'}
+- {layer: 'pois', kind: 'watering_place'}
+# catch-all, assign lowest priority
+- { layer: true }

--- a/spreadsheets/collision_rank.yaml
+++ b/spreadsheets/collision_rank.yaml
@@ -1,46 +1,46 @@
 # reserved for UX/UI
-- _reserved: {from: 1, to: 100}
+- _reserved: {from: 1, to: 99}
 # reserved for house theme overlays
-- _reserved: {from: 101, to: 201}
+- _reserved: {from: 100, to: 199}
 # reserved for data overlays
-- _reserved: {from: 202, to: 302}
+- _reserved: {from: 200, to: 299}
 - {$layer: 'earth', kind: 'continent'}
 - {$layer: 'water', kind: 'ocean'}
 - {$layer: 'places', kind: 'country'}
 # reserved for population_rank
-- _reserved: {from: 306, to: 325}
+- _reserved: {count: 19}
 - {$layer: 'places', kind: 'locality'}
 # reserved for population_rank; guess the pop from kind_detail ala
 # _default_min_zoom_for_place_kind() : city, farm, hamlet, isolated_dwelling,
 # locality, scientific_station, town, village,
-- _reserved: {from: 327, to: 346}
+- _reserved: {count: 19}
 - {$layer: 'pois', kind: 'national_park'}
 - {$layer: 'places', kind: 'region'}
 # reserved for population_rank
-- _reserved: {from: 349, to: 368}
+- _reserved: {count: 19}
 - {$layer: 'water', kind: 'sea'}
 - {$layer: 'pois', kind: 'nature_reserve'}
 - {$layer: 'water', kind: 'lake'}
 # for shields & etc
-- _reserved: {from: 372, to: 382}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'highway', kind_detail: 'motorway'}
 # for shields & etc
-- _reserved: {from: 384, to: 394}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 395, to: 405}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'highway', kind_detail: 'motorway_link'}
 # for shields & etc
-- _reserved: {from: 407, to: 417}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 418, to: 428}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'highway', kind_detail: 'trunk'}
 # for shields & etc
-- _reserved: {from: 430, to: 440}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 441, to: 451}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'highway'}
 # for shields & etc
-- _reserved: {from: 453, to: 463}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'forest'}
 - {$layer: 'earth', kind: 'island'}
 - {$layer: 'water', kind: 'water'}
@@ -58,67 +58,67 @@
 - {$layer: 'pois', kind: 'volcano'}
 - {$layer: 'pois', kind: 'wood'}
 # reserve for kind_details
-- _reserved: {from: 480, to: 490}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'peak'}
 - {$layer: 'water', kind: 'river'}
 # for shields & etc
-- _reserved: {from: 493, to: 503}
+- _reserved: {count: 10}
 - {$layer: 'transit', kind: 'train'}
 # for shields & etc
-- _reserved: {from: 505, to: 515}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'beach'}
 # reserve for kind_details
-- _reserved: {from: 517, to: 527}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'university'}
 - {$layer: 'pois', kind: 'battlefield'}
 # for shields & etc
-- _reserved: {from: 530, to: 540}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'primary'}
 # for shields & etc
-- _reserved: {from: 542, to: 552}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 553, to: 563}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'primary_link'}
 # for shields & etc
-- _reserved: {from: 565, to: 575}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 576, to: 586}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'secondary'}
 # for shields & etc
-- _reserved: {from: 588, to: 598}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 599, to: 609}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'secondary_link'}
 # for shields & etc
-- _reserved: {from: 611, to: 621}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 622, to: 632}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'tertiary'}
 # for shields & etc
-- _reserved: {from: 634, to: 644}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 645, to: 655}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'tertiary_link'}
 # for shields & etc
-- _reserved: {from: 657, to: 667}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 668, to: 678}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'trunk'}
 # for shields & etc
-- _reserved: {from: 680, to: 690}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 691, to: 701}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road', kind_detail: 'trunk_link'}
 # for shields & etc
-- _reserved: {from: 703, to: 713}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 714, to: 724}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'major_road'}
 # for shields & etc
-- _reserved: {from: 726, to: 736}
+- _reserved: {count: 10}
 - {$layer: 'water', kind: 'reef'}
 # reserve for kind_details
-- _reserved: {from: 738, to: 748}
+- _reserved: {count: 10}
 - {$layer: 'water', kind: 'canal'}
 - {$layer: 'earth', kind: 'archipelago'}
 - {$layer: 'pois', kind: 'ferry_terminal'}
@@ -128,13 +128,13 @@
 - {$layer: 'pois', kind: 'station'}
 - {$layer: 'pois', kind: 'zoo'}
 # for shields & etc
-- _reserved: {from: 757, to: 767}
+- _reserved: {count: 10}
 - {$layer: 'transit', kind: 'subway'}
 # for shields & etc
-- _reserved: {from: 769, to: 779}
+- _reserved: {count: 10}
 - {$layer: 'boundaries', kind: 'aboriginal_lands'}
 # reserve for kind_details
-- _reserved: {from: 781, to: 801}
+- _reserved: {count: 20}
 - {$layer: 'boundaries', kind: 'county'}
 - {$layer: 'boundaries', kind: 'region'}
 - {$layer: 'boundaries', kind: 'macroregion'}
@@ -149,7 +149,7 @@
 - {$layer: 'pois', kind: 'college'}
 - {$layer: 'pois', kind: 'hospital'}
 # reserve for kind_details
-- _reserved: {from: 815, to: 835}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'landmark'}
 - {$layer: 'pois', kind: 'mall'}
 - {$layer: 'pois', kind: 'museum'}
@@ -162,24 +162,24 @@
 - {$layer: 'pois', kind: 'recreation_ground'}
 - {$layer: 'pois', kind: 'waterfall'}
 # for shields & etc
-- _reserved: {from: 847, to: 857}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'ferry'}
 # for shields & etc
-- _reserved: {from: 859, to: 869}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 870, to: 880}
+- _reserved: {count: 10}
 - {$layer: 'transit', kind: 'light_rail'}
 # for shields & etc
-- _reserved: {from: 882, to: 892}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'townhall'}
 # for shields & etc
-- _reserved: {from: 894, to: 904}
+- _reserved: {count: 10}
 - {$layer: 'transit', kind: 'tram'}
 # for shields & etc
-- _reserved: {from: 906, to: 916}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'cemetery'}
 # reserve for kind_details
-- _reserved: {from: 918, to: 968}
+- _reserved: {count: 50}
 - {$layer: 'pois', kind: 'dam'}
 - {$layer: 'pois', kind: 'motorway_junction'}
 - {$layer: 'pois', kind: 'place_of_worship'}
@@ -191,10 +191,10 @@
 - {$layer: 'pois', kind: 'works'}
 - {$layer: 'places', kind: 'borough'}
 # for shields, kind_detail & etc
-- _reserved: {from: 979, to: 1029}
+- _reserved: {count: 50}
 - {$layer: 'roads', kind: 'path'}
 # for shields, kind_detail & etc
-- _reserved: {from: 1031, to: 1081}
+- _reserved: {count: 50}
 - {$layer: 'pois', kind: 'camp_site'}
 - {$layer: 'pois', kind: 'chemist'}
 - {$layer: 'pois', kind: 'community_centre'}
@@ -207,7 +207,7 @@
 - {$layer: 'pois', kind: 'golf'}
 - {$layer: 'pois', kind: 'grave_yard'}
 # reserve for kind_details
-- _reserved: {from: 1093, to: 1143}
+- _reserved: {count: 50}
 - {$layer: 'pois', kind: 'hotel'}
 - {$layer: 'pois', kind: 'marketplace'}
 - {$layer: 'pois', kind: 'motel'}
@@ -215,7 +215,7 @@
 - {$layer: 'pois', kind: 'pet'}
 - {$layer: 'pois', kind: 'pharmacy'}
 # reserve for kind_details
-- _reserved: {from: 1150, to: 1170}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'range'}
 - {$layer: 'pois', kind: 'school'}
 - {$layer: 'pois', kind: 'shoes'}
@@ -247,12 +247,12 @@
 - {$layer: 'pois', kind: 'ski_school'}
 - {$layer: 'pois', kind: 'veterinary'}
 # reserve for kind_details
-- _reserved: {from: 1201, to: 1221}
+- _reserved: {count: 20}
 # for shields & etc
-- _reserved: {from: 1222, to: 1232}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'portage_way'}
 # for shields & etc
-- _reserved: {from: 1234, to: 1244}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'dressmaker'}
 - {$layer: 'pois', kind: 'dry_cleaning'}
 - {$layer: 'pois', kind: 'fishmonger'}
@@ -296,40 +296,40 @@
 - {$layer: 'water', kind: 'basin'}
 - {$layer: 'water', kind: 'stream'}
 # for shields & etc
-- _reserved: {from: 1287, to: 1337}
+- _reserved: {count: 50}
 - {$layer: 'roads', kind: 'piste'}
 # for shields & etc
-- _reserved: {from: 1339, to: 1389}
+- _reserved: {count: 50}
 # for shields, kind_detail & etc
-- _reserved: {from: 1390, to: 1440}
+- _reserved: {count: 50}
 - {$layer: 'roads', kind: 'aerialway'}
 # for shields, kind_detail & etc
-- _reserved: {from: 1442, to: 1492}
+- _reserved: {count: 50}
 # for shields & etc
-- _reserved: {from: 1493, to: 1503}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'aeroway', kind_detail: 'runway'}
 # for shields & etc
-- _reserved: {from: 1505, to: 1515}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 1516, to: 1526}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'aeroway', kind_detail: 'taxiway'}
 # for shields & etc
-- _reserved: {from: 1528, to: 1538}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 1539, to: 1549}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'aeroway'}
 # for shields & etc
-- _reserved: {from: 1551, to: 1561}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'courthouse'}
 - {$layer: 'pois', kind: 'lighthouse'}
 - {$layer: 'pois', kind: 'obelisk'}
 # reserve for kind_details
-- _reserved: {from: 1565, to: 1575}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'police'}
 - {$layer: 'pois', kind: 'post_office'}
 - {$layer: 'pois', kind: 'ruins'}
 # reserve for kind_details
-- _reserved: {from: 1579, to: 1589}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'watermill'}
 - {$layer: 'pois', kind: 'windmill'}
 - {$layer: 'places', kind: 'neighbourhood'}
@@ -342,7 +342,7 @@
 - {$layer: 'pois', kind: 'substation'}
 - {$layer: 'pois', kind: 'gate'}
 # reserve for kind_details
-- _reserved: {from: 1601, to: 1611}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'horse_riding'}
 - {$layer: 'pois', kind: 'wharf'}
 - {$layer: 'pois', kind: 'adult_gaming_centre'}
@@ -356,35 +356,35 @@
 - {$layer: 'pois', kind: 'arts_centre'}
 - {$layer: 'pois', kind: 'bar'}
 # reserve for kind_details
-- _reserved: {from: 1624, to: 1724}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'bicycle'}
 - {$layer: 'pois', kind: 'biergarten'}
 # reserve for kind_details
-- _reserved: {from: 1727, to: 1827}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'cafe'}
 # reserve for kind_details
-- _reserved: {from: 1829, to: 1929}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'fast_food'}
 # reserve for kind_details
-- _reserved: {from: 1931, to: 2031}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'field_hospital'}
 # reserve for kind_details
-- _reserved: {from: 2033, to: 2053}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'gallery'}
 - {$layer: 'pois', kind: 'health_centre'}
 # reserve for kind_details
-- _reserved: {from: 2056, to: 2076}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'nightclub'}
 # reserve for kind_details
-- _reserved: {from: 2078, to: 2178}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'observatory'}
 - {$layer: 'pois', kind: 'outdoor'}
 - {$layer: 'pois', kind: 'pub'}
 # reserve for kind_details
-- _reserved: {from: 2182, to: 2282}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'restaurant'}
 # reserve for kind_details
-- _reserved: {from: 2284, to: 2384}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'theatre'}
 - {$layer: 'pois', kind: 'toll_booth'}
 - {$layer: 'pois', kind: 'trailhead'}
@@ -393,7 +393,7 @@
 - {$layer: 'pois', kind: 'wilderness_hut'}
 - {$layer: 'pois', kind: 'nursing_home'}
 # reserve for kind_details
-- _reserved: {from: 2392, to: 2412}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'telescope'}
 - {$layer: 'landuse', kind: 'city_wall'}
 - {$layer: 'water', kind: 'riverbank'}
@@ -401,58 +401,58 @@
 - {$layer: 'earth', kind: 'arete'}
 - {$layer: 'boundaries', kind: 'maritime'}
 # for shields & etc
-- _reserved: {from: 2419, to: 2429}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road', kind_detail: 'unclassified'}
 # for shields & etc
-- _reserved: {from: 2431, to: 2441}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 2442, to: 2452}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road', kind_detail: 'living_street'}
 # for shields & etc
-- _reserved: {from: 2454, to: 2464}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 2465, to: 2475}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road', kind_detail: 'residential'}
 # for shields & etc
-- _reserved: {from: 2477, to: 2487}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 2488, to: 2498}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road', kind_detail: 'road'}
 # for shields & etc
-- _reserved: {from: 2500, to: 2510}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 2511, to: 2521}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road', kind_detail: 'service'}
 # for shields & etc
-- _reserved: {from: 2523, to: 2533}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 2534, to: 2544}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road', kind_detail: 'raceway'}
 # for shields & etc
-- _reserved: {from: 2546, to: 2556}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 2557, to: 2567}
+- _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road'}
 # for shields & etc
-- _reserved: {from: 2569, to: 2579}
+- _reserved: {count: 10}
 # for shields & etc
-- _reserved: {from: 2580, to: 2630}
+- _reserved: {count: 50}
 - {$layer: 'roads', kind: 'racetrack'}
 # for shields & etc
-- _reserved: {from: 2632, to: 2682}
+- _reserved: {count: 50}
 # for shields & etc
-- _reserved: {from: 2683, to: 2703}
+- _reserved: {count: 20}
 - {$layer: 'roads', kind: 'rail'}
 # for shields & etc
-- _reserved: {from: 2705, to: 2725}
+- _reserved: {count: 20}
 # for shields & etc
-- _reserved: {from: 2726, to: 2736}
+- _reserved: {count: 10}
 - {$layer: 'transit', kind: 'monorail'}
 # for shields & etc
-- _reserved: {from: 2738, to: 2748}
+- _reserved: {count: 10}
 - {$layer: 'transit', kind: 'funicular'}
 # for shields & etc
-- _reserved: {from: 2750, to: 2760}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'beacon'}
 - {$layer: 'pois', kind: 'cave_entrance'}
 - {$layer: 'pois', kind: 'communications_tower'}
@@ -461,7 +461,7 @@
 - {$layer: 'pois', kind: 'farm'}
 - {$layer: 'pois', kind: 'generator'}
 # reserve for kind_details
-- _reserved: {from: 2768, to: 2788}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'geyser'}
 - {$layer: 'pois', kind: 'hazard'}
 - {$layer: 'pois', kind: 'lock'}
@@ -475,13 +475,13 @@
 - {$layer: 'landuse', kind: 'gate'}
 - {$layer: 'landuse', kind: 'grave_yard'}
 # reserve for kind_details
-- _reserved: {from: 2801, to: 2851}
+- _reserved: {count: 50}
 - {$layer: 'landuse', kind: 'guard_rail'}
 - {$layer: 'landuse', kind: 'harbour'}
 - {$layer: 'landuse', kind: 'kerb'}
 - {$layer: 'landuse', kind: 'orchard'}
 # reserve for kind_details
-- _reserved: {from: 2856, to: 2906}
+- _reserved: {count: 50}
 - {$layer: 'landuse', kind: 'plant_nursery'}
 - {$layer: 'landuse', kind: 'port'}
 - {$layer: 'landuse', kind: 'scree'}
@@ -501,16 +501,16 @@
 - {$layer: 'landuse', kind: 'wood'}
 - {$layer: 'landuse', kind: 'forest'}
 # reserve for kind_details
-- _reserved: {from: 2925, to: 2935}
+- _reserved: {count: 10}
 - {$layer: 'landuse', kind: 'natural_park'}
 # reserve for kind_details
-- _reserved: {from: 2937, to: 2947}
+- _reserved: {count: 10}
 - {$layer: 'landuse', kind: 'natural_forest'}
 # reserve for kind_details
-- _reserved: {from: 2949, to: 2959}
+- _reserved: {count: 10}
 - {$layer: 'landuse', kind: 'natural_wood'}
 # reserve for kind_details
-- _reserved: {from: 2961, to: 2971}
+- _reserved: {count: 10}
 - {$layer: 'landuse', kind: 'grass'}
 - {$layer: 'landuse', kind: 'meadow'}
 - {$layer: 'landuse', kind: 'scrub'}
@@ -557,7 +557,7 @@
 - {$layer: 'landuse', kind: 'place_of_worship'}
 - {$layer: 'landuse', kind: 'cemetery'}
 # reserve for kind_details
-- _reserved: {from: 3017, to: 3067}
+- _reserved: {count: 50}
 - {$layer: 'landuse', kind: 'school'}
 - {$layer: 'landuse', kind: 'fuel'}
 - {$layer: 'landuse', kind: 'cinema'}
@@ -568,7 +568,7 @@
 - {$layer: 'landuse', kind: 'camp_site'}
 - {$layer: 'landuse', kind: 'beach'}
 # reserve for kind_details
-- _reserved: {from: 3077, to: 3087}
+- _reserved: {count: 10}
 - {$layer: 'landuse', kind: 'garden'}
 - {$layer: 'landuse', kind: 'dog_park'}
 - {$layer: 'landuse', kind: 'pedestrian'}
@@ -581,10 +581,10 @@
 - {$layer: 'landuse', kind: 'mud'}
 - {$layer: 'pois', kind: 'wetland'}
 # reserve for kind_details
-- _reserved: {from: 3099, to: 3119}
+- _reserved: {count: 20}
 - {$layer: 'landuse', kind: 'wetland'}
 # reserve for kind_details
-- _reserved: {from: 3121, to: 3141}
+- _reserved: {count: 20}
 - {$layer: 'landuse', kind: 'land'}
 - {$layer: 'landuse', kind: 'dam'}
 - {$layer: 'landuse', kind: 'groyne'}
@@ -622,7 +622,7 @@
 - {$layer: 'pois', kind: 'block'}
 - {$layer: 'pois', kind: 'bunker'}
 # reserve for kind_details
-- _reserved: {from: 3178, to: 3198}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'shelter'}
 - {$layer: 'pois', kind: 'recreation_track'}
 - {$layer: 'pois', kind: 'recycling'}
@@ -633,12 +633,12 @@
 - {$layer: 'pois', kind: 'boat_lift'}
 - {$layer: 'pois', kind: 'pitch'}
 # reserve for kind_details
-- _reserved: {from: 3208, to: 3308}
+- _reserved: {count: 100}
 - {$layer: 'pois', kind: 'bollard'}
 - {$layer: 'pois', kind: 'cattle_grid'}
 - {$layer: 'pois', kind: 'crane'}
 # reserve for kind_details
-- _reserved: {from: 3312, to: 3322}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'ford'}
 - {$layer: 'pois', kind: 'halt'}
 - {$layer: 'pois', kind: 'plaque'}
@@ -663,7 +663,7 @@
 - {$layer: 'landuse', kind: 'picnic_site'}
 - {$layer: 'landuse', kind: 'crane'}
 # reserve for kind_details
-- _reserved: {from: 3346, to: 3356}
+- _reserved: {count: 10}
 - {$layer: 'landuse', kind: 'embankment'}
 - {$layer: 'transit', kind: 'halt'}
 - {$layer: 'transit', kind: 'stop'}
@@ -673,7 +673,7 @@
 - {$layer: 'pois', kind: 'advertising_agency'}
 - {$layer: 'pois', kind: 'ambulatory_care'}
 # reserve for kind_details
-- _reserved: {from: 3365, to: 3385}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'architect'}
 - {$layer: 'pois', kind: 'art'}
 - {$layer: 'pois', kind: 'association'}
@@ -692,10 +692,10 @@
 - {$layer: 'pois', kind: 'childcare'}
 - {$layer: 'pois', kind: 'chiropractor'}
 # reserve for kind_details
-- _reserved: {from: 3403, to: 3423}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'clinic'}
 # reserve for kind_details
-- _reserved: {from: 3425, to: 3445}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'clothes'}
 - {$layer: 'pois', kind: 'company'}
 - {$layer: 'pois', kind: 'computer'}
@@ -704,13 +704,13 @@
 - {$layer: 'pois', kind: 'craft'}
 - {$layer: 'pois', kind: 'dentist'}
 # reserve for kind_details
-- _reserved: {from: 3453, to: 3473}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'dispensary'}
 # reserve for kind_details
-- _reserved: {from: 3475, to: 3495}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'doctors'}
 # reserve for kind_details
-- _reserved: {from: 3497, to: 3517}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'educational_institution'}
 - {$layer: 'pois', kind: 'employment_agency'}
 - {$layer: 'pois', kind: 'estate_agent'}
@@ -726,18 +726,18 @@
 - {$layer: 'pois', kind: 'hairdresser'}
 - {$layer: 'pois', kind: 'healthcare_centre'}
 # reserve for kind_details
-- _reserved: {from: 3532, to: 3552}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'hifi'}
 - {$layer: 'pois', kind: 'hospice'}
 # reserve for kind_details
-- _reserved: {from: 3555, to: 3575}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'hostel'}
 - {$layer: 'pois', kind: 'jewelry'}
 - {$layer: 'pois', kind: 'karaoke'}
 - {$layer: 'pois', kind: 'lawyer'}
 - {$layer: 'pois', kind: 'midwife'}
 # reserve for kind_details
-- _reserved: {from: 3581, to: 3601}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'mobile_phone'}
 - {$layer: 'pois', kind: 'motorcycle'}
 - {$layer: 'pois', kind: 'newsagent'}
@@ -747,32 +747,32 @@
 - {$layer: 'pois', kind: 'optician'}
 - {$layer: 'pois', kind: 'paediatrics'}
 # reserve for kind_details
-- _reserved: {from: 3610, to: 3630}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'optometrist_paediatrics'}
 # reserve for kind_details
-- _reserved: {from: 3632, to: 3652}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'perfumery'}
 - {$layer: 'pois', kind: 'petting_zoo'}
 - {$layer: 'pois', kind: 'physician'}
 # reserve for kind_details
-- _reserved: {from: 3656, to: 3676}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'physiotherapist_physiotherapy'}
 # reserve for kind_details
-- _reserved: {from: 3678, to: 3698}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'physiotherapist'}
 # reserve for kind_details
-- _reserved: {from: 3700, to: 3720}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'playground'}
 - {$layer: 'pois', kind: 'psychotherapist'}
 # reserve for kind_details
-- _reserved: {from: 3723, to: 3743}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'podiatrist'}
 # reserve for kind_details
-- _reserved: {from: 3745, to: 3765}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'political_party'}
 - {$layer: 'pois', kind: 'rehabilitation'}
 # reserve for kind_details
-- _reserved: {from: 3768, to: 3788}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'religion'}
 - {$layer: 'pois', kind: 'research'}
 - {$layer: 'pois', kind: 'sanitary_dump_station'}
@@ -780,15 +780,15 @@
 - {$layer: 'pois', kind: 'snowmobile'}
 - {$layer: 'pois', kind: 'social_facility'}
 # reserve for kind_details
-- _reserved: {from: 3795, to: 3815}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'speech_therapist'}
 # reserve for kind_details
-- _reserved: {from: 3817, to: 3837}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'speech'}
 - {$layer: 'pois', kind: 'stationery'}
 - {$layer: 'pois', kind: 'studio'}
 # reserve for kind_details
-- _reserved: {from: 3841, to: 3861}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'tax_advisor'}
 - {$layer: 'pois', kind: 'telecommunication'}
 - {$layer: 'pois', kind: 'therapist'}
@@ -801,7 +801,7 @@
 - {$layer: 'transit', kind: 'platform'}
 - {$layer: 'buildings', kind: 'building'}
 # reserve for kind_details
-- _reserved: {from: 3873, to: 4073}
+- _reserved: {count: 200}
 - {$layer: 'pois', kind: 'atv'}
 - {$layer: 'pois', kind: 'bicycle_rental_station'}
 - {$layer: 'pois', kind: 'boat_storage'}
@@ -812,12 +812,12 @@
 - {$layer: 'pois', kind: 'hanami'}
 - {$layer: 'pois', kind: 'healthcare_alternative'}
 # reserve for kind_details
-- _reserved: {from: 4083, to: 4103}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'it'}
 - {$layer: 'pois', kind: 'midwife_occupational'}
 - {$layer: 'pois', kind: 'occupational_therapist'}
 # reserve for kind_details
-- _reserved: {from: 4107, to: 4127}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'money_transfer'}
 - {$layer: 'pois', kind: 'roller_coaster'}
 - {$layer: 'pois', kind: 'amusement_ride'}
@@ -828,7 +828,7 @@
 - {$layer: 'pois', kind: 'car_repair'}
 - {$layer: 'pois', kind: 'healthcare_laboratory'}
 # reserve for kind_details
-- _reserved: {from: 4137, to: 4157}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'insurance'}
 - {$layer: 'pois', kind: 'car_wash'}
 - {$layer: 'pois', kind: 'subway_entrance'}
@@ -851,7 +851,7 @@
 - {$layer: 'pois', kind: 'water_slide'}
 - {$layer: 'pois', kind: 'water_well'}
 # reserve for kind_details
-- _reserved: {from: 4179, to: 4199}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'defibrillator'}
 - {$layer: 'pois', kind: 'elevator'}
 - {$layer: 'pois', kind: 'emergency_phone'}
@@ -864,7 +864,7 @@
 - {$layer: 'pois', kind: 'memorial'}
 - {$layer: 'pois', kind: 'mooring'}
 # reserve for kind_details
-- _reserved: {from: 4211, to: 4231}
+- _reserved: {count: 20}
 - {$layer: 'pois', kind: 'motorcycle_parking'}
 - {$layer: 'pois', kind: 'petroleum_well'}
 - {$layer: 'pois', kind: 'platform'}
@@ -893,16 +893,16 @@
 - {$layer: 'landuse', kind: 'snow_fence'}
 - {$layer: 'landuse', kind: 'fence'}
 # reserve for kind_details
-- _reserved: {from: 4259, to: 4309}
+- _reserved: {count: 50}
 - {$layer: 'landuse', kind: 'wall'}
 # reserve for kind_details
-- _reserved: {from: 4311, to: 4331}
+- _reserved: {count: 20}
 - {$layer: 'landuse', kind: 'power_minor_line'}
 - {$layer: 'landuse', kind: 'power_line'}
 - {$layer: 'transit', kind: 'bus_stop'}
 - {$layer: 'buildings', kind: 'building_part'}
 # reserve for kind_details
-- _reserved: {from: 4336, to: 4386}
+- _reserved: {count: 50}
 - {$layer: 'pois', kind: 'atm'}
 - {$layer: 'pois', kind: 'bus_stop'}
 - {$layer: 'pois', kind: 'firepit'}
@@ -913,7 +913,7 @@
 - {$layer: 'pois', kind: 'telephone'}
 - {$layer: 'pois', kind: 'toilets'}
 # reserve for kind_details
-- _reserved: {from: 4396, to: 4406}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'waste_disposal'}
 - {$layer: 'pois', kind: 'bbq'}
 - {$layer: 'pois', kind: 'bicycle_repair_station'}
@@ -924,10 +924,10 @@
 - {$layer: 'pois', kind: 'bench'}
 - {$layer: 'buildings', kind: 'entrance'}
 # reserve for kind_details
-- _reserved: {from: 4416, to: 4436}
+- _reserved: {count: 20}
 - {$layer: 'buildings', kind: 'exit'}
 # reserve for kind_details
-- _reserved: {from: 4438, to: 4448}
+- _reserved: {count: 10}
 - {$layer: 'pois', kind: 'fire_hydrant'}
 - {$layer: 'pois', kind: 'gas_canister'}
 - {$layer: 'pois', kind: 'level_crossing'}

--- a/spreadsheets/collision_rank.yaml
+++ b/spreadsheets/collision_rank.yaml
@@ -683,7 +683,6 @@
 - {$layer: 'pois', kind: 'bakery'}
 - {$layer: 'pois', kind: 'beauty'}
 - {$layer: 'pois', kind: 'bed_and_breakfast'}
-- {$layer: 'pois', kind: 'blood'}
 - {$layer: 'pois', kind: 'blood_bank'}
 - {$layer: 'pois', kind: 'books'}
 - {$layer: 'pois', kind: 'butcher'}
@@ -746,18 +745,15 @@
 - {$layer: 'pois', kind: 'ngo'}
 - {$layer: 'pois', kind: 'notary'}
 - {$layer: 'pois', kind: 'optician'}
-- {$layer: 'pois', kind: 'paediatrics'}
 # reserve for kind_details
 - _reserved: {count: 20}
-- {$layer: 'pois', kind: 'optometrist_paediatrics'}
+- {$layer: 'pois', kind: 'optometrist'}
+- {$layer: 'pois', kind: 'paediatrics'}
 # reserve for kind_details
 - _reserved: {count: 20}
 - {$layer: 'pois', kind: 'perfumery'}
 - {$layer: 'pois', kind: 'petting_zoo'}
 - {$layer: 'pois', kind: 'physician'}
-# reserve for kind_details
-- _reserved: {count: 20}
-- {$layer: 'pois', kind: 'physiotherapist_physiotherapy'}
 # reserve for kind_details
 - _reserved: {count: 20}
 - {$layer: 'pois', kind: 'physiotherapist'}
@@ -785,7 +781,6 @@
 - {$layer: 'pois', kind: 'speech_therapist'}
 # reserve for kind_details
 - _reserved: {count: 20}
-- {$layer: 'pois', kind: 'speech'}
 - {$layer: 'pois', kind: 'stationery'}
 - {$layer: 'pois', kind: 'studio'}
 # reserve for kind_details
@@ -809,13 +804,11 @@
 - {$layer: 'pois', kind: 'bookmaker'}
 - {$layer: 'pois', kind: 'bureau_de_change'}
 - {$layer: 'pois', kind: 'car_parts'}
-- {$layer: 'pois', kind: 'donation'}
 - {$layer: 'pois', kind: 'hanami'}
 - {$layer: 'pois', kind: 'healthcare_alternative'}
 # reserve for kind_details
 - _reserved: {count: 20}
 - {$layer: 'pois', kind: 'it'}
-- {$layer: 'pois', kind: 'midwife_occupational'}
 - {$layer: 'pois', kind: 'occupational_therapist'}
 # reserve for kind_details
 - _reserved: {count: 20}

--- a/spreadsheets/collision_rank.yaml
+++ b/spreadsheets/collision_rank.yaml
@@ -135,17 +135,18 @@
 - {$layer: 'boundaries', kind: 'aboriginal_lands'}
 # reserve for kind_details
 - _reserved: {count: 20}
-- {$layer: 'boundaries', kind: 'county'}
-- {$layer: 'boundaries', kind: 'region'}
-- {$layer: 'boundaries', kind: 'macroregion'}
-- {$layer: 'boundaries', kind: 'map_unit'}
-- {$layer: 'boundaries', kind: 'indefinite'}
-- {$layer: 'boundaries', kind: 'indeterminate'}
-- {$layer: 'boundaries', kind: 'lease_limit'}
-- {$layer: 'boundaries', kind: 'overlay_limit'}
-- {$layer: 'boundaries', kind: 'line_of_control'}
-- {$layer: 'boundaries', kind: 'disputed'}
-- {$layer: 'boundaries', kind: 'country'}
+# NOTE: maritime boundaries come later!
+- {$layer: 'boundaries', kind: 'county', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'region', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'macroregion', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'map_unit', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'indefinite', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'indeterminate', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'lease_limit', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'overlay_limit', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'line_of_control', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'disputed', not: {maritime_boundary: true}}
+- {$layer: 'boundaries', kind: 'country', not: {maritime_boundary: true}}
 - {$layer: 'pois', kind: 'college'}
 - {$layer: 'pois', kind: 'hospital'}
 # reserve for kind_details
@@ -399,7 +400,7 @@
 - {$layer: 'water', kind: 'riverbank'}
 - {$layer: 'earth', kind: 'cliff'}
 - {$layer: 'earth', kind: 'arete'}
-- {$layer: 'boundaries', kind: 'maritime'}
+- {$layer: 'boundaries', maritime_boundary: true}
 # for shields & etc
 - _reserved: {count: 10}
 - {$layer: 'roads', kind: 'minor_road', kind_detail: 'unclassified'}

--- a/spreadsheets/collision_rank.yaml
+++ b/spreadsheets/collision_rank.yaml
@@ -903,6 +903,7 @@
 - {$layer: 'buildings', kind: 'building_part'}
 # reserve for kind_details
 - _reserved: {count: 50}
+- {$layer: 'pois', kind: 'traffic_signals'}
 - {$layer: 'pois', kind: 'atm'}
 - {$layer: 'pois', kind: 'bus_stop'}
 - {$layer: 'pois', kind: 'firepit'}
@@ -935,7 +936,6 @@
 - {$layer: 'pois', kind: 'post_box'}
 - {$layer: 'pois', kind: 'power_pole'}
 - {$layer: 'pois', kind: 'street_lamp'}
-- {$layer: 'pois', kind: 'traffic_signals'}
 - {$layer: 'pois', kind: 'waste_basket'}
 - {$layer: 'pois', kind: 'water_point'}
 - {$layer: 'pois', kind: 'watering_place'}

--- a/spreadsheets/collision_rank.yaml
+++ b/spreadsheets/collision_rank.yaml
@@ -1,0 +1,6 @@
+- layer: earth
+  kind: continent
+- layer: water
+  kind: ocean
+- layer: places
+  kind: country

--- a/spreadsheets/collision_rank.yaml
+++ b/spreadsheets/collision_rank.yaml
@@ -4,940 +4,940 @@
 - _reserved: {from: 101, to: 201}
 # reserved for data overlays
 - _reserved: {from: 202, to: 302}
-- {layer: 'earth', kind: 'continent'}
-- {layer: 'water', kind: 'ocean'}
-- {layer: 'places', kind: 'country'}
+- {$layer: 'earth', kind: 'continent'}
+- {$layer: 'water', kind: 'ocean'}
+- {$layer: 'places', kind: 'country'}
 # reserved for population_rank
 - _reserved: {from: 306, to: 325}
-- {layer: 'places', kind: 'locality'}
+- {$layer: 'places', kind: 'locality'}
 # reserved for population_rank; guess the pop from kind_detail ala
 # _default_min_zoom_for_place_kind() : city, farm, hamlet, isolated_dwelling,
 # locality, scientific_station, town, village,
 - _reserved: {from: 327, to: 346}
-- {layer: 'pois', kind: 'national_park'}
-- {layer: 'places', kind: 'region'}
+- {$layer: 'pois', kind: 'national_park'}
+- {$layer: 'places', kind: 'region'}
 # reserved for population_rank
 - _reserved: {from: 349, to: 368}
-- {layer: 'water', kind: 'sea'}
-- {layer: 'pois', kind: 'nature_reserve'}
-- {layer: 'water', kind: 'lake'}
+- {$layer: 'water', kind: 'sea'}
+- {$layer: 'pois', kind: 'nature_reserve'}
+- {$layer: 'water', kind: 'lake'}
 # for shields & etc
 - _reserved: {from: 372, to: 382}
-- {layer: 'roads', kind: 'highway', kind_detail: 'motorway'}
+- {$layer: 'roads', kind: 'highway', kind_detail: 'motorway'}
 # for shields & etc
 - _reserved: {from: 384, to: 394}
 # for shields & etc
 - _reserved: {from: 395, to: 405}
-- {layer: 'roads', kind: 'highway', kind_detail: 'motorway_link'}
+- {$layer: 'roads', kind: 'highway', kind_detail: 'motorway_link'}
 # for shields & etc
 - _reserved: {from: 407, to: 417}
 # for shields & etc
 - _reserved: {from: 418, to: 428}
-- {layer: 'roads', kind: 'highway', kind_detail: 'trunk'}
+- {$layer: 'roads', kind: 'highway', kind_detail: 'trunk'}
 # for shields & etc
 - _reserved: {from: 430, to: 440}
 # for shields & etc
 - _reserved: {from: 441, to: 451}
-- {layer: 'roads', kind: 'highway'}
+- {$layer: 'roads', kind: 'highway'}
 # for shields & etc
 - _reserved: {from: 453, to: 463}
-- {layer: 'pois', kind: 'forest'}
-- {layer: 'earth', kind: 'island'}
-- {layer: 'water', kind: 'water'}
-- {layer: 'pois', kind: 'protected_area'}
-- {layer: 'water', kind: 'bay'}
-- {layer: 'water', kind: 'fjord'}
-- {layer: 'water', kind: 'strait'}
-- {layer: 'water', kind: 'playa'}
-- {layer: 'pois', kind: 'aerodrome'}
-- {layer: 'pois', kind: 'military'}
-- {layer: 'pois', kind: 'naval_base'}
-- {layer: 'pois', kind: 'airport'}
-- {layer: 'pois', kind: 'airfield'}
-- {layer: 'pois', kind: 'park'}
-- {layer: 'pois', kind: 'volcano'}
-- {layer: 'pois', kind: 'wood'}
+- {$layer: 'pois', kind: 'forest'}
+- {$layer: 'earth', kind: 'island'}
+- {$layer: 'water', kind: 'water'}
+- {$layer: 'pois', kind: 'protected_area'}
+- {$layer: 'water', kind: 'bay'}
+- {$layer: 'water', kind: 'fjord'}
+- {$layer: 'water', kind: 'strait'}
+- {$layer: 'water', kind: 'playa'}
+- {$layer: 'pois', kind: 'aerodrome'}
+- {$layer: 'pois', kind: 'military'}
+- {$layer: 'pois', kind: 'naval_base'}
+- {$layer: 'pois', kind: 'airport'}
+- {$layer: 'pois', kind: 'airfield'}
+- {$layer: 'pois', kind: 'park'}
+- {$layer: 'pois', kind: 'volcano'}
+- {$layer: 'pois', kind: 'wood'}
 # reserve for kind_details
 - _reserved: {from: 480, to: 490}
-- {layer: 'pois', kind: 'peak'}
-- {layer: 'water', kind: 'river'}
+- {$layer: 'pois', kind: 'peak'}
+- {$layer: 'water', kind: 'river'}
 # for shields & etc
 - _reserved: {from: 493, to: 503}
-- {layer: 'transit', kind: 'train'}
+- {$layer: 'transit', kind: 'train'}
 # for shields & etc
 - _reserved: {from: 505, to: 515}
-- {layer: 'pois', kind: 'beach'}
+- {$layer: 'pois', kind: 'beach'}
 # reserve for kind_details
 - _reserved: {from: 517, to: 527}
-- {layer: 'pois', kind: 'university'}
-- {layer: 'pois', kind: 'battlefield'}
+- {$layer: 'pois', kind: 'university'}
+- {$layer: 'pois', kind: 'battlefield'}
 # for shields & etc
 - _reserved: {from: 530, to: 540}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'primary'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'primary'}
 # for shields & etc
 - _reserved: {from: 542, to: 552}
 # for shields & etc
 - _reserved: {from: 553, to: 563}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'primary_link'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'primary_link'}
 # for shields & etc
 - _reserved: {from: 565, to: 575}
 # for shields & etc
 - _reserved: {from: 576, to: 586}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'secondary'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'secondary'}
 # for shields & etc
 - _reserved: {from: 588, to: 598}
 # for shields & etc
 - _reserved: {from: 599, to: 609}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'secondary_link'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'secondary_link'}
 # for shields & etc
 - _reserved: {from: 611, to: 621}
 # for shields & etc
 - _reserved: {from: 622, to: 632}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'tertiary'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'tertiary'}
 # for shields & etc
 - _reserved: {from: 634, to: 644}
 # for shields & etc
 - _reserved: {from: 645, to: 655}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'tertiary_link'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'tertiary_link'}
 # for shields & etc
 - _reserved: {from: 657, to: 667}
 # for shields & etc
 - _reserved: {from: 668, to: 678}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'trunk'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'trunk'}
 # for shields & etc
 - _reserved: {from: 680, to: 690}
 # for shields & etc
 - _reserved: {from: 691, to: 701}
-- {layer: 'roads', kind: 'major_road', kind_detail: 'trunk_link'}
+- {$layer: 'roads', kind: 'major_road', kind_detail: 'trunk_link'}
 # for shields & etc
 - _reserved: {from: 703, to: 713}
 # for shields & etc
 - _reserved: {from: 714, to: 724}
-- {layer: 'roads', kind: 'major_road'}
+- {$layer: 'roads', kind: 'major_road'}
 # for shields & etc
 - _reserved: {from: 726, to: 736}
-- {layer: 'water', kind: 'reef'}
+- {$layer: 'water', kind: 'reef'}
 # reserve for kind_details
 - _reserved: {from: 738, to: 748}
-- {layer: 'water', kind: 'canal'}
-- {layer: 'earth', kind: 'archipelago'}
-- {layer: 'pois', kind: 'ferry_terminal'}
-- {layer: 'pois', kind: 'rest_area'}
-- {layer: 'pois', kind: 'service_area'}
-- {layer: 'pois', kind: 'stadium'}
-- {layer: 'pois', kind: 'station'}
-- {layer: 'pois', kind: 'zoo'}
+- {$layer: 'water', kind: 'canal'}
+- {$layer: 'earth', kind: 'archipelago'}
+- {$layer: 'pois', kind: 'ferry_terminal'}
+- {$layer: 'pois', kind: 'rest_area'}
+- {$layer: 'pois', kind: 'service_area'}
+- {$layer: 'pois', kind: 'stadium'}
+- {$layer: 'pois', kind: 'station'}
+- {$layer: 'pois', kind: 'zoo'}
 # for shields & etc
 - _reserved: {from: 757, to: 767}
-- {layer: 'transit', kind: 'subway'}
+- {$layer: 'transit', kind: 'subway'}
 # for shields & etc
 - _reserved: {from: 769, to: 779}
-- {layer: 'boundaries', kind: 'aboriginal_lands'}
+- {$layer: 'boundaries', kind: 'aboriginal_lands'}
 # reserve for kind_details
 - _reserved: {from: 781, to: 801}
-- {layer: 'boundaries', kind: 'county'}
-- {layer: 'boundaries', kind: 'region'}
-- {layer: 'boundaries', kind: 'macroregion'}
-- {layer: 'boundaries', kind: 'map_unit'}
-- {layer: 'boundaries', kind: 'indefinite'}
-- {layer: 'boundaries', kind: 'indeterminate'}
-- {layer: 'boundaries', kind: 'lease_limit'}
-- {layer: 'boundaries', kind: 'overlay_limit'}
-- {layer: 'boundaries', kind: 'line_of_control'}
-- {layer: 'boundaries', kind: 'disputed'}
-- {layer: 'boundaries', kind: 'country'}
-- {layer: 'pois', kind: 'college'}
-- {layer: 'pois', kind: 'hospital'}
+- {$layer: 'boundaries', kind: 'county'}
+- {$layer: 'boundaries', kind: 'region'}
+- {$layer: 'boundaries', kind: 'macroregion'}
+- {$layer: 'boundaries', kind: 'map_unit'}
+- {$layer: 'boundaries', kind: 'indefinite'}
+- {$layer: 'boundaries', kind: 'indeterminate'}
+- {$layer: 'boundaries', kind: 'lease_limit'}
+- {$layer: 'boundaries', kind: 'overlay_limit'}
+- {$layer: 'boundaries', kind: 'line_of_control'}
+- {$layer: 'boundaries', kind: 'disputed'}
+- {$layer: 'boundaries', kind: 'country'}
+- {$layer: 'pois', kind: 'college'}
+- {$layer: 'pois', kind: 'hospital'}
 # reserve for kind_details
 - _reserved: {from: 815, to: 835}
-- {layer: 'pois', kind: 'landmark'}
-- {layer: 'pois', kind: 'mall'}
-- {layer: 'pois', kind: 'museum'}
-- {layer: 'pois', kind: 'winter_sports'}
-- {layer: 'pois', kind: 'casino'}
-- {layer: 'pois', kind: 'golf_course'}
-- {layer: 'pois', kind: 'marina'}
-- {layer: 'pois', kind: 'sports_centre'}
-- {layer: 'pois', kind: 'garden'}
-- {layer: 'pois', kind: 'recreation_ground'}
-- {layer: 'pois', kind: 'waterfall'}
+- {$layer: 'pois', kind: 'landmark'}
+- {$layer: 'pois', kind: 'mall'}
+- {$layer: 'pois', kind: 'museum'}
+- {$layer: 'pois', kind: 'winter_sports'}
+- {$layer: 'pois', kind: 'casino'}
+- {$layer: 'pois', kind: 'golf_course'}
+- {$layer: 'pois', kind: 'marina'}
+- {$layer: 'pois', kind: 'sports_centre'}
+- {$layer: 'pois', kind: 'garden'}
+- {$layer: 'pois', kind: 'recreation_ground'}
+- {$layer: 'pois', kind: 'waterfall'}
 # for shields & etc
 - _reserved: {from: 847, to: 857}
-- {layer: 'roads', kind: 'ferry'}
+- {$layer: 'roads', kind: 'ferry'}
 # for shields & etc
 - _reserved: {from: 859, to: 869}
 # for shields & etc
 - _reserved: {from: 870, to: 880}
-- {layer: 'transit', kind: 'light_rail'}
+- {$layer: 'transit', kind: 'light_rail'}
 # for shields & etc
 - _reserved: {from: 882, to: 892}
-- {layer: 'pois', kind: 'townhall'}
+- {$layer: 'pois', kind: 'townhall'}
 # for shields & etc
 - _reserved: {from: 894, to: 904}
-- {layer: 'transit', kind: 'tram'}
+- {$layer: 'transit', kind: 'tram'}
 # for shields & etc
 - _reserved: {from: 906, to: 916}
-- {layer: 'pois', kind: 'cemetery'}
+- {$layer: 'pois', kind: 'cemetery'}
 # reserve for kind_details
 - _reserved: {from: 918, to: 968}
-- {layer: 'pois', kind: 'dam'}
-- {layer: 'pois', kind: 'motorway_junction'}
-- {layer: 'pois', kind: 'place_of_worship'}
-- {layer: 'pois', kind: 'plant'}
-- {layer: 'pois', kind: 'port_terminal'}
-- {layer: 'pois', kind: 'quarry'}
-- {layer: 'pois', kind: 'wastewater_plant'}
-- {layer: 'pois', kind: 'water_works'}
-- {layer: 'pois', kind: 'works'}
-- {layer: 'places', kind: 'borough'}
+- {$layer: 'pois', kind: 'dam'}
+- {$layer: 'pois', kind: 'motorway_junction'}
+- {$layer: 'pois', kind: 'place_of_worship'}
+- {$layer: 'pois', kind: 'plant'}
+- {$layer: 'pois', kind: 'port_terminal'}
+- {$layer: 'pois', kind: 'quarry'}
+- {$layer: 'pois', kind: 'wastewater_plant'}
+- {$layer: 'pois', kind: 'water_works'}
+- {$layer: 'pois', kind: 'works'}
+- {$layer: 'places', kind: 'borough'}
 # for shields, kind_detail & etc
 - _reserved: {from: 979, to: 1029}
-- {layer: 'roads', kind: 'path'}
+- {$layer: 'roads', kind: 'path'}
 # for shields, kind_detail & etc
 - _reserved: {from: 1031, to: 1081}
-- {layer: 'pois', kind: 'camp_site'}
-- {layer: 'pois', kind: 'chemist'}
-- {layer: 'pois', kind: 'community_centre'}
-- {layer: 'pois', kind: 'cosmetics'}
-- {layer: 'pois', kind: 'danger_area'}
-- {layer: 'pois', kind: 'department_store'}
-- {layer: 'pois', kind: 'doityourself'}
-- {layer: 'pois', kind: 'fort'}
-- {layer: 'pois', kind: 'garden_centre'}
-- {layer: 'pois', kind: 'golf'}
-- {layer: 'pois', kind: 'grave_yard'}
+- {$layer: 'pois', kind: 'camp_site'}
+- {$layer: 'pois', kind: 'chemist'}
+- {$layer: 'pois', kind: 'community_centre'}
+- {$layer: 'pois', kind: 'cosmetics'}
+- {$layer: 'pois', kind: 'danger_area'}
+- {$layer: 'pois', kind: 'department_store'}
+- {$layer: 'pois', kind: 'doityourself'}
+- {$layer: 'pois', kind: 'fort'}
+- {$layer: 'pois', kind: 'garden_centre'}
+- {$layer: 'pois', kind: 'golf'}
+- {$layer: 'pois', kind: 'grave_yard'}
 # reserve for kind_details
 - _reserved: {from: 1093, to: 1143}
-- {layer: 'pois', kind: 'hotel'}
-- {layer: 'pois', kind: 'marketplace'}
-- {layer: 'pois', kind: 'motel'}
-- {layer: 'pois', kind: 'music'}
-- {layer: 'pois', kind: 'pet'}
-- {layer: 'pois', kind: 'pharmacy'}
+- {$layer: 'pois', kind: 'hotel'}
+- {$layer: 'pois', kind: 'marketplace'}
+- {$layer: 'pois', kind: 'motel'}
+- {$layer: 'pois', kind: 'music'}
+- {$layer: 'pois', kind: 'pet'}
+- {$layer: 'pois', kind: 'pharmacy'}
 # reserve for kind_details
 - _reserved: {from: 1150, to: 1170}
-- {layer: 'pois', kind: 'range'}
-- {layer: 'pois', kind: 'school'}
-- {layer: 'pois', kind: 'shoes'}
-- {layer: 'pois', kind: 'ski'}
-- {layer: 'pois', kind: 'supermarket'}
-- {layer: 'pois', kind: 'theme_park'}
-- {layer: 'pois', kind: 'toys'}
-- {layer: 'pois', kind: 'variety_store'}
-- {layer: 'pois', kind: 'water_park'}
-- {layer: 'pois', kind: 'winery'}
-- {layer: 'pois', kind: 'alcohol'}
-- {layer: 'pois', kind: 'alpine_hut'}
-- {layer: 'pois', kind: 'brewery'}
-- {layer: 'pois', kind: 'charity'}
-- {layer: 'pois', kind: 'coffee'}
-- {layer: 'pois', kind: 'confectionery'}
-- {layer: 'pois', kind: 'deli'}
-- {layer: 'pois', kind: 'electronics'}
-- {layer: 'pois', kind: 'furniture'}
-- {layer: 'pois', kind: 'hardware'}
-- {layer: 'pois', kind: 'ice_cream'}
-- {layer: 'pois', kind: 'kindergarten'}
-- {layer: 'pois', kind: 'wine'}
-- {layer: 'pois', kind: 'gardener'}
-- {layer: 'pois', kind: 'sports'}
-- {layer: 'earth', kind: 'valley'}
-- {layer: 'boundaries', kind: 'locality'}
-- {layer: 'pois', kind: 'handicraft'}
-- {layer: 'pois', kind: 'ski_school'}
-- {layer: 'pois', kind: 'veterinary'}
+- {$layer: 'pois', kind: 'range'}
+- {$layer: 'pois', kind: 'school'}
+- {$layer: 'pois', kind: 'shoes'}
+- {$layer: 'pois', kind: 'ski'}
+- {$layer: 'pois', kind: 'supermarket'}
+- {$layer: 'pois', kind: 'theme_park'}
+- {$layer: 'pois', kind: 'toys'}
+- {$layer: 'pois', kind: 'variety_store'}
+- {$layer: 'pois', kind: 'water_park'}
+- {$layer: 'pois', kind: 'winery'}
+- {$layer: 'pois', kind: 'alcohol'}
+- {$layer: 'pois', kind: 'alpine_hut'}
+- {$layer: 'pois', kind: 'brewery'}
+- {$layer: 'pois', kind: 'charity'}
+- {$layer: 'pois', kind: 'coffee'}
+- {$layer: 'pois', kind: 'confectionery'}
+- {$layer: 'pois', kind: 'deli'}
+- {$layer: 'pois', kind: 'electronics'}
+- {$layer: 'pois', kind: 'furniture'}
+- {$layer: 'pois', kind: 'hardware'}
+- {$layer: 'pois', kind: 'ice_cream'}
+- {$layer: 'pois', kind: 'kindergarten'}
+- {$layer: 'pois', kind: 'wine'}
+- {$layer: 'pois', kind: 'gardener'}
+- {$layer: 'pois', kind: 'sports'}
+- {$layer: 'earth', kind: 'valley'}
+- {$layer: 'boundaries', kind: 'locality'}
+- {$layer: 'pois', kind: 'handicraft'}
+- {$layer: 'pois', kind: 'ski_school'}
+- {$layer: 'pois', kind: 'veterinary'}
 # reserve for kind_details
 - _reserved: {from: 1201, to: 1221}
 # for shields & etc
 - _reserved: {from: 1222, to: 1232}
-- {layer: 'roads', kind: 'portage_way'}
+- {$layer: 'roads', kind: 'portage_way'}
 # for shields & etc
 - _reserved: {from: 1234, to: 1244}
-- {layer: 'pois', kind: 'dressmaker'}
-- {layer: 'pois', kind: 'dry_cleaning'}
-- {layer: 'pois', kind: 'fishmonger'}
-- {layer: 'pois', kind: 'laundry'}
-- {layer: 'pois', kind: 'prison'}
-- {layer: 'water', kind: 'dock'}
-- {layer: 'pois', kind: 'container_terminal'}
-- {layer: 'pois', kind: 'electrician'}
-- {layer: 'pois', kind: 'hvac'}
-- {layer: 'pois', kind: 'metal_construction'}
-- {layer: 'pois', kind: 'offshore_platform'}
-- {layer: 'pois', kind: 'painter'}
-- {layer: 'pois', kind: 'photographer'}
-- {layer: 'pois', kind: 'photographic_laboratory'}
-- {layer: 'pois', kind: 'plumber'}
-- {layer: 'pois', kind: 'pottery'}
-- {layer: 'pois', kind: 'sawmill'}
-- {layer: 'pois', kind: 'shoemaker'}
-- {layer: 'pois', kind: 'ski_rental'}
-- {layer: 'pois', kind: 'stonemason'}
-- {layer: 'pois', kind: 'tailor'}
-- {layer: 'pois', kind: 'trade'}
-- {layer: 'pois', kind: 'waterway_fuel'}
-- {layer: 'pois', kind: 'carpenter'}
-- {layer: 'places', kind: 'macrohood'}
-- {layer: 'pois', kind: 'aquarium'}
-- {layer: 'pois', kind: 'bank'}
-- {layer: 'pois', kind: 'beach_resort'}
-- {layer: 'pois', kind: 'caravan_site'}
-- {layer: 'pois', kind: 'cinema'}
-- {layer: 'pois', kind: 'fuel'}
-- {layer: 'pois', kind: 'library'}
-- {layer: 'pois', kind: 'resort'}
-- {layer: 'pois', kind: 'summer_camp'}
-- {layer: 'landuse', kind: 'ferry_terminal'}
-- {layer: 'landuse', kind: 'aerodrome'}
-- {layer: 'pois', kind: 'fire_station'}
-- {layer: 'pois', kind: 'ranger_station'}
-- {layer: 'pois', kind: 'fitness'}
-- {layer: 'pois', kind: 'embassy'}
-- {layer: 'water', kind: 'basin'}
-- {layer: 'water', kind: 'stream'}
+- {$layer: 'pois', kind: 'dressmaker'}
+- {$layer: 'pois', kind: 'dry_cleaning'}
+- {$layer: 'pois', kind: 'fishmonger'}
+- {$layer: 'pois', kind: 'laundry'}
+- {$layer: 'pois', kind: 'prison'}
+- {$layer: 'water', kind: 'dock'}
+- {$layer: 'pois', kind: 'container_terminal'}
+- {$layer: 'pois', kind: 'electrician'}
+- {$layer: 'pois', kind: 'hvac'}
+- {$layer: 'pois', kind: 'metal_construction'}
+- {$layer: 'pois', kind: 'offshore_platform'}
+- {$layer: 'pois', kind: 'painter'}
+- {$layer: 'pois', kind: 'photographer'}
+- {$layer: 'pois', kind: 'photographic_laboratory'}
+- {$layer: 'pois', kind: 'plumber'}
+- {$layer: 'pois', kind: 'pottery'}
+- {$layer: 'pois', kind: 'sawmill'}
+- {$layer: 'pois', kind: 'shoemaker'}
+- {$layer: 'pois', kind: 'ski_rental'}
+- {$layer: 'pois', kind: 'stonemason'}
+- {$layer: 'pois', kind: 'tailor'}
+- {$layer: 'pois', kind: 'trade'}
+- {$layer: 'pois', kind: 'waterway_fuel'}
+- {$layer: 'pois', kind: 'carpenter'}
+- {$layer: 'places', kind: 'macrohood'}
+- {$layer: 'pois', kind: 'aquarium'}
+- {$layer: 'pois', kind: 'bank'}
+- {$layer: 'pois', kind: 'beach_resort'}
+- {$layer: 'pois', kind: 'caravan_site'}
+- {$layer: 'pois', kind: 'cinema'}
+- {$layer: 'pois', kind: 'fuel'}
+- {$layer: 'pois', kind: 'library'}
+- {$layer: 'pois', kind: 'resort'}
+- {$layer: 'pois', kind: 'summer_camp'}
+- {$layer: 'landuse', kind: 'ferry_terminal'}
+- {$layer: 'landuse', kind: 'aerodrome'}
+- {$layer: 'pois', kind: 'fire_station'}
+- {$layer: 'pois', kind: 'ranger_station'}
+- {$layer: 'pois', kind: 'fitness'}
+- {$layer: 'pois', kind: 'embassy'}
+- {$layer: 'water', kind: 'basin'}
+- {$layer: 'water', kind: 'stream'}
 # for shields & etc
 - _reserved: {from: 1287, to: 1337}
-- {layer: 'roads', kind: 'piste'}
+- {$layer: 'roads', kind: 'piste'}
 # for shields & etc
 - _reserved: {from: 1339, to: 1389}
 # for shields, kind_detail & etc
 - _reserved: {from: 1390, to: 1440}
-- {layer: 'roads', kind: 'aerialway'}
+- {$layer: 'roads', kind: 'aerialway'}
 # for shields, kind_detail & etc
 - _reserved: {from: 1442, to: 1492}
 # for shields & etc
 - _reserved: {from: 1493, to: 1503}
-- {layer: 'roads', kind: 'aeroway', kind_detail: 'runway'}
+- {$layer: 'roads', kind: 'aeroway', kind_detail: 'runway'}
 # for shields & etc
 - _reserved: {from: 1505, to: 1515}
 # for shields & etc
 - _reserved: {from: 1516, to: 1526}
-- {layer: 'roads', kind: 'aeroway', kind_detail: 'taxiway'}
+- {$layer: 'roads', kind: 'aeroway', kind_detail: 'taxiway'}
 # for shields & etc
 - _reserved: {from: 1528, to: 1538}
 # for shields & etc
 - _reserved: {from: 1539, to: 1549}
-- {layer: 'roads', kind: 'aeroway'}
+- {$layer: 'roads', kind: 'aeroway'}
 # for shields & etc
 - _reserved: {from: 1551, to: 1561}
-- {layer: 'pois', kind: 'courthouse'}
-- {layer: 'pois', kind: 'lighthouse'}
-- {layer: 'pois', kind: 'obelisk'}
+- {$layer: 'pois', kind: 'courthouse'}
+- {$layer: 'pois', kind: 'lighthouse'}
+- {$layer: 'pois', kind: 'obelisk'}
 # reserve for kind_details
 - _reserved: {from: 1565, to: 1575}
-- {layer: 'pois', kind: 'police'}
-- {layer: 'pois', kind: 'post_office'}
-- {layer: 'pois', kind: 'ruins'}
+- {$layer: 'pois', kind: 'police'}
+- {$layer: 'pois', kind: 'post_office'}
+- {$layer: 'pois', kind: 'ruins'}
 # reserve for kind_details
 - _reserved: {from: 1579, to: 1589}
-- {layer: 'pois', kind: 'watermill'}
-- {layer: 'pois', kind: 'windmill'}
-- {layer: 'places', kind: 'neighbourhood'}
-- {layer: 'pois', kind: 'border_control'}
-- {layer: 'pois', kind: 'customs'}
-- {layer: 'earth', kind: 'ridge'}
-- {layer: 'pois', kind: 'boatyard'}
-- {layer: 'pois', kind: 'shipyard'}
-- {layer: 'pois', kind: 'spring'}
-- {layer: 'pois', kind: 'substation'}
-- {layer: 'pois', kind: 'gate'}
+- {$layer: 'pois', kind: 'watermill'}
+- {$layer: 'pois', kind: 'windmill'}
+- {$layer: 'places', kind: 'neighbourhood'}
+- {$layer: 'pois', kind: 'border_control'}
+- {$layer: 'pois', kind: 'customs'}
+- {$layer: 'earth', kind: 'ridge'}
+- {$layer: 'pois', kind: 'boatyard'}
+- {$layer: 'pois', kind: 'shipyard'}
+- {$layer: 'pois', kind: 'spring'}
+- {$layer: 'pois', kind: 'substation'}
+- {$layer: 'pois', kind: 'gate'}
 # reserve for kind_details
 - _reserved: {from: 1601, to: 1611}
-- {layer: 'pois', kind: 'horse_riding'}
-- {layer: 'pois', kind: 'wharf'}
-- {layer: 'pois', kind: 'adult_gaming_centre'}
-- {layer: 'pois', kind: 'egress'}
-- {layer: 'pois', kind: 'parking'}
-- {layer: 'pois', kind: 'parking_garage'}
-- {layer: 'pois', kind: 'put_in'}
-- {layer: 'pois', kind: 'put_in_egress'}
-- {layer: 'pois', kind: 'quay'}
-- {layer: 'pois', kind: 'saddle'}
-- {layer: 'pois', kind: 'arts_centre'}
-- {layer: 'pois', kind: 'bar'}
+- {$layer: 'pois', kind: 'horse_riding'}
+- {$layer: 'pois', kind: 'wharf'}
+- {$layer: 'pois', kind: 'adult_gaming_centre'}
+- {$layer: 'pois', kind: 'egress'}
+- {$layer: 'pois', kind: 'parking'}
+- {$layer: 'pois', kind: 'parking_garage'}
+- {$layer: 'pois', kind: 'put_in'}
+- {$layer: 'pois', kind: 'put_in_egress'}
+- {$layer: 'pois', kind: 'quay'}
+- {$layer: 'pois', kind: 'saddle'}
+- {$layer: 'pois', kind: 'arts_centre'}
+- {$layer: 'pois', kind: 'bar'}
 # reserve for kind_details
 - _reserved: {from: 1624, to: 1724}
-- {layer: 'pois', kind: 'bicycle'}
-- {layer: 'pois', kind: 'biergarten'}
+- {$layer: 'pois', kind: 'bicycle'}
+- {$layer: 'pois', kind: 'biergarten'}
 # reserve for kind_details
 - _reserved: {from: 1727, to: 1827}
-- {layer: 'pois', kind: 'cafe'}
+- {$layer: 'pois', kind: 'cafe'}
 # reserve for kind_details
 - _reserved: {from: 1829, to: 1929}
-- {layer: 'pois', kind: 'fast_food'}
+- {$layer: 'pois', kind: 'fast_food'}
 # reserve for kind_details
 - _reserved: {from: 1931, to: 2031}
-- {layer: 'pois', kind: 'field_hospital'}
+- {$layer: 'pois', kind: 'field_hospital'}
 # reserve for kind_details
 - _reserved: {from: 2033, to: 2053}
-- {layer: 'pois', kind: 'gallery'}
-- {layer: 'pois', kind: 'health_centre'}
+- {$layer: 'pois', kind: 'gallery'}
+- {$layer: 'pois', kind: 'health_centre'}
 # reserve for kind_details
 - _reserved: {from: 2056, to: 2076}
-- {layer: 'pois', kind: 'nightclub'}
+- {$layer: 'pois', kind: 'nightclub'}
 # reserve for kind_details
 - _reserved: {from: 2078, to: 2178}
-- {layer: 'pois', kind: 'observatory'}
-- {layer: 'pois', kind: 'outdoor'}
-- {layer: 'pois', kind: 'pub'}
+- {$layer: 'pois', kind: 'observatory'}
+- {$layer: 'pois', kind: 'outdoor'}
+- {$layer: 'pois', kind: 'pub'}
 # reserve for kind_details
 - _reserved: {from: 2182, to: 2282}
-- {layer: 'pois', kind: 'restaurant'}
+- {$layer: 'pois', kind: 'restaurant'}
 # reserve for kind_details
 - _reserved: {from: 2284, to: 2384}
-- {layer: 'pois', kind: 'theatre'}
-- {layer: 'pois', kind: 'toll_booth'}
-- {layer: 'pois', kind: 'trailhead'}
-- {layer: 'pois', kind: 'viewpoint'}
-- {layer: 'pois', kind: 'water_tower'}
-- {layer: 'pois', kind: 'wilderness_hut'}
-- {layer: 'pois', kind: 'nursing_home'}
+- {$layer: 'pois', kind: 'theatre'}
+- {$layer: 'pois', kind: 'toll_booth'}
+- {$layer: 'pois', kind: 'trailhead'}
+- {$layer: 'pois', kind: 'viewpoint'}
+- {$layer: 'pois', kind: 'water_tower'}
+- {$layer: 'pois', kind: 'wilderness_hut'}
+- {$layer: 'pois', kind: 'nursing_home'}
 # reserve for kind_details
 - _reserved: {from: 2392, to: 2412}
-- {layer: 'pois', kind: 'telescope'}
-- {layer: 'landuse', kind: 'city_wall'}
-- {layer: 'water', kind: 'riverbank'}
-- {layer: 'earth', kind: 'cliff'}
-- {layer: 'earth', kind: 'arete'}
-- {layer: 'boundaries', kind: 'maritime'}
+- {$layer: 'pois', kind: 'telescope'}
+- {$layer: 'landuse', kind: 'city_wall'}
+- {$layer: 'water', kind: 'riverbank'}
+- {$layer: 'earth', kind: 'cliff'}
+- {$layer: 'earth', kind: 'arete'}
+- {$layer: 'boundaries', kind: 'maritime'}
 # for shields & etc
 - _reserved: {from: 2419, to: 2429}
-- {layer: 'roads', kind: 'minor_road', kind_detail: 'unclassified'}
+- {$layer: 'roads', kind: 'minor_road', kind_detail: 'unclassified'}
 # for shields & etc
 - _reserved: {from: 2431, to: 2441}
 # for shields & etc
 - _reserved: {from: 2442, to: 2452}
-- {layer: 'roads', kind: 'minor_road', kind_detail: 'living_street'}
+- {$layer: 'roads', kind: 'minor_road', kind_detail: 'living_street'}
 # for shields & etc
 - _reserved: {from: 2454, to: 2464}
 # for shields & etc
 - _reserved: {from: 2465, to: 2475}
-- {layer: 'roads', kind: 'minor_road', kind_detail: 'residential'}
+- {$layer: 'roads', kind: 'minor_road', kind_detail: 'residential'}
 # for shields & etc
 - _reserved: {from: 2477, to: 2487}
 # for shields & etc
 - _reserved: {from: 2488, to: 2498}
-- {layer: 'roads', kind: 'minor_road', kind_detail: 'road'}
+- {$layer: 'roads', kind: 'minor_road', kind_detail: 'road'}
 # for shields & etc
 - _reserved: {from: 2500, to: 2510}
 # for shields & etc
 - _reserved: {from: 2511, to: 2521}
-- {layer: 'roads', kind: 'minor_road', kind_detail: 'service'}
+- {$layer: 'roads', kind: 'minor_road', kind_detail: 'service'}
 # for shields & etc
 - _reserved: {from: 2523, to: 2533}
 # for shields & etc
 - _reserved: {from: 2534, to: 2544}
-- {layer: 'roads', kind: 'minor_road', kind_detail: 'raceway'}
+- {$layer: 'roads', kind: 'minor_road', kind_detail: 'raceway'}
 # for shields & etc
 - _reserved: {from: 2546, to: 2556}
 # for shields & etc
 - _reserved: {from: 2557, to: 2567}
-- {layer: 'roads', kind: 'minor_road'}
+- {$layer: 'roads', kind: 'minor_road'}
 # for shields & etc
 - _reserved: {from: 2569, to: 2579}
 # for shields & etc
 - _reserved: {from: 2580, to: 2630}
-- {layer: 'roads', kind: 'racetrack'}
+- {$layer: 'roads', kind: 'racetrack'}
 # for shields & etc
 - _reserved: {from: 2632, to: 2682}
 # for shields & etc
 - _reserved: {from: 2683, to: 2703}
-- {layer: 'roads', kind: 'rail'}
+- {$layer: 'roads', kind: 'rail'}
 # for shields & etc
 - _reserved: {from: 2705, to: 2725}
 # for shields & etc
 - _reserved: {from: 2726, to: 2736}
-- {layer: 'transit', kind: 'monorail'}
+- {$layer: 'transit', kind: 'monorail'}
 # for shields & etc
 - _reserved: {from: 2738, to: 2748}
-- {layer: 'transit', kind: 'funicular'}
+- {$layer: 'transit', kind: 'funicular'}
 # for shields & etc
 - _reserved: {from: 2750, to: 2760}
-- {layer: 'pois', kind: 'beacon'}
-- {layer: 'pois', kind: 'cave_entrance'}
-- {layer: 'pois', kind: 'communications_tower'}
-- {layer: 'pois', kind: 'cross'}
-- {layer: 'pois', kind: 'dune'}
-- {layer: 'pois', kind: 'farm'}
-- {layer: 'pois', kind: 'generator'}
+- {$layer: 'pois', kind: 'beacon'}
+- {$layer: 'pois', kind: 'cave_entrance'}
+- {$layer: 'pois', kind: 'communications_tower'}
+- {$layer: 'pois', kind: 'cross'}
+- {$layer: 'pois', kind: 'dune'}
+- {$layer: 'pois', kind: 'farm'}
+- {$layer: 'pois', kind: 'generator'}
 # reserve for kind_details
 - _reserved: {from: 2768, to: 2788}
-- {layer: 'pois', kind: 'geyser'}
-- {layer: 'pois', kind: 'hazard'}
-- {layer: 'pois', kind: 'lock'}
-- {layer: 'pois', kind: 'mineshaft'}
-- {layer: 'pois', kind: 'monument'}
-- {layer: 'pois', kind: 'power_wind'}
-- {layer: 'pois', kind: 'rapid'}
-- {layer: 'pois', kind: 'sinkhole'}
-- {layer: 'landuse', kind: 'cutting'}
-- {layer: 'landuse', kind: 'ditch'}
-- {layer: 'landuse', kind: 'gate'}
-- {layer: 'landuse', kind: 'grave_yard'}
+- {$layer: 'pois', kind: 'geyser'}
+- {$layer: 'pois', kind: 'hazard'}
+- {$layer: 'pois', kind: 'lock'}
+- {$layer: 'pois', kind: 'mineshaft'}
+- {$layer: 'pois', kind: 'monument'}
+- {$layer: 'pois', kind: 'power_wind'}
+- {$layer: 'pois', kind: 'rapid'}
+- {$layer: 'pois', kind: 'sinkhole'}
+- {$layer: 'landuse', kind: 'cutting'}
+- {$layer: 'landuse', kind: 'ditch'}
+- {$layer: 'landuse', kind: 'gate'}
+- {$layer: 'landuse', kind: 'grave_yard'}
 # reserve for kind_details
 - _reserved: {from: 2801, to: 2851}
-- {layer: 'landuse', kind: 'guard_rail'}
-- {layer: 'landuse', kind: 'harbour'}
-- {layer: 'landuse', kind: 'kerb'}
-- {layer: 'landuse', kind: 'orchard'}
+- {$layer: 'landuse', kind: 'guard_rail'}
+- {$layer: 'landuse', kind: 'harbour'}
+- {$layer: 'landuse', kind: 'kerb'}
+- {$layer: 'landuse', kind: 'orchard'}
 # reserve for kind_details
 - _reserved: {from: 2856, to: 2906}
-- {layer: 'landuse', kind: 'plant_nursery'}
-- {layer: 'landuse', kind: 'port'}
-- {layer: 'landuse', kind: 'scree'}
-- {layer: 'landuse', kind: 'urban_area'}
-- {layer: 'landuse', kind: 'urban'}
-- {layer: 'landuse', kind: 'rural'}
-- {layer: 'landuse', kind: 'protected_area'}
-- {layer: 'landuse', kind: 'national_park'}
-- {layer: 'landuse', kind: 'residential'}
-- {layer: 'landuse', kind: 'industrial'}
-- {layer: 'landuse', kind: 'nature_reserve'}
-- {layer: 'landuse', kind: 'park'}
-- {layer: 'landuse', kind: 'battlefield'}
-- {layer: 'landuse', kind: 'rock'}
-- {layer: 'landuse', kind: 'stone'}
-- {layer: 'landuse', kind: 'glacier'}
-- {layer: 'landuse', kind: 'wood'}
-- {layer: 'landuse', kind: 'forest'}
+- {$layer: 'landuse', kind: 'plant_nursery'}
+- {$layer: 'landuse', kind: 'port'}
+- {$layer: 'landuse', kind: 'scree'}
+- {$layer: 'landuse', kind: 'urban_area'}
+- {$layer: 'landuse', kind: 'urban'}
+- {$layer: 'landuse', kind: 'rural'}
+- {$layer: 'landuse', kind: 'protected_area'}
+- {$layer: 'landuse', kind: 'national_park'}
+- {$layer: 'landuse', kind: 'residential'}
+- {$layer: 'landuse', kind: 'industrial'}
+- {$layer: 'landuse', kind: 'nature_reserve'}
+- {$layer: 'landuse', kind: 'park'}
+- {$layer: 'landuse', kind: 'battlefield'}
+- {$layer: 'landuse', kind: 'rock'}
+- {$layer: 'landuse', kind: 'stone'}
+- {$layer: 'landuse', kind: 'glacier'}
+- {$layer: 'landuse', kind: 'wood'}
+- {$layer: 'landuse', kind: 'forest'}
 # reserve for kind_details
 - _reserved: {from: 2925, to: 2935}
-- {layer: 'landuse', kind: 'natural_park'}
+- {$layer: 'landuse', kind: 'natural_park'}
 # reserve for kind_details
 - _reserved: {from: 2937, to: 2947}
-- {layer: 'landuse', kind: 'natural_forest'}
+- {$layer: 'landuse', kind: 'natural_forest'}
 # reserve for kind_details
 - _reserved: {from: 2949, to: 2959}
-- {layer: 'landuse', kind: 'natural_wood'}
+- {$layer: 'landuse', kind: 'natural_wood'}
 # reserve for kind_details
 - _reserved: {from: 2961, to: 2971}
-- {layer: 'landuse', kind: 'grass'}
-- {layer: 'landuse', kind: 'meadow'}
-- {layer: 'landuse', kind: 'scrub'}
-- {layer: 'landuse', kind: 'winter_sports'}
-- {layer: 'landuse', kind: 'farm'}
-- {layer: 'landuse', kind: 'farmland'}
-- {layer: 'landuse', kind: 'university'}
-- {layer: 'landuse', kind: 'college'}
-- {layer: 'landuse', kind: 'rest_area'}
-- {layer: 'landuse', kind: 'service_area'}
-- {layer: 'landuse', kind: 'commercial'}
-- {layer: 'landuse', kind: 'retail'}
-- {layer: 'landuse', kind: 'military'}
-- {layer: 'landuse', kind: 'naval_base'}
-- {layer: 'landuse', kind: 'danger_area'}
-- {layer: 'landuse', kind: 'range'}
-- {layer: 'landuse', kind: 'prison'}
-- {layer: 'landuse', kind: 'fort'}
-- {layer: 'landuse', kind: 'theme_park'}
-- {layer: 'landuse', kind: 'wildlife_park'}
-- {layer: 'landuse', kind: 'winery'}
-- {layer: 'landuse', kind: 'zoo'}
-- {layer: 'landuse', kind: 'resort'}
-- {layer: 'landuse', kind: 'trail_riding_station'}
-- {layer: 'landuse', kind: 'hospital'}
-- {layer: 'landuse', kind: 'aquarium'}
-- {layer: 'landuse', kind: 'golf_course'}
-- {layer: 'landuse', kind: 'boatyard'}
-- {layer: 'landuse', kind: 'shipyard'}
-- {layer: 'landuse', kind: 'container_terminal'}
-- {layer: 'landuse', kind: 'port_terminal'}
-- {layer: 'landuse', kind: 'wharf'}
-- {layer: 'landuse', kind: 'quay'}
-- {layer: 'landuse', kind: 'recreation_ground'}
-- {layer: 'landuse', kind: 'caravan_site'}
-- {layer: 'landuse', kind: 'recreation_track'}
-- {layer: 'landuse', kind: 'airfield'}
-- {layer: 'landuse', kind: 'stadium'}
-- {layer: 'landuse', kind: 'sports_centre'}
-- {layer: 'landuse', kind: 'village_green'}
-- {layer: 'landuse', kind: 'common'}
-- {layer: 'landuse', kind: 'railway'}
-- {layer: 'landuse', kind: 'quarry'}
-- {layer: 'landuse', kind: 'place_of_worship'}
-- {layer: 'landuse', kind: 'cemetery'}
+- {$layer: 'landuse', kind: 'grass'}
+- {$layer: 'landuse', kind: 'meadow'}
+- {$layer: 'landuse', kind: 'scrub'}
+- {$layer: 'landuse', kind: 'winter_sports'}
+- {$layer: 'landuse', kind: 'farm'}
+- {$layer: 'landuse', kind: 'farmland'}
+- {$layer: 'landuse', kind: 'university'}
+- {$layer: 'landuse', kind: 'college'}
+- {$layer: 'landuse', kind: 'rest_area'}
+- {$layer: 'landuse', kind: 'service_area'}
+- {$layer: 'landuse', kind: 'commercial'}
+- {$layer: 'landuse', kind: 'retail'}
+- {$layer: 'landuse', kind: 'military'}
+- {$layer: 'landuse', kind: 'naval_base'}
+- {$layer: 'landuse', kind: 'danger_area'}
+- {$layer: 'landuse', kind: 'range'}
+- {$layer: 'landuse', kind: 'prison'}
+- {$layer: 'landuse', kind: 'fort'}
+- {$layer: 'landuse', kind: 'theme_park'}
+- {$layer: 'landuse', kind: 'wildlife_park'}
+- {$layer: 'landuse', kind: 'winery'}
+- {$layer: 'landuse', kind: 'zoo'}
+- {$layer: 'landuse', kind: 'resort'}
+- {$layer: 'landuse', kind: 'trail_riding_station'}
+- {$layer: 'landuse', kind: 'hospital'}
+- {$layer: 'landuse', kind: 'aquarium'}
+- {$layer: 'landuse', kind: 'golf_course'}
+- {$layer: 'landuse', kind: 'boatyard'}
+- {$layer: 'landuse', kind: 'shipyard'}
+- {$layer: 'landuse', kind: 'container_terminal'}
+- {$layer: 'landuse', kind: 'port_terminal'}
+- {$layer: 'landuse', kind: 'wharf'}
+- {$layer: 'landuse', kind: 'quay'}
+- {$layer: 'landuse', kind: 'recreation_ground'}
+- {$layer: 'landuse', kind: 'caravan_site'}
+- {$layer: 'landuse', kind: 'recreation_track'}
+- {$layer: 'landuse', kind: 'airfield'}
+- {$layer: 'landuse', kind: 'stadium'}
+- {$layer: 'landuse', kind: 'sports_centre'}
+- {$layer: 'landuse', kind: 'village_green'}
+- {$layer: 'landuse', kind: 'common'}
+- {$layer: 'landuse', kind: 'railway'}
+- {$layer: 'landuse', kind: 'quarry'}
+- {$layer: 'landuse', kind: 'place_of_worship'}
+- {$layer: 'landuse', kind: 'cemetery'}
 # reserve for kind_details
 - _reserved: {from: 3017, to: 3067}
-- {layer: 'landuse', kind: 'school'}
-- {layer: 'landuse', kind: 'fuel'}
-- {layer: 'landuse', kind: 'cinema'}
-- {layer: 'landuse', kind: 'library'}
-- {layer: 'landuse', kind: 'theatre'}
-- {layer: 'landuse', kind: 'aviary'}
-- {layer: 'landuse', kind: 'petting_zoo'}
-- {layer: 'landuse', kind: 'camp_site'}
-- {layer: 'landuse', kind: 'beach'}
+- {$layer: 'landuse', kind: 'school'}
+- {$layer: 'landuse', kind: 'fuel'}
+- {$layer: 'landuse', kind: 'cinema'}
+- {$layer: 'landuse', kind: 'library'}
+- {$layer: 'landuse', kind: 'theatre'}
+- {$layer: 'landuse', kind: 'aviary'}
+- {$layer: 'landuse', kind: 'petting_zoo'}
+- {$layer: 'landuse', kind: 'camp_site'}
+- {$layer: 'landuse', kind: 'beach'}
 # reserve for kind_details
 - _reserved: {from: 3077, to: 3087}
-- {layer: 'landuse', kind: 'garden'}
-- {layer: 'landuse', kind: 'dog_park'}
-- {layer: 'landuse', kind: 'pedestrian'}
-- {layer: 'landuse', kind: 'playground'}
-- {layer: 'landuse', kind: 'attraction'}
-- {layer: 'landuse', kind: 'water_park'}
-- {layer: 'landuse', kind: 'wilderness_hut'}
-- {layer: 'landuse', kind: 'tower'}
-- {layer: 'landuse', kind: 'footway'}
-- {layer: 'landuse', kind: 'mud'}
-- {layer: 'pois', kind: 'wetland'}
+- {$layer: 'landuse', kind: 'garden'}
+- {$layer: 'landuse', kind: 'dog_park'}
+- {$layer: 'landuse', kind: 'pedestrian'}
+- {$layer: 'landuse', kind: 'playground'}
+- {$layer: 'landuse', kind: 'attraction'}
+- {$layer: 'landuse', kind: 'water_park'}
+- {$layer: 'landuse', kind: 'wilderness_hut'}
+- {$layer: 'landuse', kind: 'tower'}
+- {$layer: 'landuse', kind: 'footway'}
+- {$layer: 'landuse', kind: 'mud'}
+- {$layer: 'pois', kind: 'wetland'}
 # reserve for kind_details
 - _reserved: {from: 3099, to: 3119}
-- {layer: 'landuse', kind: 'wetland'}
+- {$layer: 'landuse', kind: 'wetland'}
 # reserve for kind_details
 - _reserved: {from: 3121, to: 3141}
-- {layer: 'landuse', kind: 'land'}
-- {layer: 'landuse', kind: 'dam'}
-- {layer: 'landuse', kind: 'groyne'}
-- {layer: 'landuse', kind: 'dike'}
-- {layer: 'landuse', kind: 'pier'}
-- {layer: 'landuse', kind: 'bridge'}
-- {layer: 'pois', kind: 'stop_area'}
-- {layer: 'places', kind: 'microhood'}
-- {layer: 'pois', kind: 'aeroway_gate'}
-- {layer: 'pois', kind: 'bicycle_rental'}
-- {layer: 'pois', kind: 'boat_rental'}
-- {layer: 'pois', kind: 'bus_station'}
-- {layer: 'pois', kind: 'camera'}
-- {layer: 'pois', kind: 'car_rental'}
-- {layer: 'pois', kind: 'copyshop'}
-- {layer: 'pois', kind: 'dive_centre'}
-- {layer: 'pois', kind: 'dog_park'}
-- {layer: 'pois', kind: 'fishing'}
-- {layer: 'pois', kind: 'fishing_area'}
-- {layer: 'pois', kind: 'funeral_directors'}
-- {layer: 'pois', kind: 'harbourmaster'}
-- {layer: 'pois', kind: 'helipad'}
-- {layer: 'pois', kind: 'heliport'}
-- {layer: 'pois', kind: 'hot_spring'}
-- {layer: 'pois', kind: 'hunting'}
-- {layer: 'pois', kind: 'information'}
-- {layer: 'earth', kind: 'islet'}
-- {layer: 'pois', kind: 'mini_roundabout'}
-- {layer: 'pois', kind: 'miniature_golf'}
-- {layer: 'pois', kind: 'photo'}
-- {layer: 'pois', kind: 'picnic_site'}
-- {layer: 'pois', kind: 'snow_cannon'}
-- {layer: 'pois', kind: 'swimming_area'}
-- {layer: 'pois', kind: 'tyres'}
-- {layer: 'pois', kind: 'block'}
-- {layer: 'pois', kind: 'bunker'}
+- {$layer: 'landuse', kind: 'land'}
+- {$layer: 'landuse', kind: 'dam'}
+- {$layer: 'landuse', kind: 'groyne'}
+- {$layer: 'landuse', kind: 'dike'}
+- {$layer: 'landuse', kind: 'pier'}
+- {$layer: 'landuse', kind: 'bridge'}
+- {$layer: 'pois', kind: 'stop_area'}
+- {$layer: 'places', kind: 'microhood'}
+- {$layer: 'pois', kind: 'aeroway_gate'}
+- {$layer: 'pois', kind: 'bicycle_rental'}
+- {$layer: 'pois', kind: 'boat_rental'}
+- {$layer: 'pois', kind: 'bus_station'}
+- {$layer: 'pois', kind: 'camera'}
+- {$layer: 'pois', kind: 'car_rental'}
+- {$layer: 'pois', kind: 'copyshop'}
+- {$layer: 'pois', kind: 'dive_centre'}
+- {$layer: 'pois', kind: 'dog_park'}
+- {$layer: 'pois', kind: 'fishing'}
+- {$layer: 'pois', kind: 'fishing_area'}
+- {$layer: 'pois', kind: 'funeral_directors'}
+- {$layer: 'pois', kind: 'harbourmaster'}
+- {$layer: 'pois', kind: 'helipad'}
+- {$layer: 'pois', kind: 'heliport'}
+- {$layer: 'pois', kind: 'hot_spring'}
+- {$layer: 'pois', kind: 'hunting'}
+- {$layer: 'pois', kind: 'information'}
+- {$layer: 'earth', kind: 'islet'}
+- {$layer: 'pois', kind: 'mini_roundabout'}
+- {$layer: 'pois', kind: 'miniature_golf'}
+- {$layer: 'pois', kind: 'photo'}
+- {$layer: 'pois', kind: 'picnic_site'}
+- {$layer: 'pois', kind: 'snow_cannon'}
+- {$layer: 'pois', kind: 'swimming_area'}
+- {$layer: 'pois', kind: 'tyres'}
+- {$layer: 'pois', kind: 'block'}
+- {$layer: 'pois', kind: 'bunker'}
 # reserve for kind_details
 - _reserved: {from: 3178, to: 3198}
-- {layer: 'pois', kind: 'shelter'}
-- {layer: 'pois', kind: 'recreation_track'}
-- {layer: 'pois', kind: 'recycling'}
-- {layer: 'pois', kind: 'adit'}
-- {layer: 'pois', kind: 'allotments'}
-- {layer: 'pois', kind: 'archaeological_site'}
-- {layer: 'pois', kind: 'bicycle_junction'}
-- {layer: 'pois', kind: 'boat_lift'}
-- {layer: 'pois', kind: 'pitch'}
+- {$layer: 'pois', kind: 'shelter'}
+- {$layer: 'pois', kind: 'recreation_track'}
+- {$layer: 'pois', kind: 'recycling'}
+- {$layer: 'pois', kind: 'adit'}
+- {$layer: 'pois', kind: 'allotments'}
+- {$layer: 'pois', kind: 'archaeological_site'}
+- {$layer: 'pois', kind: 'bicycle_junction'}
+- {$layer: 'pois', kind: 'boat_lift'}
+- {$layer: 'pois', kind: 'pitch'}
 # reserve for kind_details
 - _reserved: {from: 3208, to: 3308}
-- {layer: 'pois', kind: 'bollard'}
-- {layer: 'pois', kind: 'cattle_grid'}
-- {layer: 'pois', kind: 'crane'}
+- {$layer: 'pois', kind: 'bollard'}
+- {$layer: 'pois', kind: 'cattle_grid'}
+- {$layer: 'pois', kind: 'crane'}
 # reserve for kind_details
 - _reserved: {from: 3312, to: 3322}
-- {layer: 'pois', kind: 'ford'}
-- {layer: 'pois', kind: 'halt'}
-- {layer: 'pois', kind: 'plaque'}
-- {layer: 'pois', kind: 'power_tower'}
-- {layer: 'pois', kind: 'stop'}
-- {layer: 'pois', kind: 'tram_stop'}
-- {layer: 'pois', kind: 'tree'}
-- {layer: 'pois', kind: 'walking_junction'}
-- {layer: 'pois', kind: 'wayside_cross'}
-- {layer: 'landuse', kind: 'taxiway'}
-- {layer: 'landuse', kind: 'runway'}
-- {layer: 'landuse', kind: 'wastewater_plant'}
-- {layer: 'landuse', kind: 'water_works'}
-- {layer: 'landuse', kind: 'works'}
-- {layer: 'landuse', kind: 'enclosure'}
-- {layer: 'landuse', kind: 'roller_coaster'}
-- {layer: 'landuse', kind: 'allotments'}
-- {layer: 'landuse', kind: 'generator'}
-- {layer: 'landuse', kind: 'maze'}
-- {layer: 'landuse', kind: 'hanami'}
-- {layer: 'landuse', kind: 'amusement_ride'}
-- {layer: 'landuse', kind: 'picnic_site'}
-- {layer: 'landuse', kind: 'crane'}
+- {$layer: 'pois', kind: 'ford'}
+- {$layer: 'pois', kind: 'halt'}
+- {$layer: 'pois', kind: 'plaque'}
+- {$layer: 'pois', kind: 'power_tower'}
+- {$layer: 'pois', kind: 'stop'}
+- {$layer: 'pois', kind: 'tram_stop'}
+- {$layer: 'pois', kind: 'tree'}
+- {$layer: 'pois', kind: 'walking_junction'}
+- {$layer: 'pois', kind: 'wayside_cross'}
+- {$layer: 'landuse', kind: 'taxiway'}
+- {$layer: 'landuse', kind: 'runway'}
+- {$layer: 'landuse', kind: 'wastewater_plant'}
+- {$layer: 'landuse', kind: 'water_works'}
+- {$layer: 'landuse', kind: 'works'}
+- {$layer: 'landuse', kind: 'enclosure'}
+- {$layer: 'landuse', kind: 'roller_coaster'}
+- {$layer: 'landuse', kind: 'allotments'}
+- {$layer: 'landuse', kind: 'generator'}
+- {$layer: 'landuse', kind: 'maze'}
+- {$layer: 'landuse', kind: 'hanami'}
+- {$layer: 'landuse', kind: 'amusement_ride'}
+- {$layer: 'landuse', kind: 'picnic_site'}
+- {$layer: 'landuse', kind: 'crane'}
 # reserve for kind_details
 - _reserved: {from: 3346, to: 3356}
-- {layer: 'landuse', kind: 'embankment'}
-- {layer: 'transit', kind: 'halt'}
-- {layer: 'transit', kind: 'stop'}
-- {layer: 'transit', kind: 'tram_stop'}
-- {layer: 'pois', kind: 'accountant'}
-- {layer: 'pois', kind: 'administrative'}
-- {layer: 'pois', kind: 'advertising_agency'}
-- {layer: 'pois', kind: 'ambulatory_care'}
+- {$layer: 'landuse', kind: 'embankment'}
+- {$layer: 'transit', kind: 'halt'}
+- {$layer: 'transit', kind: 'stop'}
+- {$layer: 'transit', kind: 'tram_stop'}
+- {$layer: 'pois', kind: 'accountant'}
+- {$layer: 'pois', kind: 'administrative'}
+- {$layer: 'pois', kind: 'advertising_agency'}
+- {$layer: 'pois', kind: 'ambulatory_care'}
 # reserve for kind_details
 - _reserved: {from: 3365, to: 3385}
-- {layer: 'pois', kind: 'architect'}
-- {layer: 'pois', kind: 'art'}
-- {layer: 'pois', kind: 'association'}
-- {layer: 'pois', kind: 'aviary'}
-- {layer: 'pois', kind: 'baby_hatch'}
-- {layer: 'pois', kind: 'bakery'}
-- {layer: 'pois', kind: 'beauty'}
-- {layer: 'pois', kind: 'bed_and_breakfast'}
-- {layer: 'pois', kind: 'blood'}
-- {layer: 'pois', kind: 'blood_bank'}
-- {layer: 'pois', kind: 'books'}
-- {layer: 'pois', kind: 'butcher'}
-- {layer: 'pois', kind: 'car'}
-- {layer: 'pois', kind: 'carousel'}
-- {layer: 'pois', kind: 'chalet'}
-- {layer: 'pois', kind: 'childcare'}
-- {layer: 'pois', kind: 'chiropractor'}
+- {$layer: 'pois', kind: 'architect'}
+- {$layer: 'pois', kind: 'art'}
+- {$layer: 'pois', kind: 'association'}
+- {$layer: 'pois', kind: 'aviary'}
+- {$layer: 'pois', kind: 'baby_hatch'}
+- {$layer: 'pois', kind: 'bakery'}
+- {$layer: 'pois', kind: 'beauty'}
+- {$layer: 'pois', kind: 'bed_and_breakfast'}
+- {$layer: 'pois', kind: 'blood'}
+- {$layer: 'pois', kind: 'blood_bank'}
+- {$layer: 'pois', kind: 'books'}
+- {$layer: 'pois', kind: 'butcher'}
+- {$layer: 'pois', kind: 'car'}
+- {$layer: 'pois', kind: 'carousel'}
+- {$layer: 'pois', kind: 'chalet'}
+- {$layer: 'pois', kind: 'childcare'}
+- {$layer: 'pois', kind: 'chiropractor'}
 # reserve for kind_details
 - _reserved: {from: 3403, to: 3423}
-- {layer: 'pois', kind: 'clinic'}
+- {$layer: 'pois', kind: 'clinic'}
 # reserve for kind_details
 - _reserved: {from: 3425, to: 3445}
-- {layer: 'pois', kind: 'clothes'}
-- {layer: 'pois', kind: 'company'}
-- {layer: 'pois', kind: 'computer'}
-- {layer: 'pois', kind: 'consulting'}
-- {layer: 'pois', kind: 'convenience'}
-- {layer: 'pois', kind: 'craft'}
-- {layer: 'pois', kind: 'dentist'}
+- {$layer: 'pois', kind: 'clothes'}
+- {$layer: 'pois', kind: 'company'}
+- {$layer: 'pois', kind: 'computer'}
+- {$layer: 'pois', kind: 'consulting'}
+- {$layer: 'pois', kind: 'convenience'}
+- {$layer: 'pois', kind: 'craft'}
+- {$layer: 'pois', kind: 'dentist'}
 # reserve for kind_details
 - _reserved: {from: 3453, to: 3473}
-- {layer: 'pois', kind: 'dispensary'}
+- {$layer: 'pois', kind: 'dispensary'}
 # reserve for kind_details
 - _reserved: {from: 3475, to: 3495}
-- {layer: 'pois', kind: 'doctors'}
+- {$layer: 'pois', kind: 'doctors'}
 # reserve for kind_details
 - _reserved: {from: 3497, to: 3517}
-- {layer: 'pois', kind: 'educational_institution'}
-- {layer: 'pois', kind: 'employment_agency'}
-- {layer: 'pois', kind: 'estate_agent'}
-- {layer: 'pois', kind: 'fashion'}
-- {layer: 'pois', kind: 'financial'}
-- {layer: 'pois', kind: 'florist'}
-- {layer: 'pois', kind: 'foundation'}
-- {layer: 'pois', kind: 'gift'}
-- {layer: 'pois', kind: 'government'}
-- {layer: 'pois', kind: 'greengrocer'}
-- {layer: 'pois', kind: 'grocery'}
-- {layer: 'pois', kind: 'guest_house'}
-- {layer: 'pois', kind: 'hairdresser'}
-- {layer: 'pois', kind: 'healthcare_centre'}
+- {$layer: 'pois', kind: 'educational_institution'}
+- {$layer: 'pois', kind: 'employment_agency'}
+- {$layer: 'pois', kind: 'estate_agent'}
+- {$layer: 'pois', kind: 'fashion'}
+- {$layer: 'pois', kind: 'financial'}
+- {$layer: 'pois', kind: 'florist'}
+- {$layer: 'pois', kind: 'foundation'}
+- {$layer: 'pois', kind: 'gift'}
+- {$layer: 'pois', kind: 'government'}
+- {$layer: 'pois', kind: 'greengrocer'}
+- {$layer: 'pois', kind: 'grocery'}
+- {$layer: 'pois', kind: 'guest_house'}
+- {$layer: 'pois', kind: 'hairdresser'}
+- {$layer: 'pois', kind: 'healthcare_centre'}
 # reserve for kind_details
 - _reserved: {from: 3532, to: 3552}
-- {layer: 'pois', kind: 'hifi'}
-- {layer: 'pois', kind: 'hospice'}
+- {$layer: 'pois', kind: 'hifi'}
+- {$layer: 'pois', kind: 'hospice'}
 # reserve for kind_details
 - _reserved: {from: 3555, to: 3575}
-- {layer: 'pois', kind: 'hostel'}
-- {layer: 'pois', kind: 'jewelry'}
-- {layer: 'pois', kind: 'karaoke'}
-- {layer: 'pois', kind: 'lawyer'}
-- {layer: 'pois', kind: 'midwife'}
+- {$layer: 'pois', kind: 'hostel'}
+- {$layer: 'pois', kind: 'jewelry'}
+- {$layer: 'pois', kind: 'karaoke'}
+- {$layer: 'pois', kind: 'lawyer'}
+- {$layer: 'pois', kind: 'midwife'}
 # reserve for kind_details
 - _reserved: {from: 3581, to: 3601}
-- {layer: 'pois', kind: 'mobile_phone'}
-- {layer: 'pois', kind: 'motorcycle'}
-- {layer: 'pois', kind: 'newsagent'}
-- {layer: 'pois', kind: 'newspaper'}
-- {layer: 'pois', kind: 'ngo'}
-- {layer: 'pois', kind: 'notary'}
-- {layer: 'pois', kind: 'optician'}
-- {layer: 'pois', kind: 'paediatrics'}
+- {$layer: 'pois', kind: 'mobile_phone'}
+- {$layer: 'pois', kind: 'motorcycle'}
+- {$layer: 'pois', kind: 'newsagent'}
+- {$layer: 'pois', kind: 'newspaper'}
+- {$layer: 'pois', kind: 'ngo'}
+- {$layer: 'pois', kind: 'notary'}
+- {$layer: 'pois', kind: 'optician'}
+- {$layer: 'pois', kind: 'paediatrics'}
 # reserve for kind_details
 - _reserved: {from: 3610, to: 3630}
-- {layer: 'pois', kind: 'optometrist_paediatrics'}
+- {$layer: 'pois', kind: 'optometrist_paediatrics'}
 # reserve for kind_details
 - _reserved: {from: 3632, to: 3652}
-- {layer: 'pois', kind: 'perfumery'}
-- {layer: 'pois', kind: 'petting_zoo'}
-- {layer: 'pois', kind: 'physician'}
+- {$layer: 'pois', kind: 'perfumery'}
+- {$layer: 'pois', kind: 'petting_zoo'}
+- {$layer: 'pois', kind: 'physician'}
 # reserve for kind_details
 - _reserved: {from: 3656, to: 3676}
-- {layer: 'pois', kind: 'physiotherapist_physiotherapy'}
+- {$layer: 'pois', kind: 'physiotherapist_physiotherapy'}
 # reserve for kind_details
 - _reserved: {from: 3678, to: 3698}
-- {layer: 'pois', kind: 'physiotherapist'}
+- {$layer: 'pois', kind: 'physiotherapist'}
 # reserve for kind_details
 - _reserved: {from: 3700, to: 3720}
-- {layer: 'pois', kind: 'playground'}
-- {layer: 'pois', kind: 'psychotherapist'}
+- {$layer: 'pois', kind: 'playground'}
+- {$layer: 'pois', kind: 'psychotherapist'}
 # reserve for kind_details
 - _reserved: {from: 3723, to: 3743}
-- {layer: 'pois', kind: 'podiatrist'}
+- {$layer: 'pois', kind: 'podiatrist'}
 # reserve for kind_details
 - _reserved: {from: 3745, to: 3765}
-- {layer: 'pois', kind: 'political_party'}
-- {layer: 'pois', kind: 'rehabilitation'}
+- {$layer: 'pois', kind: 'political_party'}
+- {$layer: 'pois', kind: 'rehabilitation'}
 # reserve for kind_details
 - _reserved: {from: 3768, to: 3788}
-- {layer: 'pois', kind: 'religion'}
-- {layer: 'pois', kind: 'research'}
-- {layer: 'pois', kind: 'sanitary_dump_station'}
-- {layer: 'pois', kind: 'scuba_diving'}
-- {layer: 'pois', kind: 'snowmobile'}
-- {layer: 'pois', kind: 'social_facility'}
+- {$layer: 'pois', kind: 'religion'}
+- {$layer: 'pois', kind: 'research'}
+- {$layer: 'pois', kind: 'sanitary_dump_station'}
+- {$layer: 'pois', kind: 'scuba_diving'}
+- {$layer: 'pois', kind: 'snowmobile'}
+- {$layer: 'pois', kind: 'social_facility'}
 # reserve for kind_details
 - _reserved: {from: 3795, to: 3815}
-- {layer: 'pois', kind: 'speech_therapist'}
+- {$layer: 'pois', kind: 'speech_therapist'}
 # reserve for kind_details
 - _reserved: {from: 3817, to: 3837}
-- {layer: 'pois', kind: 'speech'}
-- {layer: 'pois', kind: 'stationery'}
-- {layer: 'pois', kind: 'studio'}
+- {$layer: 'pois', kind: 'speech'}
+- {$layer: 'pois', kind: 'stationery'}
+- {$layer: 'pois', kind: 'studio'}
 # reserve for kind_details
 - _reserved: {from: 3841, to: 3861}
-- {layer: 'pois', kind: 'tax_advisor'}
-- {layer: 'pois', kind: 'telecommunication'}
-- {layer: 'pois', kind: 'therapist'}
-- {layer: 'pois', kind: 'tobacco'}
-- {layer: 'pois', kind: 'travel_agency'}
-- {layer: 'pois', kind: 'travel_agent'}
-- {layer: 'pois', kind: 'wildlife_park'}
-- {layer: 'transit', kind: 'station'}
-- {layer: 'transit', kind: 'stop_area'}
-- {layer: 'transit', kind: 'platform'}
-- {layer: 'buildings', kind: 'building'}
+- {$layer: 'pois', kind: 'tax_advisor'}
+- {$layer: 'pois', kind: 'telecommunication'}
+- {$layer: 'pois', kind: 'therapist'}
+- {$layer: 'pois', kind: 'tobacco'}
+- {$layer: 'pois', kind: 'travel_agency'}
+- {$layer: 'pois', kind: 'travel_agent'}
+- {$layer: 'pois', kind: 'wildlife_park'}
+- {$layer: 'transit', kind: 'station'}
+- {$layer: 'transit', kind: 'stop_area'}
+- {$layer: 'transit', kind: 'platform'}
+- {$layer: 'buildings', kind: 'building'}
 # reserve for kind_details
 - _reserved: {from: 3873, to: 4073}
-- {layer: 'pois', kind: 'atv'}
-- {layer: 'pois', kind: 'bicycle_rental_station'}
-- {layer: 'pois', kind: 'boat_storage'}
-- {layer: 'pois', kind: 'bookmaker'}
-- {layer: 'pois', kind: 'bureau_de_change'}
-- {layer: 'pois', kind: 'car_parts'}
-- {layer: 'pois', kind: 'donation'}
-- {layer: 'pois', kind: 'hanami'}
-- {layer: 'pois', kind: 'healthcare_alternative'}
+- {$layer: 'pois', kind: 'atv'}
+- {$layer: 'pois', kind: 'bicycle_rental_station'}
+- {$layer: 'pois', kind: 'boat_storage'}
+- {$layer: 'pois', kind: 'bookmaker'}
+- {$layer: 'pois', kind: 'bureau_de_change'}
+- {$layer: 'pois', kind: 'car_parts'}
+- {$layer: 'pois', kind: 'donation'}
+- {$layer: 'pois', kind: 'hanami'}
+- {$layer: 'pois', kind: 'healthcare_alternative'}
 # reserve for kind_details
 - _reserved: {from: 4083, to: 4103}
-- {layer: 'pois', kind: 'it'}
-- {layer: 'pois', kind: 'midwife_occupational'}
-- {layer: 'pois', kind: 'occupational_therapist'}
+- {$layer: 'pois', kind: 'it'}
+- {$layer: 'pois', kind: 'midwife_occupational'}
+- {$layer: 'pois', kind: 'occupational_therapist'}
 # reserve for kind_details
 - _reserved: {from: 4107, to: 4127}
-- {layer: 'pois', kind: 'money_transfer'}
-- {layer: 'pois', kind: 'roller_coaster'}
-- {layer: 'pois', kind: 'amusement_ride'}
-- {layer: 'pois', kind: 'animal'}
-- {layer: 'pois', kind: 'artwork'}
-- {layer: 'pois', kind: 'attraction'}
-- {layer: 'pois', kind: 'bicycle_parking'}
-- {layer: 'pois', kind: 'car_repair'}
-- {layer: 'pois', kind: 'healthcare_laboratory'}
+- {$layer: 'pois', kind: 'money_transfer'}
+- {$layer: 'pois', kind: 'roller_coaster'}
+- {$layer: 'pois', kind: 'amusement_ride'}
+- {$layer: 'pois', kind: 'animal'}
+- {$layer: 'pois', kind: 'artwork'}
+- {$layer: 'pois', kind: 'attraction'}
+- {$layer: 'pois', kind: 'bicycle_parking'}
+- {$layer: 'pois', kind: 'car_repair'}
+- {$layer: 'pois', kind: 'healthcare_laboratory'}
 # reserve for kind_details
 - _reserved: {from: 4137, to: 4157}
-- {layer: 'pois', kind: 'insurance'}
-- {layer: 'pois', kind: 'car_wash'}
-- {layer: 'pois', kind: 'subway_entrance'}
-- {layer: 'pois', kind: 'gambling'}
-- {layer: 'pois', kind: 'office'}
-- {layer: 'pois', kind: 'car_sharing'}
-- {layer: 'pois', kind: 'charging_station'}
-- {layer: 'pois', kind: 'enclosure'}
-- {layer: 'pois', kind: 'lottery'}
-- {layer: 'pois', kind: 'ship_chandler'}
-- {layer: 'pois', kind: 'slipway'}
-- {layer: 'pois', kind: 'summer_toboggan'}
-- {layer: 'pois', kind: 'industrial'}
-- {layer: 'pois', kind: 'shop'}
-- {layer: 'pois', kind: 'slaughterhouse'}
-- {layer: 'pois', kind: 'stone'}
-- {layer: 'pois', kind: 'trail_riding_station'}
-- {layer: 'pois', kind: 'turning_circle'}
-- {layer: 'pois', kind: 'turning_loop'}
-- {layer: 'pois', kind: 'water_slide'}
-- {layer: 'pois', kind: 'water_well'}
+- {$layer: 'pois', kind: 'insurance'}
+- {$layer: 'pois', kind: 'car_wash'}
+- {$layer: 'pois', kind: 'subway_entrance'}
+- {$layer: 'pois', kind: 'gambling'}
+- {$layer: 'pois', kind: 'office'}
+- {$layer: 'pois', kind: 'car_sharing'}
+- {$layer: 'pois', kind: 'charging_station'}
+- {$layer: 'pois', kind: 'enclosure'}
+- {$layer: 'pois', kind: 'lottery'}
+- {$layer: 'pois', kind: 'ship_chandler'}
+- {$layer: 'pois', kind: 'slipway'}
+- {$layer: 'pois', kind: 'summer_toboggan'}
+- {$layer: 'pois', kind: 'industrial'}
+- {$layer: 'pois', kind: 'shop'}
+- {$layer: 'pois', kind: 'slaughterhouse'}
+- {$layer: 'pois', kind: 'stone'}
+- {$layer: 'pois', kind: 'trail_riding_station'}
+- {$layer: 'pois', kind: 'turning_circle'}
+- {$layer: 'pois', kind: 'turning_loop'}
+- {$layer: 'pois', kind: 'water_slide'}
+- {$layer: 'pois', kind: 'water_well'}
 # reserve for kind_details
 - _reserved: {from: 4179, to: 4199}
-- {layer: 'pois', kind: 'defibrillator'}
-- {layer: 'pois', kind: 'elevator'}
-- {layer: 'pois', kind: 'emergency_phone'}
-- {layer: 'pois', kind: 'fitness_station'}
-- {layer: 'pois', kind: 'hunting_stand'}
-- {layer: 'pois', kind: 'karaoke_box'}
-- {layer: 'pois', kind: 'lifeguard_tower'}
-- {layer: 'pois', kind: 'mast'}
-- {layer: 'pois', kind: 'maze'}
-- {layer: 'pois', kind: 'memorial'}
-- {layer: 'pois', kind: 'mooring'}
+- {$layer: 'pois', kind: 'defibrillator'}
+- {$layer: 'pois', kind: 'elevator'}
+- {$layer: 'pois', kind: 'emergency_phone'}
+- {$layer: 'pois', kind: 'fitness_station'}
+- {$layer: 'pois', kind: 'hunting_stand'}
+- {$layer: 'pois', kind: 'karaoke_box'}
+- {$layer: 'pois', kind: 'lifeguard_tower'}
+- {$layer: 'pois', kind: 'mast'}
+- {$layer: 'pois', kind: 'maze'}
+- {$layer: 'pois', kind: 'memorial'}
+- {$layer: 'pois', kind: 'mooring'}
 # reserve for kind_details
 - _reserved: {from: 4211, to: 4231}
-- {layer: 'pois', kind: 'motorcycle_parking'}
-- {layer: 'pois', kind: 'petroleum_well'}
-- {layer: 'pois', kind: 'platform'}
-- {layer: 'pois', kind: 'pylon'}
-- {layer: 'pois', kind: 'rock'}
-- {layer: 'earth', kind: 'earth'}
-- {layer: 'landuse', kind: 'apron'}
-- {layer: 'landuse', kind: 'substation'}
-- {layer: 'landuse', kind: 'summer_toboggan'}
-- {layer: 'landuse', kind: 'plant'}
-- {layer: 'landuse', kind: 'pitch'}
-- {layer: 'landuse', kind: 'animal'}
-- {layer: 'landuse', kind: 'artwork'}
-- {layer: 'landuse', kind: 'carousel'}
-- {layer: 'landuse', kind: 'water_slide'}
-- {layer: 'landuse', kind: 'parking'}
-- {layer: 'water', kind: 'fountain'}
-- {layer: 'water', kind: 'ditch'}
-- {layer: 'water', kind: 'drain'}
-- {layer: 'water', kind: 'swimming_pool'}
-- {layer: 'landuse', kind: 'breakwater'}
-- {layer: 'landuse', kind: 'cutline'}
-- {layer: 'landuse', kind: 'hedge'}
-- {layer: 'landuse', kind: 'tree_row'}
-- {layer: 'landuse', kind: 'retaining_wall'}
-- {layer: 'landuse', kind: 'snow_fence'}
-- {layer: 'landuse', kind: 'fence'}
+- {$layer: 'pois', kind: 'motorcycle_parking'}
+- {$layer: 'pois', kind: 'petroleum_well'}
+- {$layer: 'pois', kind: 'platform'}
+- {$layer: 'pois', kind: 'pylon'}
+- {$layer: 'pois', kind: 'rock'}
+- {$layer: 'earth', kind: 'earth'}
+- {$layer: 'landuse', kind: 'apron'}
+- {$layer: 'landuse', kind: 'substation'}
+- {$layer: 'landuse', kind: 'summer_toboggan'}
+- {$layer: 'landuse', kind: 'plant'}
+- {$layer: 'landuse', kind: 'pitch'}
+- {$layer: 'landuse', kind: 'animal'}
+- {$layer: 'landuse', kind: 'artwork'}
+- {$layer: 'landuse', kind: 'carousel'}
+- {$layer: 'landuse', kind: 'water_slide'}
+- {$layer: 'landuse', kind: 'parking'}
+- {$layer: 'water', kind: 'fountain'}
+- {$layer: 'water', kind: 'ditch'}
+- {$layer: 'water', kind: 'drain'}
+- {$layer: 'water', kind: 'swimming_pool'}
+- {$layer: 'landuse', kind: 'breakwater'}
+- {$layer: 'landuse', kind: 'cutline'}
+- {$layer: 'landuse', kind: 'hedge'}
+- {$layer: 'landuse', kind: 'tree_row'}
+- {$layer: 'landuse', kind: 'retaining_wall'}
+- {$layer: 'landuse', kind: 'snow_fence'}
+- {$layer: 'landuse', kind: 'fence'}
 # reserve for kind_details
 - _reserved: {from: 4259, to: 4309}
-- {layer: 'landuse', kind: 'wall'}
+- {$layer: 'landuse', kind: 'wall'}
 # reserve for kind_details
 - _reserved: {from: 4311, to: 4331}
-- {layer: 'landuse', kind: 'power_minor_line'}
-- {layer: 'landuse', kind: 'power_line'}
-- {layer: 'transit', kind: 'bus_stop'}
-- {layer: 'buildings', kind: 'building_part'}
+- {$layer: 'landuse', kind: 'power_minor_line'}
+- {$layer: 'landuse', kind: 'power_line'}
+- {$layer: 'transit', kind: 'bus_stop'}
+- {$layer: 'buildings', kind: 'building_part'}
 # reserve for kind_details
 - _reserved: {from: 4336, to: 4386}
-- {layer: 'pois', kind: 'atm'}
-- {layer: 'pois', kind: 'bus_stop'}
-- {layer: 'pois', kind: 'firepit'}
-- {layer: 'pois', kind: 'life_ring'}
-- {layer: 'pois', kind: 'picnic_table'}
-- {layer: 'pois', kind: 'shower'}
-- {layer: 'pois', kind: 'taxi'}
-- {layer: 'pois', kind: 'telephone'}
-- {layer: 'pois', kind: 'toilets'}
+- {$layer: 'pois', kind: 'atm'}
+- {$layer: 'pois', kind: 'bus_stop'}
+- {$layer: 'pois', kind: 'firepit'}
+- {$layer: 'pois', kind: 'life_ring'}
+- {$layer: 'pois', kind: 'picnic_table'}
+- {$layer: 'pois', kind: 'shower'}
+- {$layer: 'pois', kind: 'taxi'}
+- {$layer: 'pois', kind: 'telephone'}
+- {$layer: 'pois', kind: 'toilets'}
 # reserve for kind_details
 - _reserved: {from: 4396, to: 4406}
-- {layer: 'pois', kind: 'waste_disposal'}
-- {layer: 'pois', kind: 'bbq'}
-- {layer: 'pois', kind: 'bicycle_repair_station'}
-- {layer: 'pois', kind: 'cycle_barrier'}
-- {layer: 'pois', kind: 'drinking_water'}
-- {layer: 'pois', kind: 'phone'}
-- {layer: 'buildings', kind: 'address'}
-- {layer: 'pois', kind: 'bench'}
-- {layer: 'buildings', kind: 'entrance'}
+- {$layer: 'pois', kind: 'waste_disposal'}
+- {$layer: 'pois', kind: 'bbq'}
+- {$layer: 'pois', kind: 'bicycle_repair_station'}
+- {$layer: 'pois', kind: 'cycle_barrier'}
+- {$layer: 'pois', kind: 'drinking_water'}
+- {$layer: 'pois', kind: 'phone'}
+- {$layer: 'buildings', kind: 'address'}
+- {$layer: 'pois', kind: 'bench'}
+- {$layer: 'buildings', kind: 'entrance'}
 # reserve for kind_details
 - _reserved: {from: 4416, to: 4436}
-- {layer: 'buildings', kind: 'exit'}
+- {$layer: 'buildings', kind: 'exit'}
 # reserve for kind_details
 - _reserved: {from: 4438, to: 4448}
-- {layer: 'pois', kind: 'fire_hydrant'}
-- {layer: 'pois', kind: 'gas_canister'}
-- {layer: 'pois', kind: 'level_crossing'}
-- {layer: 'pois', kind: 'love_hotel'}
-- {layer: 'pois', kind: 'post_box'}
-- {layer: 'pois', kind: 'power_pole'}
-- {layer: 'pois', kind: 'street_lamp'}
-- {layer: 'pois', kind: 'traffic_signals'}
-- {layer: 'pois', kind: 'waste_basket'}
-- {layer: 'pois', kind: 'water_point'}
-- {layer: 'pois', kind: 'watering_place'}
+- {$layer: 'pois', kind: 'fire_hydrant'}
+- {$layer: 'pois', kind: 'gas_canister'}
+- {$layer: 'pois', kind: 'level_crossing'}
+- {$layer: 'pois', kind: 'love_hotel'}
+- {$layer: 'pois', kind: 'post_box'}
+- {$layer: 'pois', kind: 'power_pole'}
+- {$layer: 'pois', kind: 'street_lamp'}
+- {$layer: 'pois', kind: 'traffic_signals'}
+- {$layer: 'pois', kind: 'waste_basket'}
+- {$layer: 'pois', kind: 'water_point'}
+- {$layer: 'pois', kind: 'watering_place'}
 # catch-all, assign lowest priority
-- { layer: true }
+- { $layer: true }

--- a/test/test_collision_rank.py
+++ b/test/test_collision_rank.py
@@ -136,3 +136,26 @@ class CollisionRankTest(TestCase):
         # $layer match
         _, props, _ = feature_layers[0]['features'][0]
         self.assertEqual(props.get('collision_rank'), 1)
+
+    def test_reserved_count(self):
+        """
+        Test that we can reserve a specific number of collision rank indices
+        without needing to specify the exact start/end.
+        """
+        from vectordatasource.collision import CollisionRanker
+
+        ranker = CollisionRanker([
+            # should be 1
+            {'kind': 'foo'},
+            # should skip 2-10 (count 9) as reserved
+            {'_reserved': {'count': 9}},
+            # should be 11
+            {'kind': 'bar'},
+        ])
+
+        shape = None
+        props = {'kind': 'bar'}
+        fid = 1
+        rank = ranker((shape, props, fid))
+
+        self.assertEqual(rank, 11)

--- a/test/test_collision_rank.py
+++ b/test/test_collision_rank.py
@@ -51,3 +51,36 @@ class CollisionRankTest(TestCase):
             rank = ranker((shape, props, fid))
 
             self.assertEqual(rank, expected_rank)
+
+    def test_reserved_blocks(self):
+        # test that if we overflow the reserved block by having too many items
+        # in the preceding section, then the code fails with an error.
+        from vectordatasource.collision import CollisionRanker
+
+        with self.assertRaises(AssertionError):
+            CollisionRanker([
+                {'foo': 'bar'},
+                {'baz': 'bat'},
+                {'_reserved': {'from': 2, 'to': 10}},
+            ])
+
+    def test_skips_reserved_blocks(self):
+        # test that we skip reserved blocks in the numbering
+        from vectordatasource.collision import CollisionRanker
+
+        ranker = CollisionRanker([
+            # should be 1
+            {'kind': 'foo'},
+            # should skip 2-9 as unused
+            # should skip 10-20 as reserved
+            {'_reserved': {'from': 10, 'to': 20}},
+            # should be 21
+            {'kind': 'bar'},
+        ])
+
+        shape = None
+        props = {'kind': 'bar'}
+        fid = 1
+        rank = ranker((shape, props, fid))
+
+        self.assertEqual(rank, 21)

--- a/test/test_collision_rank.py
+++ b/test/test_collision_rank.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+
+
+class CollisionRankTest(TestCase):
+
+    def test_simple_assignment(self):
+        # ranker should assign us a rank.
+        from vectordatasource.collision import CollisionRanker
+
+        ranker = CollisionRanker([
+            {'kind': 'foo'},
+        ])
+
+        shape = None
+        props = {'kind': 'foo'}
+        fid = 1
+        rank = ranker((shape, props, fid))
+
+        self.assertEqual(rank, 1)
+
+    def test_contiguous_ranks(self):
+        # ranker should assign ranks contiguously in order
+        from vectordatasource.collision import CollisionRanker
+
+        ranker = CollisionRanker([
+            {'kind': 'foo'},
+            {'kind': 'bar'},
+        ])
+
+        shape = None
+        props = {'kind': 'bar'}
+        fid = 1
+        rank = ranker((shape, props, fid))
+
+        # bar is the second in the list, so we should get 2 in response.
+        self.assertEqual(rank, 2)
+
+    def test_complex_filter(self):
+        from vectordatasource.collision import CollisionRanker
+
+        ranker = CollisionRanker([
+            {'kind': 'foo', 'population': {'min': 1000}},
+            {'kind': 'foo'},
+        ])
+
+        # check that filter expressions can be used to modify the behaviour.
+        for population, expected_rank in [(999, 2), (1000, 1)]:
+            shape = None
+            props = {'kind': 'foo', 'population': population}
+            fid = 1
+            rank = ranker((shape, props, fid))
+
+            self.assertEqual(rank, expected_rank)

--- a/vectordatasource/collision.py
+++ b/vectordatasource/collision.py
@@ -11,10 +11,33 @@ class CollisionRanker(object):
         index = 1
         matchers = []
         for case in cases:
-            matcher = create_matcher(
-                {'filter': case, 'index': index}, _output_fn)
-            matchers.append(matcher)
-            index += 1
+            assert isinstance(case, dict)
+
+            # if it's a reserved block, check the syntax and assert that the
+            # indices are reserved. note that reserved block indices are
+            # inclusive of both the "from" and "to".
+            if '_reserved' in case:
+                # reserved should be the only key, to avoid confusion with
+                # filter blocks.
+                assert case.keys() == ['_reserved']
+
+                reserved = case['_reserved']
+                from_index = reserved['from']
+                to_index = reserved['to']
+
+                # check that we've not used this index already.
+                assert index <= from_index, "Unable to satisfy reserved " \
+                    "block: already at index %d, and wanted to reserve " \
+                    "from %d." % (index, from_index)
+
+                # start counting again past the "to" reserved index.
+                index = to_index + 1
+
+            else:
+                matcher = create_matcher(
+                    {'filter': case, 'index': index}, _output_fn)
+                matchers.append(matcher)
+                index += 1
 
         filter_compiler = FilterCompiler()
         ast_fn, compiled_fn = filter_compiler.compile(

--- a/vectordatasource/collision.py
+++ b/vectordatasource/collision.py
@@ -1,0 +1,28 @@
+from vectordatasource.meta.python import FilterCompiler
+from vectordatasource.meta.python import create_matcher
+
+
+class CollisionRanker(object):
+
+    def __init__(self, cases):
+        def _output_fn(datum):
+            return datum['index']
+
+        index = 1
+        matchers = []
+        for case in cases:
+            matcher = create_matcher(
+                {'filter': case, 'index': index}, _output_fn)
+            matchers.append(matcher)
+            index += 1
+
+        filter_compiler = FilterCompiler()
+        ast_fn, compiled_fn = filter_compiler.compile(
+            matchers, 'collision_rank')
+
+        self.fn = compiled_fn
+
+    def __call__(self, feature):
+        shape, props, fid = feature
+        meta = None
+        return self.fn(shape, props, fid, meta)

--- a/vectordatasource/collision.py
+++ b/vectordatasource/collision.py
@@ -22,16 +22,25 @@ class CollisionRanker(object):
                 assert case.keys() == ['_reserved']
 
                 reserved = case['_reserved']
-                from_index = reserved['from']
-                to_index = reserved['to']
 
-                # check that we've not used this index already.
-                assert index <= from_index, "Unable to satisfy reserved " \
-                    "block: already at index %d, and wanted to reserve " \
-                    "from %d." % (index, from_index)
+                # we can reserve either a specific range of indices, or a
+                # count.
+                if reserved.keys() == ['count']:
+                    # just increment the index to skip. we can't collide with
+                    # anything, so there's no assertion to make.
+                    index += reserved['count']
 
-                # start counting again past the "to" reserved index.
-                index = to_index + 1
+                else:
+                    from_index = reserved['from']
+                    to_index = reserved['to']
+
+                    # check that we've not used this index already.
+                    assert index <= from_index, "Unable to satisfy reserved " \
+                        "block: already at index %d, and wanted to reserve " \
+                        "from %d." % (index, from_index)
+
+                    # start counting again past the "to" reserved index.
+                    index = to_index + 1
 
             else:
                 matcher = create_matcher(

--- a/vectordatasource/meta/python.py
+++ b/vectordatasource/meta/python.py
@@ -484,11 +484,7 @@ def make_zoom_assignment():
 
 
 def parse_layer_from_yaml(
-        ast_state, yaml_data, layer_name, output_fn, fn_name_fn):
-    matchers = []
-    for yaml_datum in yaml_data['filters']:
-        matcher = create_matcher(yaml_datum, output_fn)
-        matchers.append(matcher)
+        ast_state, matchers, fn_name):
     stmts = []
     for matcher in matchers:
         # columns in the query should be those needed by the rule, union those
@@ -509,7 +505,7 @@ def parse_layer_from_yaml(
     stmts = prepend_statements + stmts
 
     func = ast.FunctionDef(
-        fn_name_fn(layer_name),
+        fn_name,
         ast.arguments([
             ast.Name('shape', ast.Param()),
             ast.Name('props', ast.Param()),
@@ -525,6 +521,49 @@ def make_empty_ast_state():
     return AstState(False, False, False)
 
 
+class FilterCompiler(object):
+
+    def __init__(self):
+        scope = {}
+        import_asts = []
+
+        # add in required functions into scope for call availability
+        for func_name in dir(function):
+            fn = getattr(function, func_name)
+            if callable(fn):
+                scope[func_name] = fn
+                import_ast = ast.ImportFrom(
+                    'vectordatasource.meta.function',
+                    [ast.alias(func_name, None)],
+                    0,
+                )
+                import_asts.append(import_ast)
+
+        scope['util'] = util
+        utils_import_ast = ast.ImportFrom(
+            'vectordatasource',
+            [ast.alias('util', None)],
+            0,
+        )
+        import_asts.append(utils_import_ast)
+
+        self.import_asts = import_asts
+        self.scope = scope
+
+    def compile(self, matchers, fn_name):
+        ast_state = make_empty_ast_state()
+        ast_fn = parse_layer_from_yaml(
+            ast_state, matchers, fn_name)
+
+        mod = ast.Module([ast_fn])
+        mod_with_linenos = ast.fix_missing_locations(mod)
+        code = compile(mod_with_linenos, '<string>', 'exec')
+        exec code in self.scope
+        compiled_fn = self.scope[fn_name]
+
+        return ast_fn, compiled_fn
+
+
 LayerParseResult = namedtuple(
     'LayerParseResult', 'layer_data import_asts')
 
@@ -534,47 +573,25 @@ def parse_layers(yaml_path, output_fn, fn_name_fn):
     layers = ('landuse', 'pois', 'transit', 'water', 'places', 'boundaries',
               'buildings', 'roads', 'earth', 'admin_areas')
 
-    scope = {}
-    import_asts = []
-
-    # add in required functions into scope for call availability
-    for func_name in dir(function):
-        fn = getattr(function, func_name)
-        if callable(fn):
-            scope[func_name] = fn
-            import_ast = ast.ImportFrom(
-                'vectordatasource.meta.function',
-                [ast.alias(func_name, None)],
-                0,
-            )
-            import_asts.append(import_ast)
-
-    scope['util'] = util
-    utils_import_ast = ast.ImportFrom(
-        'vectordatasource',
-        [ast.alias('util', None)],
-        0,
-    )
-    import_asts.append(utils_import_ast)
+    filter_compiler = FilterCompiler()
 
     for layer in layers:
         file_path = os.path.join(yaml_path, '%s.yaml' % layer)
         with open(file_path) as fh:
             yaml_data = yaml.load(fh)
 
-        ast_state = make_empty_ast_state()
-        ast_fn = parse_layer_from_yaml(
-            ast_state, yaml_data, layer, output_fn, fn_name_fn)
+        matchers = []
+        for yaml_datum in yaml_data['filters']:
+            matcher = create_matcher(yaml_datum, output_fn)
+            matchers.append(matcher)
 
-        mod = ast.Module([ast_fn])
-        mod_with_linenos = ast.fix_missing_locations(mod)
-        code = compile(mod_with_linenos, '<string>', 'exec')
-        exec code in scope
-        compiled_fn = scope[fn_name_fn(layer)]
+        fn_name = fn_name_fn(layer)
+        ast_fn, compiled_fn = filter_compiler.compile(matchers, fn_name)
         layer_datum = FunctionData(layer, ast_fn, compiled_fn)
         layer_data.append(layer_datum)
 
-    layer_parse_result = LayerParseResult(layer_data, import_asts)
+    layer_parse_result = LayerParseResult(
+        layer_data, filter_compiler.import_asts)
     return layer_parse_result
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8447,7 +8447,7 @@ def add_collision_rank(ctx):
         layer_name = layer['layer_datum']['name']
         for shape, props, fid in layer['features']:
             props_with_layer = props.copy()
-            props_with_layer['layer'] = layer_name
+            props_with_layer['$layer'] = layer_name
             rank = ranker((shape, props_with_layer, fid))
             if rank is not None:
                 props['collision_rank'] = rank


### PR DESCRIPTION
Adds a method for assigning collision ranks to features.

### Method 

The idea of a collision rank is that it's a unique integer assigned to everything that gets labelled. See #988 for more background. This adds a new resource, `spreadsheets/collision_rank.yaml`, which is a YAML-encoded list of filters. The syntax of the filters is the same as the `kind` & `min_zoom` YAML in the `yaml/` directory (hopefully this minimises the amount of duplication, and means we can share bug fixes and/or new features).

Each feature is checked against each filter in turn, and is assigned the `collision_rank` corresponding to the matching index. Indices start at 1, are incremented by one for each filter, and can have "reserved blocks" which skip the index counter onwards. For example, if `collision_rank.yaml` contains:

```yaml
- kind: foo
- kind: bar
- _reserved: {from: 10, to: 20}
- kind: baz
```

Then a feature with:

*  `kind: foo` would get `collision_rank: 1`,
*  `kind: bar` would get `collision_rank: 2`,
*  `kind: baz` would get `collision_rank: 21`.

Note that indices 3-9 are unused in this example, but if we added an entry after `bar`, then it would be assigned 3. The code asserts that indices are unique, so we can't accidentally overflow the reserved blocks. Both the `from` and `to` values are inclusive, hence `baz` is assigned the next index, 21.

### Why not use a CSV

We've been managing `sort_rank` with CSVs, but the issue is that we often don't care about the exact value of the `sort_rank`, but want to easily insert values and re-order the following lines. Having the `sort_rank` explicitly in the file means that any such re-arrangement has a very large diff, and is hard to check visually. This is an experiment to see if we can make something that still gives the features we want, but without the drawbacks of the CSV.

Additionally, the CSVs tended to get mangled by Excel when loading and/or saving, as we were using a bunch of special characters to indicate things such as "any" `*` or "must be null" `-` .

Finally, CSV files can't contain comments, but YAML ones can. This will make future maintenance easier, as we can comment `# this reserved block for X, Y or Z`.

Connects to #988.
