### PR TITLE
Limit number of bays in the tile to the largest 10.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -2377,12 +2377,12 @@ Tilezen calculates the composite exterior edge for overlapping water polygons an
 #### Water `kind` values:
 
 * `basin` - polygon
-* `bay` - point, intended for label placement only
+* `bay` - point, intended for label placement only. With `tile_kind_rank`, see below.
 * `canal` - line
 * `ditch` - line
 * `dock` - polygon
 * `drain` - line
-* `fjord` - point, intended for label placement only
+* `fjord` - point, intended for label placement only. With `tile_kind_rank`, see below.
 * `fountain` - polygon
 * `lake` - polygon
 * `ocean` - polygon, point is intended for label placement only
@@ -2392,11 +2392,13 @@ Tilezen calculates the composite exterior edge for overlapping water polygons an
 * `riverbank` - polygon
 * `sea` - point, intended for label placement only
 * `stream` - line
-* `strait` - point, intended for label placement only
+* `strait` - point, intended for label placement only. With `tile_kind_rank`, see below.
 * `swimming_pool` - polygon
 * `water` - polygon
 
 Additionally, a `reservoir: true` or `alkaline: true` value can be present on the appropriate `kind=lake` features. Intermittent water features that sometimes run dry or disappear seasonally are marked `intermittent: true`.
+
+The kinds `bay`, `strait` and `fjord` are ranked by size and given a `kind_tile_rank` property that starts from 1 and counts up as the feature gets smaller. Note that the ranking is done on a "metatile", which means that each tile (of size 256px, 512px or other) won't necessarily contain the full range from 1 to N of `kind_tile_rank`s.
 
 **Gotchas:**
 

--- a/integration-test/1838-too-many-bays.py
+++ b/integration-test/1838-too-many-bays.py
@@ -1,0 +1,41 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class BayTest(FixtureTest):
+
+    def test_bays(self):
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        def _bay(osm_id, area, name):
+            return dsl.way(osm_id, dsl.box_area(z, x, y, area), {
+                'source': 'openstreetmap.org',
+                'natural': 'bay',
+                'name': name,
+            })
+
+        # generate some bays - the IDs are out of order, but should get
+        # reordered before the rank is assigned.
+        self.generate_fixtures(
+            _bay(3, 200000000, "Bay 5"),
+            _bay(9, 70000000, "Bay 9"),
+            _bay(5, 400000000, "Bay 3"),
+            _bay(4, 300000000, "Bay 4"),
+            _bay(1, 90000000, "Bay 7"),
+            _bay(2, 100000000, "Bay 6"),
+            _bay(8, 80000000, "Bay 8"),
+            _bay(10, 600000000, "Bay 1"),
+            _bay(11, 500000000, "Bay 2"),
+            _bay(6, 60000000, "Bay 10"),
+            _bay(7, 50000000, "Bay 11"),
+        )
+
+        with self.features_in_tile_layer(z, x, y, 'water') as features:
+            # should only have top 10 features
+            self.assertEqual(10, len(features))
+
+            # check that they're in order
+            ranks = [f['properties']['kind_tile_rank'] for f in features]
+            self.assertEqual(range(1, 11), ranks)

--- a/queries.yaml
+++ b/queries.yaml
@@ -973,6 +973,14 @@ post_process:
         kind: [peak, volcano]
       rank_key: kind_tile_rank
       start_zoom: 9
+  - fn: vectordatasource.transform.rank_features
+    params:
+      source_layer: water
+      items_matching:
+        kind: [bay, strait, fjord]
+        label_placement: True
+      rank_key: kind_tile_rank
+      start_zoom: 8
   - fn: vectordatasource.transform.remove_duplicate_features
     params:
       source_layers: [pois, landuse, buildings]
@@ -1414,6 +1422,15 @@ post_process:
       end_zoom: 16
       items_matching: { kind: [peak, volcano] }
       max_items: 5
+  - fn: vectordatasource.transform.keep_n_features
+    params:
+      source_layer: water
+      start_zoom: 8
+      end_zoom: 12
+      items_matching:
+        kind: [bay, strait, fjord]
+        label_placement: True
+      max_items: 10
 
   - fn: vectordatasource.transform.drop_properties_with_prefix
     params: {prefix: mz_}


### PR DESCRIPTION
This adds a `tile_kind_rank` on `bay`s, `strait`s and `fjord`s based on the area of the feature. Labels are only kept if they're in the top 10 for the metatile. For the area around Vancouver, this looks like it keeps enough labels, but they're not so overwhelming any more.

Connects to #1838.

## Before

### Zoom 8

![before_z8](https://user-images.githubusercontent.com/271360/55896298-e9ba0000-5bb5-11e9-97c8-827d4ff7ddac.png)

### Zoom 9

![before_z9](https://user-images.githubusercontent.com/271360/55896311-ede61d80-5bb5-11e9-8e86-644f95e03ca0.png)

## After

### Zoom 8

![pr_z8](https://user-images.githubusercontent.com/271360/55896313-ee7eb400-5bb5-11e9-87c4-6927f34b491c.png)

### Zoom 9

![pr_z9](https://user-images.githubusercontent.com/271360/55896314-ee7eb400-5bb5-11e9-926f-2a2b359b526c.png)
