### PR TITLE
Use Natural Earth curated min_zoom for earth layer features.

### DIFF
--- a/integration-test/1287-ne-earth-min-zoom.py
+++ b/integration-test/1287-ne-earth-min-zoom.py
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class EarthMinZoomTest(FixtureTest):
+
+    def test_min_zoom_ne(self):
+        # NE data min zoom should be taken from NE itself.
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'source': 'naturalearthdata.com',
+                'min_zoom': 1,
+            }),
+        )
+
+        self.assert_has_feature(
+            8, 0, 0, 'earth', {
+                'min_zoom': 1,
+            })
+
+    def test_min_zoom_osmdata(self):
+        # should stay at zero? (we don't use this below z8 at the moment, so
+        # the min_zoom only really matters for consistency with NE. however,
+        # there's no meaningful ID on osmdata polygons to match with NE...
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_box(z, x, y), {
+                'source': 'osmdata.openstreetmap.de',
+                'area': 1,
+                'min_zoom': 1,
+            }),
+        )
+
+        self.assert_has_feature(
+            8, 0, 0, 'earth', {
+                'id': 1,
+                'min_zoom': 0,
+            })

--- a/integration-test/399-add-island-labels.py
+++ b/integration-test/399-add-island-labels.py
@@ -11,6 +11,7 @@ class AddIslandLabels(FixtureTest):
                 u'source': u'naturalearthdata.com',
                 u'featurecla': u'Country',
                 u'scalerank': 1,
+                u'min_zoom': 0,
             }))
 
         self.assert_has_feature(
@@ -24,6 +25,7 @@ class AddIslandLabels(FixtureTest):
                 u'source': u'naturalearthdata.com',
                 u'featurecla': u'Land',
                 u'scalerank': 0,
+                u'min_zoom': 0,
             }))
 
         self.assert_has_feature(
@@ -37,11 +39,13 @@ class AddIslandLabels(FixtureTest):
                 u'source': u'naturalearthdata.com',
                 u'featurecla': u'Land',
                 u'scalerank': 0,
+                u'min_zoom': 0,
             }),
             dsl.way(2, dsl.tile_box(0, 0, 0), {
                 u'source': u'naturalearthdata.com',
                 u'featurecla': u'Land',
                 u'scalerank': 0,
+                u'min_zoom': 0,
             }),
         )
 

--- a/yaml/earth.yaml
+++ b/yaml/earth.yaml
@@ -74,8 +74,20 @@ filters:
       kind: valley
     table: osm
 
+  # Natural Earth data should have a min_zoom column in the data, and we'll use
+  # that curated value to provide min_zoom.
   - filter:
-      meta.source: [ne, shp]
+      meta.source: ne
+    min_zoom: { col: min_zoom }
+    output:
+      <<: *output_properties
+      kind: earth
+
+  # OSMData data is just polygons with auto-generated IDs. It's not used at low
+  # zooms, but if we want consistency, we should try to work out an area-based
+  # correspondance with NE data above.
+  - filter:
+      meta.source: shp
     min_zoom: 0
     output:
       <<: *output_properties


### PR DESCRIPTION
Use the `min_zoom` column from Natural Earth data instead of just zero.

Note: I wanted to match this up with the polygons from osmdata, but because we use the "split" polygons from OSMData, we don't know the original area. Perhaps we could use the non-split polygons and generate the `way_area` column before splitting the polygon up?

Connects to #1287.
