### PR TITLE
Assign aerodrome kind_detail to runways.

### DIFF
--- a/integration-test/1852-runway-kind-detail.py
+++ b/integration-test/1852-runway-kind-detail.py
@@ -1,0 +1,71 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class RunwayTest(FixtureTest):
+
+    def _check(self, aerodrome_type, runway_kind_detail):
+        import dsl
+        from tilequeue.tile import coord_to_bounds
+        from shapely.geometry import LineString
+        from shapely.geometry import CAP_STYLE
+        from ModestMaps.Core import Coordinate
+
+        z, x, y = (16, 0, 0)
+
+        bounds = coord_to_bounds(Coordinate(zoom=z, column=x, row=y))
+
+        # runway line that runs from a quarter to three quarters of the
+        # tile diagonal. this is so that we can buffer it without it
+        # going outside the tile boundary.
+        runway_line = LineString([
+            [bounds[0] + 0.25 * (bounds[2] - bounds[0]),
+             bounds[1] + 0.25 * (bounds[3] - bounds[1])],
+            [bounds[0] + 0.75 * (bounds[2] - bounds[0]),
+             bounds[1] + 0.75 * (bounds[3] - bounds[1])],
+        ])
+
+        # runway polygon which has the runway line as a centreline.
+        runway_poly = runway_line.buffer(
+            0.1 * (bounds[2] - bounds[0]),  # width 1/10th of a tile
+            cap_style=CAP_STYLE.flat,
+        )
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'aeroway': 'aerodrome',
+                'aerodrome:type': aerodrome_type,
+                'name': 'Fake Aerodrome',
+                'source': 'openstreetmap.org',
+            }),
+            # runway line
+            dsl.way(2, runway_line, {
+                'aeroway': 'runway',
+                'source': 'openstreetmap.org',
+            }),
+            # runway polygon
+            dsl.way(3, runway_poly, {
+                'area:aeroway': 'runway',
+                'source': 'openstreetmap.org',
+            })
+        )
+
+        # runway line ends up in roads layer
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 2,
+                'kind': 'aeroway',
+                'kind_detail': 'runway',
+                'aerodrome_kind_detail': runway_kind_detail,
+            })
+
+        # runway polygon is in landuse
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 3,
+                'kind': 'runway',
+                'kind_detail': runway_kind_detail,
+            })
+
+    def test_public(self):
+        self._check('public', 'public')

--- a/queries.yaml
+++ b/queries.yaml
@@ -1513,6 +1513,32 @@ post_process:
       source_layers: [water]
       pixel_area: 0.1
 
+  # merge aerodrome kind_detail onto runway lines
+  - fn: vectordatasource.transform.overlap
+    params:
+      base_layer: roads
+      cutting_layer: landuse
+      attribute: kind_detail
+      target_attribute: aerodrome_kind_detail
+      linear: true
+      base_where: >-
+        kind == 'aeroway' and kind_detail == 'runway'
+      cutting_where: >-
+        kind == 'aerodrome' and kind_detail is not None
+
+  # merge aerodrome kind_detail onto runway polygons
+  - fn: vectordatasource.transform.overlap
+    params:
+      base_layer: landuse
+      cutting_layer: landuse
+      attribute: kind_detail
+      target_attribute: kind_detail
+      linear: true
+      base_where: >-
+        kind == 'runway'
+      cutting_where: >-
+        kind == 'aerodrome' and kind_detail is not None
+
   # drop this layer before simplify_and_clip - we don't want it in the output,
   # so don't waste time simplifying and clipping it to the tile.
   - fn: vectordatasource.transform.drop_layer


### PR DESCRIPTION
Aerodrome polygons are (usually) used to map the footprint of an airport, and often have an `aerodrome:type` tag to indicate whether it's an international or domestic airport. We added that as `kind_detail` in #1277 to the aerodrome polygons, but it's useful to know that information on runways also. This allows us to hide runways of smaller airports and emphasise those of bigger (international) ones.

This extends the intercut / overlap methods to add "where" clauses, so that we can select those features within the layer which are being cut or used for cutting. We can then overlap the aerodrome polygons with the runways (lines in `roads` layer, polygons in `landuse`) to assign the `kind_detail`.

Worth noting; we already had a `kind_detail` on the runway lines in the `roads` layer, so I've called this new attribute `aerodrome_kind_detail` instead.

Connects to #1852.