### PR TITLE
Add Wikidata queries to static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ data/*.qpj
 data/wof_neighbourhoods.pgdump
 data/*.README.html
 data/*.VERSION.txt
+data/*.json
+data/wikidata_snapshot.sql
 
 # python compiled bytecode and development files
 *.pyc

--- a/data/Makefile-prepare-data.jinja2
+++ b/data/Makefile-prepare-data.jinja2
@@ -11,7 +11,7 @@ upload: shapefiles
 
 shapefiles: shapefiles.tar.gz
 
-shapefiles.tar.gz: {{ tgt_shapefile_zips }} wof_snapshot.sql
+shapefiles.tar.gz: {{ tgt_shapefile_zips }} wof_snapshot.sql wikidata_snapshot.sql
 	tar czf shapefiles.tar.gz $^
 
 download: {{ src_shapefile_zips }}
@@ -53,10 +53,19 @@ download: {{ src_shapefile_zips }}
 
 {% endfor %}
 
+{% for query in queries %}
+{{ query.output_file }}:
+	curl -o $@ '{{ query.url }}'
+
+{% endfor %}
+
+wikidata_snapshot.sql: {{ query_output_files }}
+	python wikidata_merge.py --output $@ $^
+
 wof_snapshot.sql:
 	python wof_snapshot.py
 
 clean:
-	rm -rf shapefiles.tar.gz {{ tgt_shapefile_zips }} {{ tgt_shapefile_wildcards }} {{ src_shapefile_zips }} {{ src_shapefile_wildcards }}
+	rm -rf shapefiles.tar.gz {{ tgt_shapefile_zips }} {{ tgt_shapefile_wildcards }} {{ src_shapefile_zips }} {{ src_shapefile_wildcards }} wof_snapshot.sql {{ query_output_files }} wikidata_snapshot.sql
 
 .PHONY: all download upload shapefiles

--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -161,3 +161,20 @@ shapefiles:
   - name: ne_10m_admin_1_states_provinces
     url: https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_1_states_provinces.zip
     prj: 4326
+
+
+wikidata-queries:
+  - name: aerodrome_passenger_count
+    # NOTE: this selects the _largest_ number of passengers per year, rather than the _most recent_. however, i wasn't able
+    # to figure out how to make a working query for the most recent. various answers on StackOverflow to do with population
+    # don't seem to work for this data.
+    query: >-
+      SELECT ?item (MAX(?number) as ?passenger_count)
+      WHERE
+      {
+        ?item wdt:P31 wd:Q1248784 .
+        ?item p:P3872 ?statement .
+        ?statement ps:P3872 ?number .
+      }
+      group by ?item
+      order by ?item

--- a/data/wikidata_merge.py
+++ b/data/wikidata_merge.py
@@ -1,0 +1,78 @@
+import json
+from collections import defaultdict
+
+
+def parse_wikidata(key, input_file):
+    with open(input_file, 'rb') as fh:
+        data = json.load(fh)
+
+    wikidata = defaultdict(dict)
+    for row in data['results']['bindings']:
+        wikidata_id = row[key]['value']
+
+        prefix = 'http://www.wikidata.org/entity/'
+        assert wikidata_id.startswith(prefix)
+        wikidata_id = wikidata_id[len(prefix):]
+
+        for k in row.keys():
+            if k != key:
+                wikidata[wikidata_id][k] = row[k]['value']
+
+    return wikidata
+
+
+def wikidata_merge(data, update):
+    """
+    Updates wikidata records in `data` with new records in `update`.
+    """
+
+    for wikidata_id, props in update.iteritems():
+        for k, v in props.iteritems():
+            data[wikidata_id][k] = v
+
+
+def write_wikidata_sql(io, data):
+    """
+    Write wikidata table and data to io.
+    """
+
+    io.write("""
+DROP TABLE IF EXISTS wikidata;
+CREATE TABLE wikidata (id TEXT PRIMARY KEY, tags HSTORE);
+
+COPY wikidata(id, tags) FROM stdin;
+""")
+
+    def esc(s):
+        s = s.encode('utf-8').replace('\t', ' ').replace('\n', ' ')
+        if ' ' in s:
+            s = s.replace('"', '\\\\"')
+            s = '"%s"' % s
+        return s
+
+    for wikidata_id, props in data.iteritems():
+        hstore = ','.join(
+            "%s=>%s" % (esc(k), esc(v))
+            for k, v in props.iteritems())
+        io.write("%s\t%s\n" % (wikidata_id, hstore))
+
+    io.write("\\.\n")
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', help='Output SQL file')
+    parser.add_argument('--key', default='item', help='Wikidata ID key in '
+                        'Wikidata query result binding')
+    parser.add_argument('input_files', nargs='+', help='Input JSON files '
+                        'from Wikidata query')
+    args = parser.parse_args()
+
+    wikidata = defaultdict(dict)
+    for input_file in args.input_files:
+        wikidata_merge(wikidata, parse_wikidata(args.key, input_file))
+
+    with open(args.output, 'w') as fh:
+        write_wikidata_sql(fh, wikidata)


### PR DESCRIPTION
[Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) can be a very useful source of extra information to extend the data coming from OpenStreetMap. In this case, we're extracting the [number of passengers](https://www.wikidata.org/wiki/Property:P3872) through an airport from Wikidata and will use that to categorise airports into major and minor.

The data is added as a new table, `wikidata`, indexed by the ID (i.e: `'Q[0-9]*'`) and providing `tags` which will be merged into the tags coming from OSM. Since we might do multiple queries, and these might return different tags on overlapping sets of Wikidata IDs, we merge all the Wikidata query results together. This means we should be careful not to use the same attribute names for more than one query.

Note: There's another PR coming which will do the merging of `tags`, categorisation of the aerodrome feature and bringing that data through into to the output tile.

Connects to #1873.