### PR TITLE
Fix slow road merging

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1052,6 +1052,11 @@ post_process:
       source_layer: roads
       start_zoom: 0
       end_zoom: 12
+      # this means remove all the names if "name" is one of the properties
+      # we're dropping. in other words, allows us to use "name" as a short-
+      # hand for name:XX, official_name, old_name, etc... without having to
+      # spell all of them out at length.
+      all_name_variants: true
       properties:
         - name
         - ref
@@ -1062,6 +1067,9 @@ post_process:
       source_layer: roads
       start_zoom: 0
       end_zoom: 15
+      # short-hand for "name" property in the list below means all name-like
+      # properties.
+      all_name_variants: true
       properties:
         - name
         - ref
@@ -1202,6 +1210,9 @@ post_process:
       source_layer: roads
       start_zoom: 7
       end_zoom: 11
+      # short-hand for "name" property in the list below means all name-like
+      # properties.
+      all_name_variants: true
       properties:
         - name
         - all_networks
@@ -1210,12 +1221,11 @@ post_process:
         kind == 'major_road'
   # this is a patch to get rid of name, but keep ref & network, for highways
   # when zoom < 11.
-  - fn: vectordatasource.transform.drop_properties
+  - fn: vectordatasource.transform.drop_names
     params:
       source_layer: roads
       start_zoom: 7
       end_zoom: 11
-      properties: [name]
       where: >-
         kind == 'highway'
   # drop name, ref and the multi-shield properties, but keep single-shield
@@ -1225,6 +1235,9 @@ post_process:
       source_layer: roads
       start_zoom: 0
       end_zoom: 7
+      # short-hand for "name" property in the list below means all name-like
+      # properties.
+      all_name_variants: true
       properties:
         - name
         - ref

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1018,3 +1018,22 @@ class AngleAtTest(unittest.TestCase):
 
     def test_angle_at_degenerate(self):
         self._check([[0, 0], [0, 0]], None)
+
+
+class FirstPositiveIntegerNotInTest(unittest.TestCase):
+
+    def _check(self, value, expect):
+        from vectordatasource.transform import _first_positive_integer_not_in
+        self.assertEqual(_first_positive_integer_not_in(value), expect)
+
+    def test_empty(self):
+        self._check(set(), 1)
+
+    def test_one(self):
+        self._check(set([1]), 2)
+
+    def test_hole(self):
+        self._check(set([1, 3, 4]), 2)
+
+    def test_filled_hole(self):
+        self._check(set([1, 2, 3, 4]), 5)

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -2403,9 +2403,12 @@ def drop_properties(ctx):
     """
 
     properties = ctx.params.get('properties')
+    all_name_variants = ctx.params.get('all_name_variants', False)
     assert properties, 'drop_properties: missing properties'
 
     def action(p):
+        if all_name_variants and 'name' in properties:
+            p = _remove_names(p)
         return _remove_properties(p, *properties)
 
     return _project_properties(ctx, action)

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -3949,6 +3949,107 @@ def _merge_junctions(features, angle_tolerance, simplify_tolerance):
     return new_features
 
 
+def _first_positive_integer_not_in(s):
+    """
+    Given a set of positive integers, s, return the smallest positive integer
+    which is _not_ in s.
+
+    For example:
+
+    >>> _first_positive_integer_not_in(set())
+    1
+    >>> _first_positive_integer_not_in(set([1]))
+    2
+    >>> _first_positive_integer_not_in(set([1,3,4]))
+    2
+    >>> _first_positive_integer_not_in(set([1,2,3,4]))
+    5
+    """
+
+    if len(s) == 0:
+        return 1
+
+    last = max(s)
+    for i in xrange(1, last):
+        if i not in s:
+            return i
+    return last + 1
+
+
+# utility class so that we can store the array index of the geometry
+# inside the shape index.
+class _geom_with_index(object):
+    def __init__(self, geom, index):
+        self.geom = geom
+        self.index = index
+        self._geom = geom._geom
+        self.is_empty = geom.is_empty
+
+
+class OrderedSTRTree(object):
+    """
+    An STR-tree geometry index which remembers the array index of the
+    geometries it was built with, and only returns geometries with lower
+    indices when queried.
+
+    This is used as a substitute for a dynamic index, where we'd be able
+    to add new geometries as the algorithm progressed.
+    """
+
+    def __init__(self, geoms):
+        self.shape_index = STRtree([
+            _geom_with_index(g, i) for i, g in enumerate(geoms)
+        ])
+
+    def query(self, shape, idx):
+        """
+        Return the index elements which have bounding boxes intersecting the
+        given shape _and_ have array indices less than idx.
+        """
+
+        for geom in self.shape_index.query(shape):
+            if geom.index < idx:
+                yield geom
+
+
+class SplitOrderedSTRTree(object):
+    """
+    An ordered STR-tree index which splits the geometries it is managing.
+
+    This is a simple, first-order approximation to a dynamic index. If the
+    input geometries are sorted by increasing size, then the "small" first
+    section are much less likely to overlap, and we know we're not interested
+    in anything in the "big" section because the index isn't large enough.
+
+    This should cut down the number of expensive queries, as well as the
+    number of subsequent intersection tests to check if the shapes within the
+    bounding boxes intersect.
+    """
+
+    def __init__(self, geoms):
+        split = int(0.75 * len(geoms))
+        self.small_index = STRtree([
+            _geom_with_index(g, i) for i, g in enumerate(geoms[0:split])
+        ])
+        self.big_index = STRtree([
+            _geom_with_index(g, i + split) for i, g in enumerate(geoms[split:])
+        ])
+        self.split = split
+
+    def query(self, shape, i):
+        for geom in self.small_index.query(shape):
+            if geom.index < i:
+                yield geom
+
+        # don't need to query the big index at all unless i >= split. this
+        # should cut down on the number of yielded items that need further
+        # intersection tests.
+        if i >= self.split:
+            for geom in self.big_index.query(shape):
+                if geom.index < i:
+                    yield geom
+
+
 def _linestring_nonoverlapping_partition(mls):
     """
     Given a MultiLineString input, returns a list of MultiLineStrings
@@ -3972,35 +4073,6 @@ def _linestring_nonoverlapping_partition(mls):
     # only interested in MultiLineStrings for this method!
     assert mls.geom_type == 'MultiLineString'
 
-    class _Bucket(object):
-        def __init__(self, first_shape):
-            self.shapes = [first_shape]
-            self.bounds = first_shape.bounds
-
-        def add(self, shape):
-            """
-            If the shape doesn't intersect any other shape in the bucket,
-            then add it and return True. Otherwise return False.
-            """
-
-            assert shape.geom_type == 'LineString'
-
-            bounds = shape.bounds
-            if _intersects_bounds(self.bounds, bounds):
-                for s in self.shapes:
-                    if s.intersects(shape):
-                        return False
-
-            self.shapes.append(shape)
-            self.bounds = _union_bounds(self.bounds, bounds)
-            return True
-
-        def as_shape(self):
-            if len(self.shapes) == 1:
-                return self.shapes[0]
-            else:
-                return MultiLineString(self.shapes)
-
     # simple (and sub-optimal) greedy algorithm for making sure that
     # linestrings don't intersect: put each into the first bucket which
     # doesn't already contain a linestring which intersects it.
@@ -4021,19 +4093,71 @@ def _linestring_nonoverlapping_partition(mls):
     # of 3 buckets. optimally, we can bucket 1 & 3 together and 2 & 4
     # together to only use 2 buckets. however, making this optimal seems
     # like it might be a Hard problem.
-    buckets = []
-    for shape in sorted(mls.geoms, key=lambda l: l.bounds[0]):
-        for bucket in buckets:
-            if bucket.add(shape):
-                break
-        else:
-            # if it didn't fit in any existing bucket, then make a new
-            # bucket for it.
-            buckets.append(_Bucket(shape))
+    #
+    # note that we don't create physical buckets, but assign each shape a
+    # bucket ID which hasn't been assigned to any other intersecting shape.
+    # we can assign these in an arbitrary order, and use an index to reduce
+    # the number of intersection tests needed down to O(n log n). this can
+    # matter quite a lot at low zooms, where it's possible to get 150,000
+    # tiny road segments in a single shape!
+
+    # sort the geometries before we use them. this can help if we sort things
+    # which have fewer intersections towards the front of the array, so that
+    # they can be done more quickly.
+    def _bbox_area(geom):
+        minx, miny, maxx, maxy = geom.bounds
+        return (maxx - minx) * (maxy - miny)
+
+    # if there's a large number of geoms, switch to the split index and sort
+    # so that the spatially largest objects are towards the end of the list.
+    # this should make it more likely that earlier queries are fast.
+    if len(mls.geoms) > 15000:
+        geoms = sorted(mls.geoms, key=_bbox_area)
+        shape_index = SplitOrderedSTRTree(geoms)
+    else:
+        geoms = mls.geoms
+        shape_index = OrderedSTRTree(geoms)
+
+    # first, assign everything the "null" bucket with index zero. this means
+    # we haven't gotten around to it yet, and we can use it as a sentinel
+    # value to check for logic errors.
+    bucket_for_shape = [0] * len(geoms)
+
+    for idx, shape in enumerate(geoms):
+        overlapping_buckets = set()
+
+        # assign the lowest bucket ID that hasn't been assigned to any
+        # overlapping shape with a lower index. this is because:
+        #  1. any overlapping shape would cause the insertion of a point if it
+        #     were allowed in this bucket, and
+        #  2. we're assigning in-order, so shapes at higher array indexes will
+        #     still be assigned to the null bucket. we'll get to them later!
+        for indexed_shape in shape_index.query(shape, idx):
+            if indexed_shape.geom.intersects(shape):
+                bucket = bucket_for_shape[indexed_shape.index]
+                assert bucket > 0
+                overlapping_buckets.add(bucket)
+
+        bucket_for_shape[idx] = _first_positive_integer_not_in(
+            overlapping_buckets)
 
     results = []
-    for bucket in buckets:
-        results.append(bucket.as_shape())
+    for bucket_id in set(bucket_for_shape):
+        # by this point, no shape should be assigned to the null bucket any
+        # more.
+        assert bucket_id > 0
+
+        # collect all the shapes which have been assigned to this bucket.
+        shapes = []
+        for idx, shape in enumerate(geoms):
+            if bucket_for_shape[idx] == bucket_id:
+                shapes.append(shape)
+
+        if len(shapes) == 1:
+            results.append(shapes[0])
+        else:
+            results.append(MultiLineString(shapes))
+
     return results
 
 


### PR DESCRIPTION
The tile `9/454/201` was taking a _huge_ amount of time to render - several hours. This is due to the changes I made in #1703 to prevent intersections between lines being re-added as part of MultiLineString operations. According to the OGC spec, LineStrings within a MultiLineString may only meet at points, but this means we end up with way more points in the output than we need to accurately describe the geometry. Therefore, we split them up into several features, where each MultiLineString in each feature only contains non-overlapping LineStrings.

The algorithm I was using to do this wasn't efficient - it simply looped over all the features looking for intersections with previous features. And it worked OK on cities with a lower road density and lots of mergeable cross-shaped junctions, such as New York.

However, in Tokyo, where the tile was taking hours to render, there are 400,000 lines in the tile and the road network is not a grid, meaning there's less opportunity for merging.

Therefore, I replaced the previous algorithm with one that is more efficient for larger numbers of tiles. It works by indexing all the shapes rather than doing direct comparison. For large inputs, the shapes are additionally sorted by bounding box area and the index split between small and large. This means that the small-to-small comparisons are done more quickly (any given two small shapes are much less likely to intersect than a small and a large, or a large and a large).

Finally, we have been stripping `name` off roads at low zooms, but were not stripping `name:*` translations or `official_name` and similar "name-like" properties. This PR adds an `all_name_variants` parameter to `drop_properties` which tells it to treat `name` as if it's all `name:*` and variants. One `drop_properties` which was only dropping `name` was converted to `drop_names` instead. Dropping these might (slightly) increase mergeability and will decrease the number of properties stored in the tile.
