### PR TITLE
Postgres / SQL doesn't allow trailing commas in function calls

### DIFF
--- a/queries/planet_osm_point.jinja2
+++ b/queries/planet_osm_point.jinja2
@@ -5,7 +5,7 @@ SELECT
 
   -- common properties across all layers
   to_jsonb(tags) || jsonb_build_object(
-    'source', 'openstreetmap.org',
+    'source', 'openstreetmap.org'
   ) AS __properties__,
 
   CASE WHEN mz_building_min_zoom IS NOT NULL


### PR DESCRIPTION
Remove the trailing comma to fix the syntax.

Problem introduced in #1828.