### PR TITLE
Override or backfill aerodrome kind_detail

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1094,3 +1094,20 @@ BEGIN
   RETURN val;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- get extra wikidata properties matched to an OSM feature on the wikidata ID
+CREATE OR REPLACE FUNCTION extra_wikidata_properties(wikidata_id text)
+RETURNS JSONB AS $$
+DECLARE
+  tags HSTORE DEFAULT NULL;
+BEGIN
+  IF wikidata_id IS NOT NULL THEN
+    SELECT w.tags INTO tags FROM wikidata w WHERE w.id = wikidata_id;
+  END IF;
+  IF tags IS NOT NULL THEN
+    RETURN to_jsonb(tags);
+  ELSE
+    RETURN '{}'::jsonb;
+  END IF;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -883,7 +883,7 @@ To resolve inconsistency in data tagging in OpenStreetMap we normalize several o
 * `administrative`
 * `adult_gaming_centre`
 * `advertising_agency`
-* `aerodrome` - with `kind_detail` in `public`, `private`, `military_public`, `airfield`, `international`, `regional`, `gliding`.
+* `aerodrome` - with `kind_detail` in `public`, `private`, `military_public`, `airfield`, `international`, `regional`, `gliding`. And _optional_ `passenger_count` giving the number of passengers through the aerodrome per year.
 * `aeroway_gate`
 * `airfield` for military use.
 * `airport`

--- a/integration-test/1873-backfill-aerodrome.py
+++ b/integration-test/1873-backfill-aerodrome.py
@@ -1,0 +1,142 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class AerodromeTest(FixtureTest):
+
+    def test_sfo(self):
+        # SFO should be international because the "aerodrome" tag is
+        # international. that should override the "aerodrome:type=public" tag.
+        import dsl
+
+        z, x, y = (13, 1311, 3170)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/545819287
+            dsl.way(545819287, dsl.box_area(z, x, y, 12545795), {
+                'aerodrome': 'international',
+                'aerodrome:type': 'public',
+                'aeroway': 'aerodrome',
+                'city_served': 'San Francisco, California',
+                'ele': '4',
+                'iata': 'SFO',
+                'icao': 'KSFO',
+                'name': 'San Francisco International Airport',
+                'source': 'openstreetmap.org',
+                'wikidata': 'Q8688',
+                'wikipedia': 'en:San Francisco International Airport',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 545819287,
+                'kind': 'aerodrome',
+                'kind_detail': 'international',
+            })
+
+    def test_bes(self):
+        # BES should be international, too. it doesn't have aerodrome:type,
+        # but should still get the kind_detail from falling back to the
+        # "aerodrome" tag.
+        import dsl
+
+        z, x, y = (13, 3995, 2832)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/5369273
+            dsl.way(5369273, dsl.box_area(z, x, y, 4789953), {
+                'aerodrome': 'international',
+                'aeroway': 'aerodrome',
+                'iata': 'BES',
+                'icao': 'LFRB',
+                'name': u'A\xe9roport de Brest-Bretagne',
+                'name:br': 'Aerborzh Brest-Breizh',
+                'ref': 'LFRB',
+                'source': 'openstreetmap.org',
+                'wikidata': 'Q1191525',
+                'wikipedia': u'fr:A\xe9roport Brest Bretagne',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 5369273,
+                'kind': 'aerodrome',
+                'kind_detail': 'international',
+            })
+
+    def test_mex(self):
+        # although MEX doesn't have an "aerodrome:type" of international, and
+        # no "aerodrome" tag, there's still an "international_flights" tag we
+        # can use to determine this.
+        import dsl
+
+        z, x, y = (13, 1841, 3645)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/99909133
+            dsl.way(99909133, dsl.box_area(z, x, y, 8005638), {
+                'aerodrome:type': 'public',
+                'aeroway': 'aerodrome',
+                'barrier': 'fence',
+                'ele': '2238',
+                'fence_type': 'wire',
+                'iata': 'MEX',
+                'icao': 'MMMX',
+                'international_flights': 'yes',
+                'is_in': 'Mexico City,D.F.,Mexico',
+                'name': u'Aeropuerto Internacional de la Ciudad de M\xe9xico',
+                'name:en': 'Mexico City International Airport',
+                'operator': u'Grupo Aeroportuario de la Ciudad de M\xe9xico',
+                'passengers': '33000000',
+                'source': 'openstreetmap.org',
+                'wikidata': 'Q860559',
+                'wikipedia': 'en:Mexico City International Airport',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 99909133,
+                'kind': 'aerodrome',
+                'kind_detail': 'international',
+            })
+
+    def test_tpe(self):
+        # TPE doesn't have "aerodrome" or "aerodrome:type" tags, so we look at
+        # the join to Wikidata for the passenger numbers.
+        import dsl
+
+        z, x, y = (13, 6854, 3506)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/321502590
+            dsl.way(321502590, dsl.box_area(z, x, y, 13507964), {
+                'aeroway': 'aerodrome',
+                'barrier': 'wall',
+                'ele': '33',
+                'iata': 'TPE',
+                'icao': 'RCTP',
+                'IFR': 'yes',
+                'name': u'\u81fa\u7063\u6843\u5712\u570b\u969b\u6a5f\u5834',
+                'name:af': 'Taiwan Taoyuan Internasionale Lughawe',
+                'name:de': 'Flughafen Taiwan Taoyuan',
+                'name:en': 'Taiwan Taoyuan International Airport',
+                'name:es': u'Aeropuerto Internacional de Taiw\xe1n Taoyuan',
+                'name:fr': u'A\xe9roport international Taiwan-Taoyuan',
+                'source': 'openstreetmap.org',
+                'variation': '4 W 2014 0.04 W',
+                'website': 'https://www.taoyuan-airport.com/',
+                'wikidata': 'Q44856',
+                'wikipedia:en': 'Taiwan_Taoyuan_International_Airport',
+                'passenger_count': '46535180',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 321502590,
+                'kind': 'aerodrome',
+                'kind_detail': 'international',
+            })

--- a/integration-test/1873-backfill-aerodrome.py
+++ b/integration-test/1873-backfill-aerodrome.py
@@ -140,3 +140,39 @@ class AerodromeTest(FixtureTest):
                 'kind': 'aerodrome',
                 'kind_detail': 'international',
             })
+
+    def test_aci(self):
+        # ACI is a regional airport, carrying around 100,000 passengers a year.
+        # however, it has no tags on it to indicate it's more important than a
+        # flying club airfield. so we use the passenger count to backfill that.
+        import dsl
+
+        z, x, y = (15, 16182, 11154)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/384693131
+            dsl.way(384693131, dsl.box_area(z, x, y, 601403), {
+                'aeroway': 'aerodrome',
+                'alt_name': 'The Blaye',
+                'ele': '88',
+                'iata': 'ACI',
+                'icao': 'EGJA',
+                'is_in': 'Alderney,Channel Islands,UK',
+                'name': 'Alderney Airport',
+                'operator': 'States of Guernsey',
+                'ref': 'ACI',
+                'source': 'openstreetmap.org',
+                'start_date': '1935',
+                'type': 'civil',
+                'wikidata': 'Q2559952',
+                'wikipedia': 'en:Alderney Airport',
+                'passenger_count': '105458',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 384693131,
+                'kind': 'aerodrome',
+                'kind_detail': 'regional',
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -273,6 +273,7 @@ layers:
       - vectordatasource.transform.make_representative_point
       - vectordatasource.transform.height_to_meters
       - vectordatasource.transform.pois_capacity_int
+      - vectordatasource.transform.major_airport_detector
       - vectordatasource.transform.elevation_to_meters
       - vectordatasource.transform.normalize_operator_values
       - vectordatasource.transform.truncate_min_zoom_to_2dp

--- a/queries/planet_osm_point.jinja2
+++ b/queries/planet_osm_point.jinja2
@@ -4,7 +4,7 @@ SELECT
   {% filter geometry %}way{% endfilter %} AS __geometry__,
 
   -- common properties across all layers
-  to_jsonb(tags) || jsonb_build_object(
+  to_jsonb(tags) || extra_wikidata_properties(tags->'wikidata') || jsonb_build_object(
     'source', 'openstreetmap.org'
   ) AS __properties__,
 

--- a/queries/planet_osm_polygon.jinja2
+++ b/queries/planet_osm_polygon.jinja2
@@ -36,7 +36,7 @@ SELECT
   END AS __label__,
 
   -- common properties across all layers
-  to_jsonb(tags) || jsonb_build_object(
+  to_jsonb(tags) || extra_wikidata_properties(tags->'wikidata') || jsonb_build_object(
     'source', 'openstreetmap.org',
     'area', way_area
   ) AS __properties__,

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8956,3 +8956,30 @@ def update_min_zoom(ctx):
 
     layer['features'] = new_features
     return layer
+
+
+def major_airport_detector(shape, props, fid, zoom):
+    if props.get('kind') == 'aerodrome':
+        passengers = props.get('passenger_count', 0)
+        kind_detail = props.get('kind_detail')
+
+        # if we didn't detect that the airport is international (probably
+        # missing tagging to indicate that), but it carries over a million
+        # passengers a year, then it's probably an airport in the same class
+        # as an international one.
+        #
+        # for example, TPE (Taipei) airport hasn't got any international
+        # tagging, but carries over 45 million passengers a year. however,
+        # CGH (Sao Paulo Congonhas) carries 21 million, but is actually a
+        # domestic airport -- however it's so large we'd probably want to
+        # display it at the same scale as an international airport.
+        if kind_detail != 'international' and passengers > 1000000:
+            props['kind_detail'] = 'international'
+
+        # likewise, if we didn't detect a kind detail, but the number of
+        # passengers suggests it's more than just a flying club airfield,
+        # then set a regional kind_detail.
+        elif kind_detail is None and passengers > 10000:
+            props['kind_detail'] = 'regional'
+
+    return shape, props, fid

--- a/yaml/pois.yaml
+++ b/yaml/pois.yaml
@@ -807,11 +807,18 @@ filters:
       kind: {col: aeroway}
       kind_detail:
         case:
+          - when: { "international_flights": "yes" }
+            then: international
+          - when: { "aerodrome": international }
+            then: international
           - when: { "aerodrome:type": [public, private, airfield, international, regional, gliding] }
             then: { col: "aerodrome:type" }
           - when: { "aerodrome:type": "military/public" }
             then: military_public
+          - when: { "aerodrome": [public, private, airfield, regional, gliding] }
+            then: { col: "aerodrome" }
       tier: 3
+      passenger_count: {call: {func: util.safe_int, args: [{col: passenger_count}]}}
   # naval_base
   - filter: { military: naval_base }
     min_zoom: { min: [ { max: [ 8, { sum: [ { col: zoom }, 2 ] }, *tier3_min_zoom ] }, 14 ] }


### PR DESCRIPTION
We would like to be able to distinguish between large, important airports and smaller, less important airports in the map. However, the tagging of airports (`kind: aerodrome`) from OSM is somewhat inconsistent. We were previously using the `aerodrome:type`, but this is often missing.

This patch adds several backfilling mechanisms:

1. Using the `aerodrome` tag in addition to `aerodrome:type`. The two tags share many values in practice, so we can use `aerodrome=international` to override `aerodrome:type=*`.
2. Using the `international_flights=yes` tag to override `aerodrome` and `aerodrome:type`.
3. Joining to Wikidata to get the number of passengers the airport serves each year, allowing us to backfill not only very large airports with `kind_detail: international`, but also medium-sized airports where we weren't able to figure out the type from the `aerodrome` and `aerodrome:type` tags (if there were any).

Caveats: We look for airports with more than a million passengers per year to identify "international" airports. It turns out that there are several _domestic_ airports which serve more than a million people a year. For those airports, "international" is probably best interpreted as a description of the size of the airport, rather than the routes flown to/from it.

Connects to #1873.