### PR TITLE
Add HGV properties

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1468,7 +1468,7 @@ The `hgv` property indicates general truck heavy goods vehicle truck access, val
 
 **Roads `hgv_restriction` values:**
 
-For `hgv_restriction` property indicates general truck heavy goods vehicle truck access restrictions, values include: `weight` (kg), `height` (cm), `length` (cm), `width` (cm), `wpa` (weight per axle, in kg), `kpra` (king pin to rear axle leght, in cm), `hazmat`, `other` and `multiple` if more than one.
+For `hgv_restriction` property indicates general truck heavy goods vehicle truck access restrictions, values include: `weight` (metric tonnes), `height` (metres), `length` (metres), `width` (metres), `wpa` (weight per axle, in metric tonnes), `kpra` (king pin to rear axle leght, in metric tonnes), `hazmat` (true if restricted, otherwise omitted), `other` and `multiple` if more than one.
 
 
 #### Roads layer network values

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -520,7 +520,6 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `dog_park`
 * `embankment` - A raised area of land, usually to carry a road or railway.
 * `enclosure`
-* `low_emission_zone` - An area beloging to a low emission zone, such as the (London Low Emission Zone)[https://en.wikipedia.org/wiki/London_low_emission_zone]. (See also)[https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dlow_emission_zone].
 * `farm`
 * `farmland`
 * `farmyard`
@@ -548,6 +547,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 * `kerb` line.
 * `land`
 * `library`
+* `low_emission_zone` - An area beloging to a low emission zone, such as the (London Low Emission Zone)[https://en.wikipedia.org/wiki/London_low_emission_zone]. (See also)[https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dlow_emission_zone].
 * `maze`
 * `meadow`
 * `military`

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -2,7 +2,7 @@
 from . import FixtureTest
 
 
-class HgvTest(FixtureTest):
+class LowEmissionZoneTest(FixtureTest):
 
     def test_low_emission_zone_way(self):
         import dsl
@@ -25,3 +25,28 @@ class HgvTest(FixtureTest):
                 'min_zoom': lambda z: 12 <= z < 13,
                 'kind': 'low_emission_zone',
             })
+
+
+class HgvRoadPropertiesTest(FixtureTest):
+
+    def test_hgv_access(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        for value in ('no', 'designated', 'destination', 'delivery', 'local',
+                      'agricultural'):
+            self.generate_fixtures(
+                dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                    'highway': 'unclassified',
+                    'hgv': value,
+                    'source': 'openstreetmap.org',
+                }),
+            )
+
+            self.assert_has_feature(
+                z, x, y, 'roads', {
+                    'kind': 'minor_road',
+                    'kind_detail': 'unclassified',
+                    'hgv': value,
+                })

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -29,7 +29,7 @@ class LowEmissionZoneTest(FixtureTest):
 
 class HgvRoadPropertiesTest(FixtureTest):
 
-    def test_hgv_access(self):
+    def test_access(self):
         import dsl
 
         z, x, y = (16, 0, 0)
@@ -51,7 +51,7 @@ class HgvRoadPropertiesTest(FixtureTest):
                     'hgv': value,
                 })
 
-    def test_hgv_whitelist(self):
+    def test_access_whitelist(self):
         import dsl
 
         z, x, y = (16, 0, 0)
@@ -70,3 +70,82 @@ class HgvRoadPropertiesTest(FixtureTest):
                 'kind_detail': 'unclassified',
                 'hgv': type(None),
             })
+
+    def _check_restriction(self, tags, restriction=None, shield_text=None):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        all_tags = tags.copy()
+        all_tags.update({
+            'highway': 'unclassified',
+            'source': 'openstreetmap.org',
+        })
+        self.generate_fixtures(dsl.way(1, dsl.tile_diagonal(z, x, y), all_tags))
+
+        expect = {
+            'kind': 'minor_road',
+            'kind_detail': 'unclassified',
+        }
+        if restriction:
+            expect['hgv_restriction'] = restriction
+        if shield_text:
+            expect['hgv_restriction_shield_text'] = shield_text
+
+        self.assert_has_feature(z, x, y, 'roads', expect)
+
+    def test_restriction_weight(self):
+        self._check_restriction(
+            {'maxweight': 1.5},
+            restriction='weight', shield_text='1.5t',
+        )
+
+    def test_restriction_height(self):
+        self._check_restriction(
+            {'maxheight': 2.0},
+            restriction='height', shield_text='2m',
+        )
+
+    def test_restriction_height_imperial(self):
+        # this rounds _down_ to 1.9m, since 6'6" is 1.98m, so that it doesn't
+        # mistakenly indicate that a vehicle which is 1.99m would be allowed
+        # to pass.
+        self._check_restriction(
+            {'maxheight': "6'6\""},
+            restriction='height', shield_text='1.9m',
+        )
+
+    def test_restriction_width(self):
+        self._check_restriction(
+            {'maxwidth': 3},
+            restriction='width', shield_text='3m',
+        )
+
+    def test_restriction_width_imperial(self):
+        self._check_restriction(
+            {'maxwidth': "6'6\""},
+            restriction='width', shield_text='1.9m',
+        )
+
+    def test_restriction_length(self):
+        self._check_restriction(
+            {'maxlength': 3},
+            restriction='length', shield_text='3m',
+        )
+
+    def test_restriction_wpa(self):
+        self._check_restriction(
+            {'maxaxleload': 1.5},
+            restriction='wpa', shield_text='1.5t',
+        )
+
+    def test_restriction_hazmat(self):
+        self._check_restriction(
+            {'hazmat': 'no'},
+            restriction='hazmat')
+
+    def test_restriction_multiple(self):
+        self._check_restriction(
+            {'maxheight': 1.5,
+             'maxweight': 1.5},
+            restriction='multiple')

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class HgvTest(FixtureTest):
+
+    def test_low_emission_zone_way(self):
+        import dsl
+
+        z, x, y = (13, 4212, 2702)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/373249337
+            dsl.way(373249337, dsl.box_area(z, x, y, 8608219), {
+                'boundary': 'low_emission_zone',
+                'name': 'Milieuzone Utrecht',
+                'source': 'openstreetmap.org',
+                'website': 'http://www.utrecht.nl/verkeersbeleid/milieuzone/',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 373249337,
+                'min_zoom': lambda z: 12 <= z < 13,
+                'kind': 'low_emission_zone',
+            })

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -50,3 +50,23 @@ class HgvRoadPropertiesTest(FixtureTest):
                     'kind_detail': 'unclassified',
                     'hgv': value,
                 })
+
+    def test_hgv_whitelist(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'highway': 'unclassified',
+                'hgv': 'not_a_whitelisted_value',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'kind': 'minor_road',
+                'kind_detail': 'unclassified',
+                'hgv': type(None),
+            })

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -149,3 +149,58 @@ class HgvRoadPropertiesTest(FixtureTest):
             {'maxheight': 1.5,
              'maxweight': 1.5},
             restriction='multiple')
+
+
+class TollTest(FixtureTest):
+
+    def test_toll(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        values = {
+            'yes': True,
+            'some_random_value': True,
+            'no': type(None),
+        }
+
+        for value, expect in values.items():
+            self.generate_fixtures(
+                dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                    'highway': 'unclassified',
+                    'toll': value,
+                    'source': 'openstreetmap.org',
+                }),
+            )
+
+            self.assert_has_feature(
+                z, x, y, 'roads', {
+                    'kind': 'minor_road',
+                    'toll': expect,
+                })
+
+    def test_hgv_toll(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        values = {
+            'yes': True,
+            'some_random_value': True,
+            'no': type(None),
+        }
+
+        for value, expect in values.items():
+            self.generate_fixtures(
+                dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                    'highway': 'unclassified',
+                    'toll:hgv': value,
+                    'source': 'openstreetmap.org',
+                }),
+            )
+
+            self.assert_has_feature(
+                z, x, y, 'roads', {
+                    'kind': 'minor_road',
+                    'toll_hgv': expect,
+                })

--- a/queries.yaml
+++ b/queries.yaml
@@ -225,6 +225,7 @@ layers:
       - vectordatasource.transform.normalize_cycleway
       - vectordatasource.transform.add_is_bicycle_related
       - vectordatasource.transform.add_road_network_from_ncat
+      - vectordatasource.transform.add_vehicle_restrictions
       - vectordatasource.transform.road_trim_properties
       - vectordatasource.transform.remove_feature_id
       - vectordatasource.transform.tags_remove

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -1357,3 +1357,17 @@ filters:
     output:
       <<: *output_properties
       kind: quay
+
+  # Low Emissions Zones
+  - filter:
+      any:
+        - {boundary: low_emission_zone}
+        # NOTE: this seems to be an outdated tag, but still used on 15 objects
+        # at the time of writing, including the London "Ultra Low Emission Zone"
+        # -- although this won't show up as it hasn't been mapped enough to form
+        # a closed polygon yet.
+        - {type: LEZ}
+    min_zoom: { clamp: { min: 11, max: 16, value: { sum: [ { col: zoom }, 6.5 ] } } }
+    output:
+      <<: *output_properties
+      kind: low_emission_zone

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -27,6 +27,7 @@ global:
       motor_vehicle: {col: tags->motor_vehicle}
       access: {col: access}
       bicycle: {col: bicycle}
+      hgv: {col: hgv}
       service: {col: service}
       sport: {col: sport}
       surface:

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -27,7 +27,10 @@ global:
       motor_vehicle: {col: tags->motor_vehicle}
       access: {col: access}
       bicycle: {col: bicycle}
-      hgv: {col: hgv}
+      hgv:
+        case:
+          - when: {hgv: [agricultural, delivery, designated, destination, local, 'no']}
+            then: {col: hgv}
       service: {col: service}
       sport: {col: sport}
       surface:

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -94,6 +94,13 @@ global:
             then: {col: embankment}
           - when: {embankment: [both, two_sided]}
             then: 'yes'
+      # vehicle dimensions / content restrictions
+      maxweight: {col: maxweight}
+      maxheight: {col: maxheight}
+      maxwidth: {col: maxwidth}
+      maxlength: {col: maxlength}
+      maxaxleload: {col: maxaxleload}
+      hazmat: {col: hazmat}
   - &osm_network
       mz_networks: {col: mz_networks}
       network: {col: network}

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -94,6 +94,21 @@ global:
             then: {col: embankment}
           - when: {embankment: [both, two_sided]}
             then: 'yes'
+
+      # tolls
+      toll:
+        case:
+          - when:
+              toll: true
+              not: {toll: 'no'}
+            then: true
+      toll_hgv:
+        case:
+          - when:
+              "toll:hgv": true
+              not: {"toll:hgv": 'no'}
+            then: true
+
       # vehicle dimensions / content restrictions
       maxweight: {col: maxweight}
       maxheight: {col: maxheight}


### PR DESCRIPTION
Add:

* `low_emission_zone` polygons in `landuse`.
* `hgv_restriction` for `roads` as documented, with a value of `weight`, `height`, `width`, `length`, `wpa`, `hazmat` or `multiple`.
* `hgv_restriction_shield_text` for `roads` as documented, with a number + unit quantity where available (i.e: for all except `hazmat`).
* `hgv` restriction on `roads`; one of `agricultural`, `delivery`, `designated`, `destination`, `local`, `no`.
* `toll` and `toll_hgv` on `roads`; `true` when present, omitted default of `false`.

Notes:

* The documentation was originally confused about whether units for length should be cm or metres, kg or metric tonnes. I've settled on metres and tonnes, as these produce shield text closer to signage actually seen in Real Life, such as 10t or 3m, and also shorter shield text (1.5t vs 1,500kg).
* The documentation describes a `kpra` restriction, but I wasn't able to find a commonly-used OSM tag which corresponds to that, so I've left it out. If we find one, we can add it in a follow-up.
* I've added the restriction and shield text for `roads` layer line geometries, but not yet points. We might need to give some more thought to that, since the points at the end of the road ought to represent the addition of restrictions in the direction of travel and therefore we need to consider the restrictions _between_ two roads. In other words, we wouldn't want to insert a point a the start of a road with the same or less restrictive restriction than the previous one. This requirement to consider connectivity is not simple with our current architecture, as we'd have to reconstruct it from the `planet_osm_ways` table - something we currently do to figure out if a gate is on a road, but gates are (comparatively) rare and working out which are the ingress nodes onto a way is significantly more complex.

Connects to #1553.
