### PR TITLE
Add railway types

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1470,7 +1470,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 
 **Rail** is added starting at zoom 11, with minor railroad `spur` added at zoom 12+ (based on "service" values), and further detail for `yard` and `crossover` and 13 and 14 respectively with all railroads shown by zoom 15. Features for rail tracks are included in this layer, whereas geometries and further information about rail lines or routes is available in the `transit` layer.
 
-Railway `kind_detail` values in this layer include: `rail`, `tram`, `light_rail`, `narrow_gauge`, `monorail`, `subway`, and `funicular`.
+Railway `kind_detail` values in this layer include: `abandoned`, `disused`, `funicular`, `light_rail`, `miniature`, `monorail`, `narrow_gauge`, `preserved`, `rail`, `razed`, `subway`, `tram`. Note that the `kind_detail` values `abandoned`, `disused`, `razed` may indicate features that no longer exist.
 
 Railway `service` values are:
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1470,7 +1470,7 @@ To improve performance, some road segments are merged at low and mid-zooms. To f
 
 **Rail** is added starting at zoom 11, with minor railroad `spur` added at zoom 12+ (based on "service" values), and further detail for `yard` and `crossover` and 13 and 14 respectively with all railroads shown by zoom 15. Features for rail tracks are included in this layer, whereas geometries and further information about rail lines or routes is available in the `transit` layer.
 
-Railway `kind_detail` values in this layer include: `abandoned`, `disused`, `funicular`, `light_rail`, `miniature`, `monorail`, `narrow_gauge`, `preserved`, `rail`, `razed`, `subway`, `tram`. Note that the `kind_detail` values `abandoned`, `disused`, `razed` may indicate features that no longer exist.
+Railway `kind_detail` values in this layer include: `disused`, `funicular`, `light_rail`, `miniature`, `monorail`, `narrow_gauge`, `preserved`, `rail`, `subway`, `tram`.
 
 Railway `service` values are:
 

--- a/integration-test/955-railway-types.py
+++ b/integration-test/955-railway-types.py
@@ -19,11 +19,10 @@ class RailwayTest(FixtureTest):
             }),
         )
 
-        self.assert_has_feature(
+        # should _not_ include razed rails
+        self.assert_no_matching_feature(
             z, x, y, 'roads', {
                 'id': 521306179,
-                'kind': u'rail',
-                'kind_detail': u'razed',
             })
 
     def test_abandoned_rail(self):
@@ -40,11 +39,10 @@ class RailwayTest(FixtureTest):
             }),
         )
 
-        self.assert_has_feature(
+        # should _not_ include abandoned rails
+        self.assert_no_matching_feature(
             z, x, y, 'roads', {
                 'id': 521306174,
-                'kind': u'rail',
-                'kind_detail': u'abandoned',
             })
 
     def test_disused_rail(self):
@@ -124,9 +122,6 @@ class RailwayTest(FixtureTest):
 
     def test_narrow_gauge(self):
         self._check('narrow_gauge', 'narrow_gauge')
-
-    def test_abandoned(self):
-        self._check('abandoned', 'abandoned')
 
     def test_disused(self):
         self._check('disused', 'disused')

--- a/integration-test/955-railway-types.py
+++ b/integration-test/955-railway-types.py
@@ -1,0 +1,147 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class RailwayTest(FixtureTest):
+
+    def test_razed_rail(self):
+        import dsl
+
+        z, x, y = (16, 34905, 23736)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/521306179
+            dsl.way(521306179, dsl.tile_diagonal(z, x, y), {
+                'historic': 'railway',
+                'name': 'Ferrovia Massalombarda-Imola-Fontanelice',
+                'railway': 'razed',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 521306179,
+                'kind': u'rail',
+                'kind_detail': u'razed',
+            })
+
+    def test_abandoned_rail(self):
+        import dsl
+
+        z, x, y = (16, 34900, 23738)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/521306174
+            dsl.way(521306174, dsl.tile_diagonal(z, x, y), {
+                'railway': 'abandoned',
+                'service': 'yard',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 521306174,
+                'kind': u'rail',
+                'kind_detail': u'abandoned',
+            })
+
+    def test_disused_rail(self):
+        import dsl
+
+        z, x, y = (16, 10503, 25309)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/610527680
+            dsl.way(610527680, dsl.tile_diagonal(z, x, y), {
+                'disused:railway': 'rail',
+                'railway': 'disused',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 610527680,
+                'kind': u'rail',
+                'kind_detail': u'disused',
+            })
+
+    def test_rail_rail(self):
+        import dsl
+
+        z, x, y = (16, 10504, 25313)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/77517466
+            dsl.way(77517466, dsl.tile_diagonal(z, x, y), {
+                'electrified': 'no',
+                'gauge': '1435',
+                'maxspeed': '79 mph',
+                'maxspeed:freight': '70 mph',
+                'name': 'Martinez Subdivision MT1',
+                'owner': 'Union Pacific Railroad',
+                'passenger_lines': '2',
+                'railway': 'rail',
+                'railway:track_ref': '1',
+                'source': 'openstreetmap.org',
+                'usage': 'main',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 77517466,
+                'kind': u'rail',
+                'kind_detail': u'rail',
+            })
+
+    def _check(self, osm_tag, expected_kind_detail):
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'railway': osm_tag,
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 1,
+                'kind': 'rail',
+                'kind_detail': expected_kind_detail,
+            })
+
+    def test_subway(self):
+        self._check('subway', 'subway')
+
+    def test_preserved(self):
+        self._check('preserved', 'preserved')
+
+    def test_narrow_gauge(self):
+        self._check('narrow_gauge', 'narrow_gauge')
+
+    def test_abandoned(self):
+        self._check('abandoned', 'abandoned')
+
+    def test_disused(self):
+        self._check('disused', 'disused')
+
+    def test_funicular(self):
+        self._check('funicular', 'funicular')
+
+    def test_monorail(self):
+        self._check('monorail', 'monorail')
+
+    def test_miniature(self):
+        self._check('miniature', 'miniature')
+
+    def test_light_rail(self):
+        self._check('light_rail', 'light_rail')
+
+    def test_tram(self):
+        self._check('tram', 'tram')

--- a/scripts/templates/road_test.jinja2
+++ b/scripts/templates/road_test.jinja2
@@ -11,13 +11,13 @@
             # https://www.openstreetmap.org/way/{{way_id}}
             dsl.way({{way_id}}, dsl.tile_diagonal(z, x, y), {
         {%- for k, v in way_tags|dictsort %}
-                '{{k}}': u'{{v}}',
+                {{k|repr}}: {{v|repr}},
         {%- endfor %}
             }),
         {%- for rel in relations %}
             dsl.relation({{loop.index}}, {
         {%- for k, v in rel|dictsort %}
-                '{{k}}': u'{{v}}',
+                {{k|repr}}: {{v|repr}},
         {%- endfor %}
             }, ways=[{{way_id}}]),
         {%- endfor %}

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -694,7 +694,7 @@ filters:
       kind: rail
       kind_detail: rail
   - filter:
-      railway: [abandoned, disused, funicular, light_rail, miniature, monorail, narrow_gauge, preserved, razed, subway, tram]
+      railway: [disused, funicular, light_rail, miniature, monorail, narrow_gauge, preserved, subway, tram]
     min_zoom: 15
     table: osm
     output:

--- a/yaml/roads.yaml
+++ b/yaml/roads.yaml
@@ -694,7 +694,7 @@ filters:
       kind: rail
       kind_detail: rail
   - filter:
-      railway: [tram, light_rail, narrow_gauge, monorail, subway, funicular]
+      railway: [abandoned, disused, funicular, light_rail, miniature, monorail, narrow_gauge, preserved, razed, subway, tram]
     min_zoom: 15
     table: osm
     output:


### PR DESCRIPTION
Add abandoned, disused, razed, miniature and preserved railway types as rail kind details.

Also, minor change to road test template to handle escaping better by using Python's `repr` rather than printing everything as a single-quoted Unicode string.

Connects to #955.