### PR TITLE
Make water label dropping work for NE at low zooms

### DIFF
--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -122,31 +122,49 @@ def is_in(iso_code, z, x, y, way_id=-1):
     })
 
 
-def box_area(z, x, y, area):
+def box_area(z, x, y, area, include_boundary=False):
     """
     Returns a Shapely Polygon which is in the z/x/y tile and has the given
     area in Mercator square meters.
+
+    If include_boundary is truthy, set up the shape such that the boundary
+    is part of the tile. Try to keep the centroid within the tile. If that
+    isn't possible, throw an exception.
     """
 
-    from tilequeue.tile import coord_to_mercator_bounds
-    from tilequeue.tile import reproject_mercator_to_lnglat
-    from shapely.geometry import box
-    from shapely.ops import transform
     from ModestMaps.Core import Coordinate
     from math import sqrt
+    from shapely.geometry import box
+    from shapely.ops import transform
+    from tilequeue.tile import coord_to_mercator_bounds
+    from tilequeue.tile import half_earth_circum
+    from tilequeue.tile import reproject_mercator_to_lnglat
 
     bounds = coord_to_mercator_bounds(Coordinate(zoom=z, column=x, row=y))
-    size = sqrt(area)
+
+    if include_boundary:
+        # make the shape 90% of the tile's height, and whatever width is
+        # necessary for that without wrapping around the world.
+        size_y = 0.9 * (bounds[3] - bounds[1])
+        size_x = area / size_y
+
+    else:
+        # otherwise, a square shape is easiest to reason about.
+        size_y = size_x = sqrt(area)
 
     # make a shape with the given size
     centre_x = 0.5 * (bounds[0] + bounds[2])
     centre_y = 0.5 * (bounds[1] + bounds[3])
 
+    def _check(coord):
+        assert -half_earth_circum <= coord <= half_earth_circum
+        return coord
+
     mercator_shape = box(
-        centre_x - 0.5 * size,
-        centre_y - 0.5 * size,
-        centre_x + 0.5 * size,
-        centre_y + 0.5 * size,
+        _check(centre_x - 0.5 * size_x),
+        _check(centre_y - 0.5 * size_y),
+        _check(centre_x + 0.5 * size_x),
+        _check(centre_y + 0.5 * size_y),
     )
 
     return transform(reproject_mercator_to_lnglat, mercator_shape)

--- a/queries.yaml
+++ b/queries.yaml
@@ -485,6 +485,26 @@ post_process:
         boundary: [true]
         area: true
       snap_tolerance: 0.125
+
+  # the NE water queries pull in the full set of object properties for boundary
+  # lines, which we don't want. strip them off here.
+  - fn: vectordatasource.transform.drop_names
+    params:
+      source_layer: water
+      start_zoom: 0
+      end_zoom: 8
+      geom_types: [LineString, MultiLineString]
+      where: >-
+        kind == 'lake' and boundary
+  - fn: vectordatasource.transform.drop_properties
+    params:
+      source_layer: water
+      start_zoom: 0
+      end_zoom: 8
+      properties: [mz_label_placement]
+      where: >-
+        kind == 'lake' and boundary
+
   # have to do the water properties matching _after_ exterior boundaries
   # as it depends on having the "boundary: yes" property available.
   - fn: vectordatasource.transform.csv_match_properties

--- a/queries.yaml
+++ b/queries.yaml
@@ -477,7 +477,7 @@ post_process:
   - fn: vectordatasource.transform.exterior_boundaries
     params:
       base_layer: water
-      start_zoom: 9
+      start_zoom: 8
       prop_transform:
         kind: true
         id: true


### PR DESCRIPTION
In #1775, we tried to drop water labels at low zooms. However, the tests didn't take into account that we do not use the `exterior_boundaries` post-processor to extract water boundaries from NE data - we query them directly from the database. This means they come with a full set of names and `mz_label_placement`, and they generate water labels.

I've fixed the tests to reflect how we actually query NE lakes, and added post-process stages to remove the names and label placement geometry from the tile.

Also, I noticed that we weren't generating water boundaries at zoom 8 because we hadn't updated `start_zoom` to match when we switched to using OSM at zoom 8. So fixed that too.

Connects to #1730.