### PR TITLE
Fix failing test(s)

### DIFF
--- a/integration-test/1732-restore-building-scale-rank.py
+++ b/integration-test/1732-restore-building-scale-rank.py
@@ -112,7 +112,10 @@ class BuildingScaleRankTest(FixtureTest):
         # rank and are merged at z14.
         z, x, y = (14, 0, 0)
 
-        self._setup_row(z, x, y, 10, 50, 10, landuse_kind='retail')
+        # z14 area cutoff is 500, so make sure width*depth >= 500, preferably
+        # by a margin that means numerical noise won't push it under the
+        # threshold.
+        self._setup_row(z, x, y, 11, 50, 10, landuse_kind='retail')
 
         # should be only 1 building feature now
         self.assert_n_matching_features(


### PR DESCRIPTION
We had one test failing because it was trying to test the building area cut-off at z14, which is 500sqm, by constructing a building 50m x 10m. Unfortunately, due to the limits of numerical precision (only on CircleCI, not my local machine) sometimes that would come out as 499.99999sqm. Then the building wouldn't be included at z14 and the test would fail.

This fixes that problem by bumping the size of the building up to 11x50m, which is sufficiently larger than the cut-off that rounding shouldn't be a problem.

There was a second problem, which is that CircleCI has a watchdog that terminates a test if it hasn't produced any output in >10 minutes. One of our tests (`358-merge-same-roads`) was pulling in a massive 10MB geojson file and was taking too long. On my local machine it took 30s, but CircleCI was clearly a little slower. Instead of using real data, I've swapped it out for generative tests which are much faster.

(Side note: On my machine, the integration tests pass in 29.7s, but on CircleCI they take 671s! That's 22x longer. Anyone know if that's just the machine / CPU time slice that's available, or if there's something we can do to close that gap?)
