### PR TITLE
Fix tests failing due to interaction between #1881 and #1882

### DIFF
--- a/integration-test/1074-ne-roads-min-zoom.py
+++ b/integration-test/1074-ne-roads-min-zoom.py
@@ -29,6 +29,6 @@ class NEroadminzoom(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'roads', {
                 'id': 1,
-                'kind': u'highway',
+                'kind': u'major_road',
                 'min_zoom': 5.1,
             })

--- a/integration-test/1817-ne-toll-roads.py
+++ b/integration-test/1817-ne-toll-roads.py
@@ -29,6 +29,6 @@ class NEroadtoll(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'roads', {
                 'id': 1,
-                'kind': u'highway',
+                'kind': u'major_road',
                 'toll': True,
             })


### PR DESCRIPTION
#1881 and #1882 were merged in parallel, and each branch passed tests independently. However, merging both together caused the new tests introduced in #1881 to fail because they were incorrectly `kind: highway, kind_detail: trunk`, which got fixed in #1882 to `kind: major_road`.