### PR TITLE
Fix polygon merging failure.

### DIFF
--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -565,8 +565,10 @@ class DropMergedIdTest(unittest.TestCase):
         def _drop_all_props((shape, props, fid)):
             return None
 
+        tolerance = 1.0e-4
         merged_features = _merge_features_by_property(
-            buildings, _POLYGON_DIMENSION, update_props_pre_fn=_drop_all_props)
+            buildings, _POLYGON_DIMENSION, tolerance,
+            update_props_pre_fn=_drop_all_props)
 
         self.assertEquals(2, len(merged_features))
         for f in merged_features:


### PR DESCRIPTION
Sometimes the GEOS/Shapely polygon merging routine `unary_union` fails with a `ValueError` and message "No Shapely geometry can be created from null value." This means that the union failed, and GEOS is passing back a null value to Shapely. This was repeatably happening with tile `11/1052/672` near Monnickendam in the Netherlands when trying to merge together a lot of very small and closely-spaced field polygons.

The problem appears to be one of numerical instability; because the polygons are very closely spaced, some intersection tests are coming up with nonsensical answers.

I did initially try to fix this by isolating the problem, recursively attempting to merge subsets of the list of polygons until either some small set was unmergeable or the whole thing worked. Unfortunately, this turned out to not be robust because the issue is merging _between_ two polygons, not in the polygon itself. This means that the issue simply resurfaced when aggregating the results of the recursive merge.

An alternative way of fixing this is to `buffer` out a small distance, so that these points of numerical instability are more rare (although we can't guarantee to get rid of them entirely). This seems to be much more stable in practice.

This PR detects failure of the merge and tries again with a small (1/16th pixel) buffer. If that also fails, then it bails and returns an empty result set. The reasoning behind that is that I think we'd prefer to have a tile, even if it's missing some data, than not have a tile at all.
