### PR TITLE
Increase min zoom for POIs to at least match their landuse AOIs

### DIFF
--- a/integration-test/1794-demote-landuse-pois.py
+++ b/integration-test/1794-demote-landuse-pois.py
@@ -1,0 +1,68 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class PoiMinZoomTest(FixtureTest):
+
+    def _check(self, props, landuse_zoom, poi_zoom=None, kind=None):
+        import dsl
+
+        if kind is None:
+            assert len(props) == 1
+            kind = props.values()[0]
+
+        if poi_zoom is None:
+            poi_zoom = landuse_zoom
+
+        x, y = 0, 0
+        tags = {
+            'source': 'openstreetmap.org',
+            'name': 'Insert Name Here',
+        }
+        tags.update(props)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(landuse_zoom, x, y), tags),
+        )
+
+        self.assert_has_feature(
+            landuse_zoom, x, y, 'landuse', {
+                'min_zoom': landuse_zoom,
+            })
+        zdiff = landuse_zoom - poi_zoom
+        pcoord = (1 << (zdiff - 1)) - 1 if zdiff > 0 else 0
+        self.assert_has_feature(
+            poi_zoom, pcoord, pcoord, 'pois', {
+                'min_zoom': poi_zoom,
+            })
+
+    def test_quay(self):
+        self._check({'landuse': 'quay'}, 16)
+        self._check({'man_made': 'quay'}, 16)
+
+    def test_range(self):
+        self._check({'military': 'range'}, 11)
+
+    def test_wharf(self):
+        self._check({'landuse': 'wharf'}, 16)
+
+    def test_boatyard(self):
+        self._check({'waterway': 'boatyard'}, 15)
+
+    def test_shipyard(self):
+        self._check({'landuse': 'shipyard'}, 15)
+
+    def test_danger_area(self):
+        self._check({'military': 'danger_area'}, 11)
+
+    def test_port_terminal(self):
+        self._check({'landuse': 'port_terminal'}, 13)
+
+    def test_sports_centre(self):
+        self._check({'leisure': 'sports_centre'}, 12)
+
+    def test_ferry_terminal(self):
+        self._check({'landuse': 'ferry_terminal'}, 13)
+
+    def test_container_terminal(self):
+        self._check({'landuse': 'container_terminal'}, 13)

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -792,15 +792,22 @@ filters:
       kind: {col: aeroway}
       tier: 3
   # airfield, naval_base
-  - filter: {military: [airfield, range, naval_base]}
+  - filter: {military: [airfield, naval_base]}
     min_zoom: { min: [ { max: [ 8, { sum: [ { col: zoom }, 2 ] }, *tier3_min_zoom ] }, 14 ] }
     output:
       <<: *output_properties
       kind: {col: military}
       tier: 3
+  - filter:
+      military: range
+    min_zoom: { clamp: { max: 16, min: 11, value: { sum: [ { col: zoom }, 1 ] } } }
+    output:
+      <<: *output_properties
+      kind: range
+      tier: 3
   # danger_area
   - filter: {military: danger_area}
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 2.55 ] }, *tier3_min_zoom ] }, 15 ] }
+    min_zoom: { clamp: { max: 16, min: 11, value: { sum: [ { col: zoom }, 1 ] } } }
     output:
       <<: *output_properties
       kind: danger_area
@@ -972,7 +979,7 @@ filters:
   # retail - no POI
   # sports_centre
   - filter: {leisure: sports_centre}
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 3.98 ] }, *tier4_min_zoom ] }, 17 ] }
+    min_zoom: { max: [ 12, *tier4_min_zoom ] }
     output:
       <<: *output_properties
       kind:
@@ -1062,21 +1069,33 @@ filters:
       kind: zoo
       tier: 4
   # other random landuse
-  - filter: {landuse: [container_terminal, port_terminal, quay, shipyard, wharf]}
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 3 ] }, *tier4_min_zoom ] }, 13 ] }
+  - filter: {landuse: [container_terminal, port_terminal]}
+    min_zoom: { clamp: { min: 13, max: 16, value: { sum: [ { col: zoom }, 2.81 ] } } }
+    output:
+      <<: *output_properties
+      kind: {col: landuse}
+      tier: 4
+  - filter: {landuse: [shipyard]}
+    min_zoom: { max: [ 15, *tier4_min_zoom ] }
+    output:
+      <<: *output_properties
+      kind: {col: landuse}
+      tier: 4
+  - filter: {landuse: [quay, wharf]}
+    min_zoom: 16
     output:
       <<: *output_properties
       kind: {col: landuse}
       tier: 4
   # seems odd quay is both landuse and man_made...
   - filter: {man_made: quay}
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 3 ] }, *tier4_min_zoom ] }, 13 ] }
+    min_zoom: 16
     output:
       <<: *output_properties
       kind: quay
       tier: 4
   - filter: {waterway: boatyard}
-    min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 3 ] }, *tier4_min_zoom ] }, 13 ] }
+    min_zoom: { max: [ 15, *tier4_min_zoom ] }
     output:
       <<: *output_properties
       kind: {col: waterway}
@@ -1508,7 +1527,7 @@ filters:
       any:
         amenity: ferry_terminal
         landuse: ferry_terminal
-    min_zoom: { clamp: { min: 11, max: 15, value: { sum: [ { col: zoom }, 3.2 ] } } }
+    min_zoom: { clamp: { min: 13, max: 16, value: { sum: [ { col: zoom }, 2.81 ] } } }
     output:
       <<: *output_properties
       kind: ferry_terminal


### PR DESCRIPTION
If not higher. Context: https://github.com/tilezen/vector-datasource/issues/1794#issuecomment-460125438

Changed:
* Quays & Wharves
* Ranges & Danger areas
* Boatyards & Shipyards
* Sports Centres
* Port, Ferry and Container terminals

Connects to #1794.
