### PR TITLE
Add whitelisted kind_detail to aerodromes.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -482,7 +482,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 
 #### Landuse `kind` values:
 
-* `aerodrome` - with `kind_detail` in `public`, `private`, `military/public`, `airfield`, `international`, `regional`, `gliding`.
+* `aerodrome` - with `kind_detail` in `public`, `private`, `military_public`, `airfield`, `international`, `regional`, `gliding`.
 * `airfield`
 * `allotments`
 * `amusement_ride`
@@ -881,7 +881,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `administrative`
 * `adult_gaming_centre`
 * `advertising_agency`
-* `aerodrome` - with `kind_detail` in `public`, `private`, `military/public`, `airfield`, `international`, `regional`, `gliding`.
+* `aerodrome` - with `kind_detail` in `public`, `private`, `military_public`, `airfield`, `international`, `regional`, `gliding`.
 * `aeroway_gate`
 * `airfield` for military use.
 * `airport`

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -482,7 +482,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 
 #### Landuse `kind` values:
 
-* `aerodrome`
+* `aerodrome` - with `kind_detail` in `public`, `private`, `military/public`, `airfield`, `international`, `regional`, `gliding`.
 * `airfield`
 * `allotments`
 * `amusement_ride`
@@ -881,7 +881,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `administrative`
 * `adult_gaming_centre`
 * `advertising_agency`
-* `aerodrome`
+* `aerodrome` - with `kind_detail` in `public`, `private`, `military/public`, `airfield`, `international`, `regional`, `gliding`.
 * `aeroway_gate`
 * `airfield` for military use.
 * `airport`

--- a/integration-test/1277-kind-detail-aerodrome.py
+++ b/integration-test/1277-kind-detail-aerodrome.py
@@ -36,7 +36,7 @@ class AerodromeTest(FixtureTest):
         self._check('private', 'private')
 
     def test_military_public(self):
-        self._check('military/public', 'military/public')
+        self._check('military/public', 'military_public')
 
     def test_airfield(self):
         self._check('airfield', 'airfield')

--- a/integration-test/1277-kind-detail-aerodrome.py
+++ b/integration-test/1277-kind-detail-aerodrome.py
@@ -1,0 +1,74 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class AerodromeTest(FixtureTest):
+
+    def _check(self, aerodrome_type, kind_detail):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'aeroway': 'aerodrome',
+                'aerodrome:type': aerodrome_type,
+                'name': 'Fake Aerodrome',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'kind': 'aerodrome',
+                'kind_detail': kind_detail,
+            })
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'kind': 'aerodrome',
+                'kind_detail': kind_detail,
+            })
+
+    def test_public(self):
+        self._check('public', 'public')
+
+    def test_private(self):
+        self._check('private', 'private')
+
+    def test_military_public(self):
+        self._check('military/public', 'military/public')
+
+    def test_airfield(self):
+        self._check('airfield', 'airfield')
+
+    def test_international(self):
+        self._check('international', 'international')
+
+    def test_regional(self):
+        self._check('regional', 'regional')
+
+    def test_gliding(self):
+        self._check('gliding', 'gliding')
+
+    def test_unknown(self):
+        self._check('unknown', type(None))
+
+    def test_military(self):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'aeroway': 'aerodrome',
+                'aerodrome:type': 'military',
+                'name': 'Fake Aerodrome',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        # note: kind=airfield means a _military_ airfield
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'kind': 'airfield',
+            })

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -602,13 +602,25 @@ filters:
   ############################################################
   # TIER 3
   ############################################################
-  - filter: {aeroway: aerodrome}
+  - filter:
+      aeroway: aerodrome
+      not: { "aerodrome:type": military }
     min_zoom: *tier3_min_zoom
     output:
       <<: *output_properties
       kind: aerodrome
+      kind_detail:
+        case:
+          - when: { "aerodrome:type": [public, private, "military/public", airfield, international, regional, gliding] }
+            then: { col: "aerodrome:type" }
       tier: 3
-  - filter: {military: airfield}
+  - filter:
+      any:
+        - military: airfield
+          # backfill for aerodrome:type=military, we call that "airfield"
+        - all:
+            aeroway: aerodrome
+            "aerodrome:type": military
     min_zoom: *tier3_min_zoom
     output:
       <<: *output_properties

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -611,8 +611,10 @@ filters:
       kind: aerodrome
       kind_detail:
         case:
-          - when: { "aerodrome:type": [public, private, "military/public", airfield, international, regional, gliding] }
+          - when: { "aerodrome:type": [public, private, airfield, international, regional, gliding] }
             then: { col: "aerodrome:type" }
+          - when: { "aerodrome:type": "military/public" }
+            then: military_public
       tier: 3
   - filter:
       any:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -793,8 +793,10 @@ filters:
       kind: {col: aeroway}
       kind_detail:
         case:
-          - when: { "aerodrome:type": [public, private, "military/public", airfield, international, regional, gliding] }
+          - when: { "aerodrome:type": [public, private, airfield, international, regional, gliding] }
             then: { col: "aerodrome:type" }
+          - when: { "aerodrome:type": "military/public" }
+            then: military_public
       tier: 3
   # airfield, naval_base
   - filter: { military: [airfield, naval_base] }

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -786,17 +786,29 @@ filters:
   # aerodrome
   - filter:
       aeroway: [aerodrome, airport, heliport]
+      not: { "aerodrome:type": military }
     min_zoom: { min: [ { max: [ { sum: [ { col: zoom }, 4.12 ] }, *tier3_min_zoom ] }, 13 ] }
     output:
       <<: *output_properties
       kind: {col: aeroway}
+      kind_detail:
+        case:
+          - when: { "aerodrome:type": [public, private, "military/public", airfield, international, regional, gliding] }
+            then: { col: "aerodrome:type" }
       tier: 3
   # airfield, naval_base
-  - filter: {military: [airfield, naval_base]}
+  - filter: { military: [airfield, naval_base] }
     min_zoom: { min: [ { max: [ 8, { sum: [ { col: zoom }, 2 ] }, *tier3_min_zoom ] }, 14 ] }
     output:
       <<: *output_properties
       kind: {col: military}
+      tier: 3
+  # backfill for things tagged primarily as aeroways, but we want to show as military.
+  - filter: { aeroway: aerodrome, "aerodrome:type": military }
+    min_zoom: { min: [ { max: [ 8, { sum: [ { col: zoom }, 2 ] }, *tier3_min_zoom ] }, 14 ] }
+    output:
+      <<: *output_properties
+      kind: airfield
       tier: 3
   - filter:
       military: range


### PR DESCRIPTION
Whitelisted values:

* `public`
* `private`
* `military/public`
* `airfield`
* `international`
* `regional`
* `gliding`

Also remapped `aeroway:type=military` to `kind=airfield`, same as `military=airfield`, as that seemed more appropriate. I left `military/public`, as I think that means an aerodrome shared between both.

Connects to #1277.