### PR TITLE
When harbour landuse is also water, drop the polygon

### DIFF
--- a/integration-test/1590-harbour-water-not-landuse.py
+++ b/integration-test/1590-harbour-water-not-landuse.py
@@ -1,0 +1,86 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class HarbourTest(FixtureTest):
+
+    def test_over_water(self):
+        # interesting use of *land*use over water...
+        import dsl
+
+        z, x, y = (16, 32272, 21795)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/3303804
+            dsl.way(3303804, dsl.box_area(z, x, y, 1045925), {
+                'access:tide': 'yes',
+                'landuse': 'harbour',
+                'name': 'Royal Portbury Dock',
+                'natural': 'water',
+                'seamark:harbour:category': 'roro',
+                'seamark:type': 'harbour',
+                'source': 'openstreetmap.org',
+                'waterway': 'dock',
+                'wikidata': 'Q7374733',
+            }),
+        )
+
+        # water feature should come through (note: it's a kind: dock, rather
+        # than kind: water because of the waterway=dock tag taking precedence).
+        self.assert_has_feature(
+            z, x, y, 'water', {
+                'id': 3303804,
+                'kind': 'dock',
+            })
+
+        # harbour landuse label should come through
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 3303804,
+                'kind': 'harbour',
+                'name': 'Royal Portbury Dock',
+                'label_placement': True,
+            })
+
+        # landuse area should _not_ come through over the water.
+        self.assert_no_matching_feature(
+            z, x, y, 'landuse', {
+                'id': 3303804,
+                'label_placement': type(None),
+            })
+
+    def test_over_land(self):
+        # same test as before, but this time without the tags which indicate
+        # it's water. over land, we should retain the landuse polygon.
+        import dsl
+
+        z, x, y = (16, 32272, 21795)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/3303804
+            dsl.way(3303804, dsl.box_area(z, x, y, 1045925), {
+                'access:tide': 'yes',
+                'landuse': 'harbour',
+                'name': 'Royal Portbury Dock',
+                'seamark:harbour:category': 'roro',
+                'seamark:type': 'harbour',
+                'source': 'openstreetmap.org',
+                'wikidata': 'Q7374733',
+            }),
+        )
+
+        # harbour landuse label should come through
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 3303804,
+                'kind': 'harbour',
+                'name': 'Royal Portbury Dock',
+                'label_placement': True,
+            })
+
+        # landuse area should come through over land.
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 3303804,
+                'label_placement': type(None),
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -836,6 +836,14 @@ post_process:
         'name' in properties or
         ('sport' in properties and properties.get('kind', 'rock') not in ('rock', 'stone'))
 
+  # drop any polygon features with tz_drop_polygon
+  - fn: vectordatasource.transform.drop_features_where
+    params:
+      source_layer: landuse
+      where: >-
+        properties.get('tz_drop_polygon', False) and
+        geom_type in ('Polygon', 'MultiPolygon')
+
   # drop mz_label placement at zooms we don't apply handle_label_placement
   - fn: vectordatasource.transform.drop_properties
     params:
@@ -1406,8 +1414,11 @@ post_process:
       end_zoom: 16
       items_matching: { kind: [peak, volcano] }
       max_items: 5
+
   - fn: vectordatasource.transform.drop_properties_with_prefix
     params: {prefix: mz_}
+  - fn: vectordatasource.transform.drop_properties_with_prefix
+    params: {prefix: tz_}
 
   # drop small inners in buildings before we do the merge.
   - fn: vectordatasource.transform.drop_small_inners

--- a/queries.yaml
+++ b/queries.yaml
@@ -836,12 +836,12 @@ post_process:
         'name' in properties or
         ('sport' in properties and properties.get('kind', 'rock') not in ('rock', 'stone'))
 
-  # drop any polygon features with tz_drop_polygon
+  # drop any polygon features with mz_drop_polygon
   - fn: vectordatasource.transform.drop_features_where
     params:
       source_layer: landuse
       where: >-
-        properties.get('tz_drop_polygon', False) and
+        properties.get('mz_drop_polygon', False) and
         geom_type in ('Polygon', 'MultiPolygon')
 
   # drop mz_label placement at zooms we don't apply handle_label_placement
@@ -1417,8 +1417,6 @@ post_process:
 
   - fn: vectordatasource.transform.drop_properties_with_prefix
     params: {prefix: mz_}
-  - fn: vectordatasource.transform.drop_properties_with_prefix
-    params: {prefix: tz_}
 
   # drop small inners in buildings before we do the merge.
   - fn: vectordatasource.transform.drop_small_inners

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -2400,6 +2400,7 @@ def drop_features_where(ctx):
 
         local = properties.copy()
         local['properties'] = properties
+        local['geom_type'] = shape.geom_type
 
         if not eval(where, {}, local):
             new_features.append(feature)

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -786,6 +786,11 @@ filters:
       kind: winter_sports
       tier: 4
   # port, ferry, container terminals
+  #
+  # if these are also water features, then we don't want to output a polygon
+  # for this. because we can't alter the geometry type at this stage, we handle
+  # this by setting a parameter that indicates we should drop the polygon at a
+  # later stage.
   - filter:
       landuse:
         - harbour
@@ -797,6 +802,14 @@ filters:
     output:
       <<: *output_properties
       kind: {col: landuse}
+      tz_drop_polygon:
+        case:
+          - when:
+              any:
+                - { waterway: true }
+                - { natural: [water, bay, strait, fjord, reef] }
+                - { landuse: [reservoir, basin] }
+            then: true
   # pier with mooring
   - filter:
       man_made: pier

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -802,7 +802,8 @@ filters:
     output:
       <<: *output_properties
       kind: {col: landuse}
-      tz_drop_polygon:
+      # mz = metazen :-)
+      mz_drop_polygon:
         case:
           - when:
               any:


### PR DESCRIPTION
When a polygon is tagged as both something that we would consider water and a habour (or port or terminal), then keep the label placement point in the `landuse` layer, but drop the polygon as it would cover the water polygon from the `water` layer.

Another way of doing this would be to subtract the `water` layer polygons from (a subset of) the `landuse` layer polygons.However, I though this might lead to more unexpected side-effects, so stuck with the more specific feature and tag-based system.

Connects to #1590.