### PR TITLE
Update min zoom of water label points.

### DIFF
--- a/integration-test/1730-further-water-layer-name-dropping.py
+++ b/integration-test/1730-further-water-layer-name-dropping.py
@@ -172,3 +172,52 @@ class LowZoomWaterTest(NELakeFixtureTest):
                 'name': type(None),
                 'name:fr': type(None),
             })
+
+
+class WaterLabelZoomAdjustmentTest(FixtureTest):
+
+    def test_label_lake_athabasca_z5(self):
+        import dsl
+
+        z, x, y = (5, 6, 9)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.box_area(z, x, y, 31390412728.710949), {
+                'featurecla': u'Lake',
+                'label': u'Lake Athabasca',
+                'min_label': 3.7,
+                'min_zoom': 2.0,
+                'name': u'Lake Athabasca',
+                'name_abb': u'L. Athabasca',
+                'name_de': u'Athabascasee',
+                'name_en': u'Lake Athabasca',
+                'name_es': u'Lago Athabasca',
+                'name_fr': u'lac Athabasca',
+                'name_hu': u'Atabaszk-tó',
+                'name_it': u'Athabasca',
+                'name_ja': u'アサバスカ湖',
+                'name_nl': u'Athabascameer',
+                'name_pl': u'Athabaska',
+                'name_pt': u'Lago Athabasca',
+                'name_ru': u'Атабаска',
+                'name_sv': u'Athabascasjön',
+                'name_tr': u'Athabasca Gölü',
+                'name_zh': u'阿薩巴斯卡湖',
+                'ne_id': u'1159106863',
+                'scalerank': 2,
+                'source': u'naturalearthdata.com',
+                'wdid_score': 4,
+                'wikidataid': u'Q272463',
+            }),
+        )
+
+        # we should get a label placement point, and its zoom should have been
+        # adjusted. we should also have all the names at this point.
+        self.assert_has_feature(
+            z, x, y, 'water', {
+                'kind': 'lake',
+                'label_placement': True,
+                'min_zoom': 5,
+                'name': str,
+                'name:de': str,
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -777,35 +777,6 @@ post_process:
       where: >-
         kind == 'lake'
 
-  # some water polygon features are too small to need a label - and if we label
-  # them then the label is often so prominent that it hides the polygon it's
-  # for! see the images here for examples of this:
-  # https://github.com/tilezen/vector-datasource/issues/1477#issuecomment-447162484
-  #
-  # therefore, we want to remove the name properties from those small water
-  # polygon features before we extract the label placements in a following step.
-  - fn: vectordatasource.transform.drop_names
-    params:
-      source_layer: water
-      start_zoom: 4
-      end_zoom: 16
-      geom_types: [Polygon, MultiPolygon]
-      where: >-
-        area < {
-            4:  40000000000,
-            5:  10000000000,
-            6:   5000000000,
-            7:    400000000,
-            8:    200000000,
-            9:    100000000,
-            10:    10000000,
-            11:     4000000,
-            12:      750000,
-            13:      100000,
-            14:       50000,
-            15:       10000,
-        }.get(zoom)
-
   - fn: vectordatasource.transform.handle_label_placement
     params:
       layers:
@@ -816,6 +787,40 @@ post_process:
       label_property_value: true
       label_where: >-
         'name' in properties
+
+  # some water polygon features are too small to need a label - and if we label
+  # them then the label is often so prominent that it hides the polygon it's
+  # for! see the images here for examples of this:
+  # https://github.com/tilezen/vector-datasource/issues/1477#issuecomment-447162484
+  #
+  # we want to reset min_zoom on these features and screen them out if they
+  # don't meet minimum sizes per zoom.
+  - fn: vectordatasource.transform.update_min_zoom
+    params:
+      source_layer: water
+      start_zoom: 4
+      end_zoom: 16
+      # the inclusion of "None" in the list might seem odd, but None compares
+      # numerically smaller than any integer, so acts as a default for this
+      # table.
+      min_zoom: >-
+        [min_zoom for min_zoom, area_threshold in [
+            (4,  40000000000),
+            (5,  10000000000),
+            (6,   5000000000),
+            (7,    400000000),
+            (8,    200000000),
+            (9,    100000000),
+            (10,    10000000),
+            (11,     4000000),
+            (12,      750000),
+            (13,      100000),
+            (14,       50000),
+            (15,       10000),
+            (16,        None),
+        ] if area >= area_threshold][0]
+      where: >-
+        kind == 'lake' and label_placement
 
   - fn: vectordatasource.transform.handle_label_placement
     params:


### PR DESCRIPTION
Instead of using the `min_zoom` of the original feature and dropping the label when the feature was too small, instead reset the `min_zoom` of the newly-created label feature and then limit based on that.

Connects to #1730.