### PR TITLE
Don't create a zero area property on points.

### DIFF
--- a/queries/planet_osm_point.jinja2
+++ b/queries/planet_osm_point.jinja2
@@ -6,7 +6,6 @@ SELECT
   -- common properties across all layers
   to_jsonb(tags) || jsonb_build_object(
     'source', 'openstreetmap.org',
-    'area', 0
   ) AS __properties__,
 
   CASE WHEN mz_building_min_zoom IS NOT NULL


### PR DESCRIPTION
I think this might have been used for something in the past, but I can't find any step or post-processing transform which would require `area=0` to work, so I think it's not needed any more. Rather than set it in the query and strip it off later, I think it's better just to not query it...

Connects to #1825.
