### PR TITLE
Export wikidata properties

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -33,7 +33,8 @@ CREATE TABLE wof_neighbourhood (
   inception DATE NOT NULL DEFAULT '0001-01-01',
   cessation DATE NOT NULL DEFAULT '9999-12-31',
   is_visible BOOLEAN NOT NULL DEFAULT true,
-  l10n_name HSTORE
+  l10n_name HSTORE,
+  wikidata TEXT
 );
 
 CREATE INDEX wof_neighbourhood_label_position_index ON wof_neighbourhood USING GIST(label_position);

--- a/data/wof_snapshot.py
+++ b/data/wof_snapshot.py
@@ -130,6 +130,7 @@ if __name__ == '__main__':
         fh.write("COPY public.wof_neighbourhood ("
                  "wof_id, placetype, name, hash, n_photos, area, min_zoom, "
                  "max_zoom, is_landuse_aoi, label_position, geometry, "
-                 "inception, cessation, is_visible, l10n_name) FROM stdin;\n")
+                 "inception, cessation, is_visible, l10n_name, wikidata) "
+                 "FROM stdin;\n")
         write_neighbourhood_data_to_file(fh, reader.wof_items)
         fh.write("\\.\n")

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -743,6 +743,7 @@ Places with `kind` values of `continent`, `country`, with others added starting 
 * `max_zoom`: a suggested maximum zoom beyond which the place should not be visible. Currently neighbourhoods only, from Who's On First.
 * `is_landuse_aoi`: Currently neighbourhoods only, from Who's On First
 * `kind_detail`: the original value of the OSM `place` tag and Natural Earth `featurecla`, see below.
+* `wikidata`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
 
 #### Place `kind` values:
 
@@ -827,6 +828,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `exit_to`: only for highway exits
 * `ref`: generally only for `aeroway_gate` and `station_entrance` features
 * `religion`: TODO
+* `wikidata`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
 * `zoo`: TODO
 
 #### POI properties (only on `kind:station`):
@@ -2374,6 +2376,7 @@ Tilezen calculates the composite exterior edge for overlapping water polygons an
 * `area`: in square meters (spherical Mercator, no real-world), `polygon` features only
 * `id`: OpenStreetMap feature `osm_id`, when sourced from `openstreetmap.org`
 * `is_tunnel`: for `line` features only (`true` values only)
+* `wikidata`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
 
 #### Water `kind` values:
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -743,7 +743,7 @@ Places with `kind` values of `continent`, `country`, with others added starting 
 * `max_zoom`: a suggested maximum zoom beyond which the place should not be visible. Currently neighbourhoods only, from Who's On First.
 * `is_landuse_aoi`: Currently neighbourhoods only, from Who's On First
 * `kind_detail`: the original value of the OSM `place` tag and Natural Earth `featurecla`, see below.
-* `wikidata`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
+* `wikidata_id`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
 
 #### Place `kind` values:
 
@@ -828,7 +828,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `exit_to`: only for highway exits
 * `ref`: generally only for `aeroway_gate` and `station_entrance` features
 * `religion`: TODO
-* `wikidata`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
+* `wikidata_id`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
 * `zoo`: TODO
 
 #### POI properties (only on `kind:station`):
@@ -2376,7 +2376,7 @@ Tilezen calculates the composite exterior edge for overlapping water polygons an
 * `area`: in square meters (spherical Mercator, no real-world), `polygon` features only
 * `id`: OpenStreetMap feature `osm_id`, when sourced from `openstreetmap.org`
 * `is_tunnel`: for `line` features only (`true` values only)
-* `wikidata`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
+* `wikidata_id`: when present, the [Wikidata](https://www.wikidata.org) ID corresponding to this feature.
 
 #### Water `kind` values:
 

--- a/integration-test/1425-more-osm-features.py
+++ b/integration-test/1425-more-osm-features.py
@@ -926,6 +926,29 @@ class MoreOSMFeaturesTest(FixtureTest):
                 'kind': u'plaque',
             })
 
+    def test_memorial_node(self):
+        # if a memorial _isn't_ a plaque, then it should stay as a memorial!
+        # this is the counter-example to test_plaque_node above, as previously
+        # there was a bug where the test for plaque was too general and
+        # accidentally re-classified all memorials as plaques.
+        import dsl
+
+        z, x, y = (16, 0, 0)
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_centre_shape(z, x, y), {
+                'historic': u'memorial',
+                'name': u'A. Name Here',
+                'source': u'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1,
+                'kind': 'memorial',
+            })
+
     def test_reef_way(self):
         import dsl
 

--- a/integration-test/858-wikidata.py
+++ b/integration-test/858-wikidata.py
@@ -1,0 +1,102 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class OSMTest(FixtureTest):
+
+    def test_place(self):
+        import dsl
+
+        z, x, y = (16, 10482, 25330)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/26819236
+            dsl.point(26819236, (-122.4199061, 37.7790262), {
+                'name': u'San Francisco',
+                'place': u'city',
+                'population': u'864816',
+                'rank': u'10',
+                'short_name': u'SF',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q62',
+                'wikipedia': u'en:San Francisco',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata': 'Q62',
+            })
+
+    def test_poi(self):
+        import dsl
+
+        z, x, y = (16, 10482, 25330)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/1901905716
+            dsl.point(1901905716, (-122.4185377, 37.7789014), {
+                'historic': u'memorial',
+                'name': u'Abraham Lincoln',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q20011487',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 1901905716,
+                'kind': u'memorial',
+                'wikidata': u'Q20011487',
+            })
+
+    def test_water(self):
+        import dsl
+
+        z, x, y = (16, 10752, 32895)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/305640005
+            dsl.way(305640005, dsl.tile_centre_shape(z, x, y), {
+                'name': u'Pacific Ocean',
+                'place': u'ocean',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q98',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'water', {
+                'id': 305640005,
+                'kind': u'ocean',
+                'wikidata': u'Q98',
+            })
+
+
+class WOFTest(FixtureTest):
+
+    def test_place(self):
+        import dsl
+
+        z, x, y = (16, 10483, 25328)
+
+        self.generate_fixtures(
+            dsl.point(85865903, (-122.414102, 37.785926), {
+                "max_zoom": 18.0,
+                "min_zoom": 15.0,
+                "name": "Tenderloin",
+                "placetype": "neighbourhood",
+                "source": "whosonfirst.org",
+                "wikidata": "Q7464",
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 85865903,
+                'kind': 'neighbourhood',
+                'wikidata': 'Q7464',
+            })

--- a/integration-test/858-wikidata.py
+++ b/integration-test/858-wikidata.py
@@ -28,7 +28,7 @@ class OSMTest(FixtureTest):
                 'id': 26819236,
                 'kind': 'locality',
                 'kind_detail': 'city',
-                'wikidata': 'Q62',
+                'wikidata_id': 'Q62',
             })
 
     def test_poi(self):
@@ -50,7 +50,7 @@ class OSMTest(FixtureTest):
             z, x, y, 'pois', {
                 'id': 1901905716,
                 'kind': u'memorial',
-                'wikidata': u'Q20011487',
+                'wikidata_id': u'Q20011487',
             })
 
     def test_water(self):
@@ -72,7 +72,7 @@ class OSMTest(FixtureTest):
             z, x, y, 'water', {
                 'id': 305640005,
                 'kind': u'ocean',
-                'wikidata': u'Q98',
+                'wikidata_id': u'Q98',
             })
 
 
@@ -98,5 +98,5 @@ class WOFTest(FixtureTest):
             z, x, y, 'places', {
                 'id': 85865903,
                 'kind': 'neighbourhood',
-                'wikidata': 'Q7464',
+                'wikidata_id': 'Q7464',
             })

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -741,6 +741,7 @@ class WOFSource(object):
                     'min_zoom': n.min_zoom,
                     'max_zoom': n.max_zoom,
                     'placetype': n.placetype,
+                    'wikidata': n.wikidata,
                 }
                 properties.update(n.l10n_names)
 

--- a/queries/ne-places.jinja2
+++ b/queries/ne-places.jinja2
@@ -21,7 +21,8 @@ SELECT
     'population', pop_max,
     'featurecla', featurecla,
     'scalerank', scalerank,
-    'min_zoom', mz_places_min_zoom
+    'min_zoom', mz_places_min_zoom,
+    'wikidata', wikidataid
   ) AS __places_properties__,
 
   NULL::jsonb AS __roads_properties__,

--- a/queries/ne-water-10m.jinja2
+++ b/queries/ne-water-10m.jinja2
@@ -2,7 +2,7 @@
 {% block query %}
 {{ ne_water_query(False, True, False, False, True, 'ne_10m_ocean') }}
 UNION ALL
-{{ ne_water_query(False, True, True, False, True, 'ne_10m_lakes') }}
+{{ ne_water_query(False, True, True, False, True, 'ne_10m_lakes', wikidata=True) }}
 UNION ALL
 {{ ne_water_query(False, False, False, True, False, 'ne_10m_coastline') }}
 UNION ALL

--- a/queries/ne-water-110m.jinja2
+++ b/queries/ne-water-110m.jinja2
@@ -2,7 +2,7 @@
 {% block query %}
 {{ ne_water_query(False, True, False, False, True, 'ne_110m_ocean') }}
 UNION ALL
-{{ ne_water_query(False, True, True, False, True, 'ne_110m_lakes') }}
+{{ ne_water_query(False, True, True, False, True, 'ne_110m_lakes', wikidata=True) }}
 UNION ALL
 {{ ne_water_query(False, False, False, True, False, 'ne_110m_coastline') }}
 UNION ALL

--- a/queries/ne-water-50m.jinja2
+++ b/queries/ne-water-50m.jinja2
@@ -2,7 +2,7 @@
 {% block query %}
 {{ ne_water_query(False, True, False, False, True, 'ne_50m_ocean') }}
 UNION ALL
-{{ ne_water_query(False, True, True, False, True, 'ne_50m_lakes') }}
+{{ ne_water_query(False, True, True, False, True, 'ne_50m_lakes', wikidata=True) }}
 UNION ALL
 {{ ne_water_query(False, False, False, True, False, 'ne_50m_coastline') }}
 UNION ALL

--- a/queries/ne-water-playas-10m.jinja2
+++ b/queries/ne-water-playas-10m.jinja2
@@ -1,7 +1,7 @@
 {% extends 'ne.jinja2' %}
 {% block query %}
 -- polygons
-{{ ne_water_query(False, True, True, False, True, 'ne_10m_playas') }}
+{{ ne_water_query(False, True, True, False, True, 'ne_10m_playas', wikidata=True) }}
 UNION ALL
 -- boundaries
 {{ ne_water_query(True, True, True, True, True, 'ne_10m_playas') }}

--- a/queries/ne-water-playas-50m.jinja2
+++ b/queries/ne-water-playas-50m.jinja2
@@ -1,7 +1,7 @@
 {% extends 'ne.jinja2' %}
 {% block query %}
 -- polygons
-{{ ne_water_query(False, True, True, False, True, 'ne_50m_playas') }}
+{{ ne_water_query(False, True, True, False, True, 'ne_50m_playas', wikidata=True) }}
 UNION ALL
 -- boundaries
 {{ ne_water_query(True, True, True, True, True, 'ne_50m_playas') }}

--- a/queries/ne.jinja2
+++ b/queries/ne.jinja2
@@ -111,7 +111,7 @@ WHERE
 
 {% endmacro %}
 
-{% macro ne_water_query(boundary_geometry, label_geometry, name, boundary, has_area, table) %}
+{% macro ne_water_query(boundary_geometry, label_geometry, name, boundary, has_area, table, wikidata=False) %}
 
 SELECT
 
@@ -148,6 +148,9 @@ SELECT
 {% endif %}
 {% if has_area %}
     'area', way_area,
+{% endif %}
+{% if wikidata %}
+    'wikidata', wikidataid,
 {% endif %}
     'min_zoom', mz_water_min_zoom,
     'featurecla', featurecla

--- a/queries/wof.jinja2
+++ b/queries/wof.jinja2
@@ -11,7 +11,8 @@ SELECT
       'mz_n_photos', n_photos,
       'area', area,
       'is_landuse_aoi', is_landuse_aoi,
-      'placetype', wof_np.placetype_string
+      'placetype', wof_np.placetype_string,
+      'wikidata', wikidata
     ) AS __properties__,
 
     jsonb_build_object(

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -23,6 +23,7 @@ global:
       call:
         func: util.true_or_none
         args: [ { col: is_landuse_aoi } ]
+    wikidata: {col: wikidata}
 
   - &ne_places_min_zoom
     lookup:

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -23,7 +23,7 @@ global:
       call:
         func: util.true_or_none
         args: [ { col: is_landuse_aoi } ]
-    wikidata: {col: wikidata}
+    wikidata_id: {col: wikidata}
 
   - &ne_places_min_zoom
     lookup:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -2246,7 +2246,9 @@ filters:
   # memorial plaques more specific than plain memorials
   - filter:
       any:
-        - {historic: memorial, memorial: plaque}
+        - all:
+            - historic: memorial
+            - memorial: plaque
         - historic: memorial_plaque
     min_zoom: 16
     output:

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -20,6 +20,7 @@ global:
     attraction: {col: attraction}
     zoo: {col: zoo}
     exit_to: {col: exit_to}
+    wikidata: {col: wikidata}
   - &transit_properties
     mz_transit_score: {col: mz_transit_score}
     mz_transit_root_relation_id: {col: mz_transit_root_relation_id}

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -20,7 +20,7 @@ global:
     attraction: {col: attraction}
     zoo: {col: zoo}
     exit_to: {col: exit_to}
-    wikidata: {col: wikidata}
+    wikidata_id: {col: wikidata}
   - &transit_properties
     mz_transit_score: {col: mz_transit_score}
     mz_transit_root_relation_id: {col: mz_transit_root_relation_id}

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -11,7 +11,7 @@ globals:
     label_placement: {col: label_placement}
     boundary: {col: boundary}
     tunnel: {col: tunnel}
-    wikidata: {col: wikidata}
+    wikidata_id: {col: wikidata}
   - &water_standard_properties_osm
       <<: *output_properties
       intermittent:

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -11,6 +11,7 @@ globals:
     label_placement: {col: label_placement}
     boundary: {col: boundary}
     tunnel: {col: tunnel}
+    wikidata: {col: wikidata}
   - &water_standard_properties_osm
       <<: *output_properties
       intermittent:


### PR DESCRIPTION
For features in the `water`, `places` and `pois` layers, export [Wikidata](https://www.wikidata.org) IDs, where they're available from upstream data (i.e: OSM, NE or WOF).

Note: this requires https://github.com/tilezen/tilequeue/pull/375 for the WOF import to work properly, although tests should still pass without it.

Connects to #858.
