### PR TITLE
Apply airport detection logic to polygons too.

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -482,7 +482,7 @@ _TIP: Some `landuse` features only exist as point features in OpenStreetMap. Fin
 
 #### Landuse `kind` values:
 
-* `aerodrome` - with `kind_detail` in `public`, `private`, `military_public`, `airfield`, `international`, `regional`, `gliding`.
+* `aerodrome` - with `kind_detail` in `public`, `private`, `military_public`, `airfield`, `international`, `regional`, `gliding`. And _optional_ `passenger_count` giving the number of passengers through the aerodrome per year.
 * `airfield`
 * `allotments`
 * `amusement_ride`

--- a/integration-test/1873-backfill-aerodrome-polygons.py
+++ b/integration-test/1873-backfill-aerodrome-polygons.py
@@ -12,7 +12,7 @@ class AerodromeTest(FixtureTest):
 
         self.generate_fixtures(
             # https://www.openstreetmap.org/way/545819287
-            dsl.way(545819287, dsl.box_area(z, x, y, 12545795), {
+            dsl.way(545819287, dsl.tile_box(z, x, y), {
                 'aerodrome': 'international',
                 'aerodrome:type': 'public',
                 'aeroway': 'aerodrome',
@@ -24,6 +24,15 @@ class AerodromeTest(FixtureTest):
                 'source': 'openstreetmap.org',
                 'wikidata': 'Q8688',
                 'wikipedia': 'en:San Francisco International Airport',
+            }),
+            # https://www.openstreetmap.org/way/22567191
+            dsl.way(22567191, dsl.tile_diagonal(z, x, y), {
+                'aeroway': 'runway',
+                'length': '3618',
+                'ref': '10L/28R',
+                'surface': 'asphalt',
+                'width': '61',
+                'source': 'openstreetmap.org',
             }),
         )
 
@@ -40,4 +49,13 @@ class AerodromeTest(FixtureTest):
                 'id': 545819287,
                 'kind': 'aerodrome',
                 'kind_detail': 'international',
+            })
+
+        # runway inside polygon
+        self.assert_has_feature(
+            z, x, y, 'roads', {
+                'id': 22567191,
+                'kind': 'aeroway',
+                'kind_detail': 'runway',
+                'aerodrome_kind_detail': 'international',
             })

--- a/integration-test/1873-backfill-aerodrome-polygons.py
+++ b/integration-test/1873-backfill-aerodrome-polygons.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class AerodromeTest(FixtureTest):
+
+    def test_sfo(self):
+        # SFO should be "international": both the polygon _and_ the POI.
+        import dsl
+
+        z, x, y = (13, 1311, 3170)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/545819287
+            dsl.way(545819287, dsl.box_area(z, x, y, 12545795), {
+                'aerodrome': 'international',
+                'aerodrome:type': 'public',
+                'aeroway': 'aerodrome',
+                'city_served': 'San Francisco, California',
+                'ele': '4',
+                'iata': 'SFO',
+                'icao': 'KSFO',
+                'name': 'San Francisco International Airport',
+                'source': 'openstreetmap.org',
+                'wikidata': 'Q8688',
+                'wikipedia': 'en:San Francisco International Airport',
+            }),
+        )
+
+        # POI
+        self.assert_has_feature(
+            z, x, y, 'pois', {
+                'id': 545819287,
+                'kind': 'aerodrome',
+                'kind_detail': 'international',
+            })
+
+        self.assert_has_feature(
+            z, x, y, 'landuse', {
+                'id': 545819287,
+                'kind': 'aerodrome',
+                'kind_detail': 'international',
+            })

--- a/queries.yaml
+++ b/queries.yaml
@@ -205,6 +205,7 @@ layers:
       - vectordatasource.transform.detect_osm_relation
       - vectordatasource.transform.remove_feature_id
       - vectordatasource.transform.normalize_operator_values
+      - vectordatasource.transform.major_airport_detector
       - vectordatasource.transform.truncate_min_zoom_to_2dp
     sort: vectordatasource.sort.landuse
     area-inclusion-threshold: 1

--- a/yaml/landuse.yaml
+++ b/yaml/landuse.yaml
@@ -624,11 +624,18 @@ filters:
       kind: aerodrome
       kind_detail:
         case:
+          - when: { "international_flights": "yes" }
+            then: international
+          - when: { "aerodrome": international }
+            then: international
           - when: { "aerodrome:type": [public, private, airfield, international, regional, gliding] }
             then: { col: "aerodrome:type" }
           - when: { "aerodrome:type": "military/public" }
             then: military_public
+          - when: { "aerodrome": [public, private, airfield, regional, gliding] }
+            then: { col: "aerodrome" }
       tier: 3
+      passenger_count: {call: {func: util.safe_int, args: [{col: passenger_count}]}}
   - filter: {military: naval_base}
     min_zoom: *tier3_min_zoom
     output:


### PR DESCRIPTION
As pointed out in https://github.com/tilezen/vector-datasource/issues/1873#issuecomment-490760803, PR #1879 didn't apply the same logic to `aerodrome` polygons as it applied to points. Applying the same logic is necessary to avoid confusion, but also so that the `aerodrome`'s matching `kind_detail` can be passed on to `runway` features within its boundary.

Connects to #1873.