### PR TITLE
Update to new version of static assets bundle including wikidata.

### DIFF
--- a/data/Makefile-import-data.jinja2
+++ b/data/Makefile-import-data.jinja2
@@ -12,6 +12,8 @@ import-shapefiles.sh: {{ tgt_shapefile_shps }}
 {% for shapefile in shapefiles %}
 	@echo 'shp2pgsql -dID -s 3857 -g the_geom {{ shapefile['tgt_shp'] }} {{ shapefile['name'] }}' >> import-shapefiles.sh
 {% endfor %}
+	# wikidata snapshot already in SQL, so just pipe directly to psql
+	@echo 'cat wikidata_snapshot.sql' >> import-shapefiles.sh
 	@echo './import-shapefiles.sh | psql -d <database>'
 
 shapefiles: shapefiles.tar.gz

--- a/data/Makefile-prepare-data.jinja2
+++ b/data/Makefile-prepare-data.jinja2
@@ -24,7 +24,8 @@ download: {{ src_shapefile_zips }}
 {% for shapefile in reproj_shapefiles %}
 {{ shapefile.src_shp }}: {{ shapefile.src_zip }}
 	unzip {% if shapefile.junk_dirs %}-j{% endif %} -o {{ shapefile.src_zip }} '{% if shapefile.junk_dirs %}*/{% endif %}{{ shapefile.src_wildcard }}'
-	touch --no-create {{ shapefile.src_shp }}
+	# touch -c means don't create the file if it doesn't already exist
+	touch -c {{ shapefile.src_shp }}
 	[ -f {{ shapefile.src_shp }} ]
 
 {{ shapefile.tgt_shp }}: {{ shapefile.src_shp }}

--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
 bucket: tilezen-assets
-datestamp: 20190412
+datestamp: 20190503
 
 shapefiles:
 


### PR DESCRIPTION
Uploaded a new version of the static assets bundle which includes the `wikidata_snapshot.sql`.

Added a line to `import-shapefiles.sh` to also import the wikidata snapshot. Switched from the more readable `--no-create` option to `touch` to the more cryptic `-c` because the latter is supported by both the GNU (Linux) and Mac OS versions of `touch`, whereas the long option is only supported by the GNU version.
