### PR TITLE
Clip to Mercator world bounds before projecting shapefiles.

### DIFF
--- a/data/Makefile-prepare-data.jinja2
+++ b/data/Makefile-prepare-data.jinja2
@@ -1,3 +1,8 @@
+# clip input to the bounds of EPSG:3857 _before_ projecting. this ensures that
+# there are no unprojectable points, but that the data fills the all the way to
+# the corners of the world.
+OGR_CLIP_OPTS=-clipsrc -180 -85.051128779806604 180 85.051128779806604
+
 all: download shapefiles
 
 upload: shapefiles
@@ -22,7 +27,7 @@ download: {{ src_shapefile_zips }}
 	touch {{ shapefile.src_shp }}
 
 {{ shapefile.tgt_shp }}: {{ shapefile.src_shp }}
-	OGR_ENABLE_PARTIAL_REPROJECTION=1 ogr2ogr -t_srs EPSG:3857 -lco encoding=utf8 {{ shapefile.tgt_shp }} {{ shapefile.src_shp }}
+	ogr2ogr $(OGR_CLIP_OPTS) -t_srs EPSG:3857 -lco encoding=utf8 {{ shapefile.tgt_shp }} {{ shapefile.src_shp }}
 {% if shapefile.tile %}
 	python tile-shapefile.py {{ shapefile.tgt_shp }} tiled-{{ shapefile.tgt_shp }}
 	rm -f {{ shapefile.tgt_shp_wildcard }}


### PR DESCRIPTION
Previously, we had set an option to make `ogr2ogr` drop points which could not be projected into Mercator coordinates. This generally worked fine, and we ended up with output that looked correct.

However, the 1:110M oceans polygon was being truncated because there wasn't a point at exactly the corner of the Mercator world, and dropping the out-of-range points left a bit of a gap.

We can fix this by clipping (i.e: intersecting) with the Mercator world bounds before projecting. This should ensure that points are within the destination projection without the need to drop them. It's effectively inserting a point at the corner of the Mercator world.

Connects to #1806.
