### PR TITLE
Add roads under construction.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1370,7 +1370,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 * `name`: From OpenStreetMap, but transformed to abbreviated names as detailed above.
 * `id`: From OpenStreetMap or Natural Earth. Dropped at low- and mid-zooms when features are merged. _See planned bug fix [#1002](https://github.com/tilezen/vector-datasource/issues/1002)._
 * `source`: `openstreetmap` or `naturalearthdata.com`
-* `kind`: one of High Road's values for `highway`, `major_road`, `minor_road`, `rail`, `path`, `ferry`, `piste`, `aerialway`, `aeroway`, `racetrack`, `portage_way`.
+* `kind`: one of High Road's values for `highway`, `major_road`, `minor_road`, `rail`, `path`, `ferry`, `piste`, `aerialway`, `aeroway`, `racetrack`, `portage_way`, `construction`.
 * `kind_detail`: See kind detail list below, sourced from the OpenStreetMap values.
 * `landuse_kind`: See description above, values match values in the `landuse` layer.
 * `sort_rank`: a suggestion for which order to draw features. The value is an integer where smaller numbers suggest that features should be "behind" features with larger numbers. At zooms >= 15, the `sort_rank` is adjusted to realistically model bridge, tunnel, and layer ordering.
@@ -1447,6 +1447,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 
 * `aerialway`
 * `aeroway`
+* `construction` - Indicates that the road is under construction and may not be usable by some or all types of traffic.
 * `ferry`
 * `highway`
 * `major_road`

--- a/integration-test/394-construction-roads.py
+++ b/integration-test/394-construction-roads.py
@@ -1,0 +1,102 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class ConstructionTest(FixtureTest):
+
+    def test_residential(self):
+        import dsl
+
+        z, x, y = (16, 10492, 25319)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/215879087
+            dsl.way(215879087, dsl.tile_diagonal(z, x, y), {
+                'construction': u'residential',
+                'highway': u'construction',
+                'name': u'4th Street',
+                'source': u'openstreetmap.org',
+                'tiger:cfcc': u'A41',
+                'tiger:county': u'San Francisco, CA',
+                'tiger:name_base': u'4th',
+                'tiger:name_type': u'St',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 215879087,
+                'kind': u'construction',
+                'kind_detail': u'residential',
+                'min_zoom': 12,
+            })
+
+    def test_motorway_link(self):
+        import dsl
+
+        z, x, y = (16, 10492, 25322)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/236455470
+            dsl.way(236455470, dsl.tile_diagonal(z, x, y), {
+                'construction': u'motorway_link',
+                'destination': u'Yerba Buena island',
+                'highway': u'construction',
+                'oneway': u'yes',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 236455470,
+                'kind': u'construction',
+                'kind_detail': u'motorway_link',
+                'min_zoom': 12,
+            })
+
+    def test_tertiary(self):
+        import dsl
+
+        z, x, y = (16, 10492, 25322)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/11416105
+            dsl.way(11416105, dsl.tile_diagonal(z, x, y), {
+                'construction': u'tertiary',
+                'highway': u'construction',
+                'oneway': u'yes',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 11416105,
+                'kind': u'construction',
+                'kind_detail': u'tertiary',
+                'min_zoom': 12,
+            })
+
+    def test_cycleway(self):
+        import dsl
+
+        z, x, y = (16, 10492, 25322)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/662177827
+            dsl.way(662177827, dsl.tile_diagonal(z, x, y), {
+                'construction': u'cycleway',
+                'foot': u'yes',
+                'highway': u'construction',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 662177827,
+                'kind': u'construction',
+                'kind_detail': u'cycleway',
+                'min_zoom': 13,
+            })

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -554,6 +554,55 @@ filters:
       kind_detail: raceway
   #############################################################
   #
+  # OSM construction
+  #
+  #############################################################
+  - filter:
+      all:
+        - highway: construction
+        - construction: [motorway, motorway_link, trunk, primary, secondary, tertiary, trunk_link, unclassified, residential, road]
+    min_zoom: 12
+    table: osm
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network
+      kind: construction
+      kind_detail: {col: construction}
+  - filter:
+      all:
+        - highway: construction
+        - construction: [primary_link, secondary_link, living_street, service, pedestrian, track, cycleway, bridleway]
+    min_zoom: 13
+    table: osm
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network
+      kind: construction
+      kind_detail: {col: construction}
+  - filter:
+      all:
+        - highway: construction
+        - construction: [tertiary_link, footway, steps]
+    min_zoom: 14
+    table: osm
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network
+      kind: construction
+      kind_detail: {col: construction}
+  - filter:
+      all:
+        - highway: construction
+        - construction: corridor
+    min_zoom: 16
+    table: osm
+    output:
+      <<: *osm_highway_properties
+      <<: *osm_network
+      kind: construction
+      kind_detail: {col: construction}
+  #############################################################
+  #
   # OSM aeroway
   #
   #############################################################


### PR DESCRIPTION
These get a new `kind: construction`, and `kind_detail` from the OSM `highway` tag, same as other roads. I've set the `min_zoom` to the maximum of the corresponding non-construction features and 12, as I think we can probably ignore whether a path under construction is part of a walking or cycling route. (Roads under construction are pretty rare features, and I don't think we'll miss them at lower zooms).

Connects to #394.
