### PR TITLE
Add more viewpoint data from Natural Earth

### DIFF
--- a/data/apply-schema-update.sql
+++ b/data/apply-schema-update.sql
@@ -91,6 +91,7 @@ PERFORM add_column_if_not_exists('planet_osm_line', 'mz_boundary_min_zoom', 'REA
 
 PERFORM add_column_if_not_exists('ne_110m_admin_0_boundary_lines_land', 'mz_boundary_min_zoom', 'REAL');
 PERFORM add_column_if_not_exists('ne_50m_admin_0_boundary_lines_land', 'mz_boundary_min_zoom', 'REAL');
+PERFORM add_column_if_not_exists('ne_50m_admin_0_boundary_lines_disputed_areas', 'mz_boundary_min_zoom', 'REAL');
 PERFORM add_column_if_not_exists('ne_50m_admin_1_states_provinces_lines', 'mz_boundary_min_zoom', 'REAL');
 PERFORM add_column_if_not_exists('ne_10m_admin_0_boundary_lines_land', 'mz_boundary_min_zoom', 'REAL');
 PERFORM add_column_if_not_exists('ne_10m_admin_0_boundary_lines_map_units', 'mz_boundary_min_zoom', 'REAL');

--- a/data/apply-updates-non-planet-tables.sql
+++ b/data/apply-updates-non-planet-tables.sql
@@ -27,6 +27,14 @@ UPDATE ne_10m_admin_0_boundary_lines_disputed_areas
   WHERE NOT ST_IsValid(the_geom);
 DELETE FROM ne_10m_admin_0_boundary_lines_disputed_areas WHERE NOT ST_IsValid(the_geom);
 
+UPDATE ne_50m_admin_0_boundary_lines_disputed_areas
+  SET
+    the_geom = (CASE WHEN GeometryType(ST_MakeValid(the_geom)) = 'MULTILINESTRING'
+                          THEN ST_MakeValid(the_geom)
+                     ELSE the_geom END)
+  WHERE NOT ST_IsValid(the_geom);
+DELETE FROM ne_50m_admin_0_boundary_lines_disputed_areas WHERE NOT ST_IsValid(the_geom);
+
 UPDATE ne_10m_admin_1_states_provinces_lines
   SET
     the_geom = (CASE WHEN GeometryType(ST_MakeValid(the_geom)) = 'MULTILINESTRING'
@@ -106,6 +114,10 @@ UPDATE ne_110m_admin_0_boundary_lines_land
 UPDATE ne_50m_admin_0_boundary_lines_land
   SET mz_boundary_min_zoom = mz_calculate_min_zoom_boundaries(ne_50m_admin_0_boundary_lines_land.*)
   WHERE mz_calculate_min_zoom_boundaries(ne_50m_admin_0_boundary_lines_land.*) IS NOT NULL;
+
+UPDATE ne_50m_admin_0_boundary_lines_disputed_areas
+  SET mz_boundary_min_zoom = mz_calculate_min_zoom_boundaries(ne_50m_admin_0_boundary_lines_disputed_areas.*)
+  WHERE mz_calculate_min_zoom_boundaries(ne_50m_admin_0_boundary_lines_disputed_areas.*) IS NOT NULL;
 
 UPDATE ne_50m_admin_1_states_provinces_lines
   SET mz_boundary_min_zoom = mz_calculate_min_zoom_boundaries(ne_50m_admin_1_states_provinces_lines.*)

--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
 bucket: tilezen-assets
-datestamp: 20190503
+datestamp: 20190517
 
 shapefiles:
 
@@ -85,19 +85,19 @@ shapefiles:
     prj: 4326
     tile: true
 
-  - name: ne_10m_populated_places
-    url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_populated_places.zip
-    prj: 4326
-
-  - name: ne_110m_admin_0_boundary_lines_land
-    url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip
-    prj: 4326
-
-  - name: ne_50m_admin_0_boundary_lines_land
-    url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_0_boundary_lines_land.zip
-    prj: 4326
-
-  # TEMPORARY DISABLE TO PULL IN v5-PRE2 DATA
+  # TEMPORARY DISABLE TO PULL IN v5-PRE4 DATA
+  #
+  # - name: ne_10m_populated_places
+  #   url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_populated_places.zip
+  #   prj: 4326
+  #
+  # - name: ne_110m_admin_0_boundary_lines_land
+  #   url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_boundary_lines_land.zip
+  #   prj: 4326
+  #
+  # - name: ne_50m_admin_0_boundary_lines_land
+  #   url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_0_boundary_lines_land.zip
+  #   prj: 4326
   #
   #- name: ne_10m_admin_0_boundary_lines_land
   #  url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_0_boundary_lines_land.zip
@@ -106,33 +106,69 @@ shapefiles:
   #- name: ne_10m_admin_0_boundary_lines_map_units
   #  url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_0_boundary_lines_map_units.zip
   #  prj: 4326
+  #
+  # - name: ne_50m_admin_1_states_provinces_lines
+  #   url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_1_states_provinces_lines.zip
+  #   prj: 4326
+  #   shapefile-name: ne_50m_admin_1_states_provinces_lines.shp
+
+  # - name: ne_10m_admin_1_states_provinces_lines
+  #   url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_1_states_provinces_lines.zip
+  #   prj: 4326
+
+  - name: ne_10m_populated_places
+    shapefile-name: ne_10m_populated_places.shp
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    prj: 4326
+    junk_dirs: yes
+
+  - name: ne_110m_admin_0_boundary_lines_land
+    shapefile-name: ne_110m_admin_0_boundary_lines_land.shp
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    prj: 4326
+    junk_dirs: yes
+
+  - name: ne_50m_admin_0_boundary_lines_land
+    shapefile-name: ne_50m_admin_0_boundary_lines_land.shp
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    prj: 4326
+    junk_dirs: yes
+
+  - name: ne_50m_admin_0_boundary_lines_disputed_areas
+    shapefile-name: ne_50m_admin_0_boundary_lines_disputed_areas.shp
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    prj: 4326
+    junk_dirs: yes
 
   - name: ne_10m_admin_0_boundary_lines_disputed_areas
     shapefile-name: ne_10m_admin_0_boundary_lines_disputed_areas.shp
-    url: https://github.com/tilezen/vector-datasource/files/2868291/ne_v5.0.0-pre2-boundaries-pov.zip
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
     prj: 4326
     junk_dirs: yes
 
   - name: ne_10m_admin_0_boundary_lines_land
     shapefile-name: ne_10m_admin_0_boundary_lines_land.shp
-    url: https://github.com/tilezen/vector-datasource/files/2868291/ne_v5.0.0-pre2-boundaries-pov.zip
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
     prj: 4326
     junk_dirs: yes
 
   - name: ne_10m_admin_0_boundary_lines_map_units
     shapefile-name: ne_10m_admin_0_boundary_lines_map_units.shp
-    url: https://github.com/tilezen/vector-datasource/files/2868291/ne_v5.0.0-pre2-boundaries-pov.zip
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
     prj: 4326
     junk_dirs: yes
 
   - name: ne_50m_admin_1_states_provinces_lines
-    url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_1_states_provinces_lines.zip
-    prj: 4326
     shapefile-name: ne_50m_admin_1_states_provinces_lines.shp
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    prj: 4326
+    junk_dirs: yes
 
   - name: ne_10m_admin_1_states_provinces_lines
-    url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_1_states_provinces_lines.zip
+    shapefile-name: ne_10m_admin_1_states_provinces_lines.shp
+    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
     prj: 4326
+    junk_dirs: yes
 
   - name: ne_10m_roads
     url: http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_roads.zip

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -740,7 +740,9 @@ Places with `kind` values of `continent`, `country`, with others added starting 
 #### Place properties (common optional):
 
 * `country_capital`: a `true` value normalizes values between OpenStreetMap and Natural Earth for kinds of `Admin-0 capital`, `Admin-0 capital alt`, and `Admin-0 region capital`.
+* `country_capital:xx`: when present, either `true` or `false` to override the `country_capital` value for XX's viewpoint.
 * `region_capital`: a `true` value normalizes values between OpenStreetMap and Natural Earth for kinds of `Admin-1 capital` and `Admin-1 region capital`.
+* `region_capital:xx`: when present, either `true` or `false` to override the `region_capital` value for XX's viewpoint.
 * `max_zoom`: a suggested maximum zoom beyond which the place should not be visible. Currently neighbourhoods only, from Who's On First.
 * `is_landuse_aoi`: Currently neighbourhoods only, from Who's On First
 * `kind_detail`: the original value of the OSM `place` tag and Natural Earth `featurecla`, see below.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -740,9 +740,9 @@ Places with `kind` values of `continent`, `country`, with others added starting 
 #### Place properties (common optional):
 
 * `country_capital`: a `true` value normalizes values between OpenStreetMap and Natural Earth for kinds of `Admin-0 capital`, `Admin-0 capital alt`, and `Admin-0 region capital`.
-* `country_capital:xx`: when present, either `true` or `false` to override the `country_capital` value for XX's viewpoint.
+* `country_capital:xx`: when present, either `true` or `false` to override the `country_capital` value for XX's viewpoint. Note that the viewpoints are either lower-case [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) codes or the pseudo-code `iso`, same as for `kind:xx` on boundaries.
 * `region_capital`: a `true` value normalizes values between OpenStreetMap and Natural Earth for kinds of `Admin-1 capital` and `Admin-1 region capital`.
-* `region_capital:xx`: when present, either `true` or `false` to override the `region_capital` value for XX's viewpoint.
+* `region_capital:xx`: when present, either `true` or `false` to override the `region_capital` value for XX's viewpoint. Note that the viewpoints are either lower-case [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) codes or the pseudo-code `iso`, same as for `kind:xx` on boundaries.
 * `max_zoom`: a suggested maximum zoom beyond which the place should not be visible. Currently neighbourhoods only, from Who's On First.
 * `is_landuse_aoi`: Currently neighbourhoods only, from Who's On First
 * `kind_detail`: the original value of the OSM `place` tag and Natural Earth `featurecla`, see below.

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -295,6 +295,9 @@ class PlaceTest(FixtureTest):
                 'region_capital:cn': type(True),
             })
 
+    # NOTE: this isn't a test, just a factoring-out of common code used by all
+    # the subsequent tests, which are testing variations of what happens when
+    # the default (featurecla) is different from an override (fclass_iso).
     def _check(self, default, dispute, expected):
         import dsl
 

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -264,3 +264,130 @@ class BoundaryTest(FixtureTest):
 
         self.assertTrue(saw_xa, "Expected to see XA's viewpoint boundary")
         self.assertTrue(saw_xb, "Expected to see XB's country boundary")
+
+
+class PlaceTest(FixtureTest):
+
+    def test_disputed_capital(self):
+        import dsl
+
+        z, x, y = 16, 0, 0
+
+        # a country capital which CN doesn't think is a country capital. this
+        # is just a test case, and any resemblance to real disputes, living or
+        # dead, is purely coincidental.
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_centre_shape(z, x, y), {
+                'name': 'Foo',
+                'featurecla': 'Admin-0 capital',
+                'fclass_cn': 'Admin-1 capital',
+                'scalerank': 4,
+                'min_zoom': 4,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'kind': 'locality',
+                'country_capital': type(True),
+                'country_capital:cn': type(False),
+                'region_capital:cn': type(True),
+            })
+
+    def _check(self, default, dispute, expected):
+        import dsl
+
+        z, x, y = 16, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_centre_shape(z, x, y), {
+                'name': 'Foo',
+                'featurecla': default,
+                'fclass_iso': dispute,
+                'scalerank': 4,
+                'min_zoom': 4,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        expected['kind'] = 'locality'
+        self.assert_has_feature(z, x, y, 'places', expected)
+
+    def test_country_country(self):
+        # explicit override still comes out in the output
+        self._check(
+            'Admin-0 capital',
+            'Admin-0 capital',
+            {'country_capital:iso': type(True)}
+        )
+
+    def test_country_region(self):
+        # region override disables country_capital and adds region_capital.
+        self._check(
+            'Admin-0 capital',
+            'Admin-1 capital',
+            {
+                'country_capital:iso': type(False),
+                'region_capital:iso': type(True),
+            }
+        )
+
+    def test_country_none(self):
+        # override to none should just disable country_capital
+        self._check(
+            'Admin-0 capital',
+            'Populated place',
+            {'country_capital:iso': type(False)}
+        )
+
+    def test_region_country(self):
+        # override sets country_capital and disables region_capital
+        self._check(
+            'Admin-1 capital',
+            'Admin-0 capital',
+            {
+                'country_capital:iso': type(True),
+                'region_capital:iso': type(False),
+            }
+        )
+
+    def test_region_region(self):
+        # explicit override still comes out in the output
+        self._check(
+            'Admin-1 capital',
+            'Admin-1 capital',
+            {'region_capital:iso': type(True)}
+        )
+
+    def test_region_none(self):
+        # disables region_capital
+        self._check(
+            'Admin-1 capital',
+            'Populated place',
+            {'region_capital:iso': type(False)}
+        )
+
+    def test_none_country(self):
+        # sets country_capital
+        self._check(
+            'Populated place',
+            'Admin-0 capital',
+            {'country_capital:iso': type(True)}
+        )
+
+    def test_none_region(self):
+        # sets region_capital
+        self._check(
+            'Populated place',
+            'Admin-1 capital',
+            {'region_capital:iso': type(True)}
+        )
+
+    def test_none_none(self):
+        # does nothing?
+        self._check(
+            'Populated place',
+            'Populated place',
+            {}
+        )

--- a/queries.yaml
+++ b/queries.yaml
@@ -186,6 +186,7 @@ layers:
       - vectordatasource.transform.tags_remove
       - vectordatasource.transform.place_population_int
       - vectordatasource.transform.population_rank
+      - vectordatasource.transform.capital_alternate_viewpoint
       - vectordatasource.transform.calculate_default_place_min_zoom
       - vectordatasource.transform.add_id_to_properties
       - vectordatasource.transform.detect_osm_relation

--- a/queries/ne-boundaries-10m.jinja2
+++ b/queries/ne-boundaries-10m.jinja2
@@ -6,5 +6,5 @@ UNION ALL
 UNION ALL
 {{ ne_boundaries_query(False, True, 'ne_10m_admin_0_boundary_lines_disputed_areas') }}
 UNION ALL
-{{ ne_boundaries_query(True, False, 'ne_10m_admin_1_states_provinces_lines') }}
+{{ ne_boundaries_query(True, True, 'ne_10m_admin_1_states_provinces_lines') }}
 {% endblock %}

--- a/queries/ne-boundaries-110m.jinja2
+++ b/queries/ne-boundaries-110m.jinja2
@@ -1,4 +1,4 @@
 {% extends 'ne.jinja2' %}
 {% block query %}
-{{ ne_boundaries_query(False, False, 'ne_110m_admin_0_boundary_lines_land') }}
+{{ ne_boundaries_query(False, True, 'ne_110m_admin_0_boundary_lines_land') }}
 {% endblock %}

--- a/queries/ne-boundaries-50m.jinja2
+++ b/queries/ne-boundaries-50m.jinja2
@@ -1,6 +1,8 @@
 {% extends 'ne.jinja2' %}
 {% block query %}
-{{ ne_boundaries_query(False, False, 'ne_50m_admin_0_boundary_lines_land') }}
+{{ ne_boundaries_query(False, True, 'ne_50m_admin_0_boundary_lines_land') }}
 UNION ALL
-{{ ne_boundaries_query(False, False, 'ne_50m_admin_1_states_provinces_lines') }}
+{{ ne_boundaries_query(False, True, 'ne_50m_admin_0_boundary_lines_disputed_areas') }}
+UNION ALL
+{{ ne_boundaries_query(False, True, 'ne_50m_admin_1_states_provinces_lines') }}
 {% endblock %}

--- a/queries/ne-places.jinja2
+++ b/queries/ne-places.jinja2
@@ -23,6 +23,11 @@ SELECT
     'scalerank', scalerank,
     'min_zoom', mz_places_min_zoom,
     'wikidata', wikidataid
+  ) || jsonb_build_object(
+{#- need to have a separate call to jsonb_build_object for viewpoints because it doesn't support more than 100 parameters, and we're over that with the number of languages + number of viewpoints #}
+{%- for vpt in ne_viewpoints %}
+    'fclass_{{vpt}}', fclass_{{vpt}}{{ "," if not loop.last }}
+{%- endfor %}
   ) AS __places_properties__,
 
   NULL::jsonb AS __roads_properties__,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 AppDirs==1.4.3
 argparse==1.4.0
 ASTFormatter==0.6.4
-boto==2.48.0
+boto==2.49.0
 edtf==2.6.0
 future==0.16.0
 gunicorn==19.9.0
@@ -21,6 +21,7 @@ simplejson==3.12.0
 six==1.11.0
 StreetNames==0.1.5
 tqdm==4.31.1
+urllib3==1.24.3 ## REMOVE THIS AS SOON AS botocore ALLOWS >=1.25
 Werkzeug==0.12.2
 wsgiref==0.1.2
 git+https://github.com/tilezen/tilequeue@master#egg=tilequeue

--- a/vectordatasource/meta/sql.py
+++ b/vectordatasource/meta/sql.py
@@ -13,6 +13,7 @@ LAYER_TABLES = {
         'ne_10m_admin_1_states_provinces_lines',
         'ne_110m_admin_0_boundary_lines_land',
         'ne_50m_admin_0_boundary_lines_land',
+        'ne_50m_admin_0_boundary_lines_disputed_areas',
         'ne_50m_admin_1_states_provinces_lines',
         'planet_osm_line',
         'planet_osm_polygon',

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9202,3 +9202,50 @@ def major_airport_detector(shape, props, fid, zoom):
             props['kind_detail'] = 'regional'
 
     return shape, props, fid
+
+
+_NE_COUNTRY_CAPITALS = [
+    'Admin-0 region capital',
+    'Admin-0 capital alt',
+    'Admin-0 capital',
+]
+
+
+_NE_REGION_CAPITALS = [
+    'Admin-1 capital',
+    'Admin-1 region capital',
+]
+
+
+def capital_alternate_viewpoint(shape, props, fid, zoom):
+    """
+    Removes the fclass_* properties and replaces them with viewpoint overrides
+    for country_capital and region_capital.
+    """
+
+    fclass_prefix = 'fclass_'
+
+    default_country_capital = props.get('country_capital', False)
+    default_region_capital = props.get('region_capital', False)
+
+    for k in props.keys():
+        if k.startswith(fclass_prefix):
+            viewpoint = k[len(fclass_prefix):]
+            fclass = props.pop(k)
+
+            country_capital = fclass in _NE_COUNTRY_CAPITALS
+            region_capital = fclass in _NE_REGION_CAPITALS
+
+            if country_capital:
+                props['country_capital:' + viewpoint] = True
+
+            elif region_capital:
+                props['region_capital:' + viewpoint] = True
+
+            if default_country_capital and not country_capital:
+                props['country_capital:' + viewpoint] = False
+
+            elif default_region_capital and not region_capital:
+                props['region_capital:' + viewpoint] = False
+
+    return shape, props, fid

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -53,36 +53,36 @@ global:
 
   - &ne_localized_kind_properties
     'kind:iso': {col: fclass_iso }
-    'kind:us': {col: fclass_us }
-    'kind:fr': {col: fclass_fr }
-    'kind:ru': {col: fclass_ru }
-    'kind:es': {col: fclass_es }
-    'kind:cn': {col: fclass_cn }
-    'kind:tw': {col: fclass_tw }
-    'kind:in': {col: fclass_in }
-    'kind:np': {col: fclass_np }
-    'kind:pk': {col: fclass_pk }
-    'kind:de': {col: fclass_de }
-    'kind:gb': {col: fclass_gb }
-    'kind:br': {col: fclass_br }
-    'kind:il': {col: fclass_il }
-    'kind:ps': {col: fclass_ps }
-    'kind:sa': {col: fclass_sa }
-    'kind:eg': {col: fclass_eg }
-    'kind:ma': {col: fclass_ma }
-    'kind:pt': {col: fclass_pt }
     'kind:ar': {col: fclass_ar }
+    'kind:bd': {col: fclass_bd }
+    'kind:br': {col: fclass_br }
+    'kind:cn': {col: fclass_cn }
+    'kind:de': {col: fclass_de }
+    'kind:eg': {col: fclass_eg }
+    'kind:es': {col: fclass_es }
+    'kind:fr': {col: fclass_fr }
+    'kind:gb': {col: fclass_gb }
+    'kind:gr': {col: fclass_gr }
+    'kind:id': {col: fclass_id }
+    'kind:il': {col: fclass_il }
+    'kind:in': {col: fclass_in }
+    'kind:it': {col: fclass_it }
     'kind:jp': {col: fclass_jp }
     'kind:ko': {col: fclass_ko }
-    'kind:vn': {col: fclass_vn }
-    'kind:tr': {col: fclass_tr }
-    'kind:id': {col: fclass_id }
-    'kind:pl': {col: fclass_pl }
-    'kind:gr': {col: fclass_gr }
-    'kind:it': {col: fclass_it }
+    'kind:ma': {col: fclass_ma }
     'kind:nl': {col: fclass_nl }
+    'kind:np': {col: fclass_np }
+    'kind:pk': {col: fclass_pk }
+    'kind:pl': {col: fclass_pl }
+    'kind:ps': {col: fclass_ps }
+    'kind:pt': {col: fclass_pt }
+    'kind:ru': {col: fclass_ru }
+    'kind:sa': {col: fclass_sa }
     'kind:se': {col: fclass_se }
-    'kind:bd': {col: fclass_bd }
+    'kind:tr': {col: fclass_tr }
+    'kind:tw': {col: fclass_tw }
+    'kind:us': {col: fclass_us }
+    'kind:vn': {col: fclass_vn }
 
   # this is a hack to get around the fact that boundary features with the same
   # tags exist in both the polygons and lines table. osm2pgsql makes geometries

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -39,6 +39,42 @@ global:
         - [ 9, 9 ]
       default: 10
 
+  - &ne_country_capital [Admin-0 region capital, Admin-0 capital alt, Admin-0 capital]
+  - &ne_region_capital [Admin-1 capital, Admin-1 region capital]
+
+  - &alternate_fclass
+    fclass_iso: { col: fclass_iso }
+    fclass_us: { col: fclass_us }
+    fclass_fr: { col: fclass_fr }
+    fclass_ru: { col: fclass_ru }
+    fclass_es: { col: fclass_es }
+    fclass_cn: { col: fclass_cn }
+    fclass_tw: { col: fclass_tw }
+    fclass_in: { col: fclass_in }
+    fclass_np: { col: fclass_np }
+    fclass_pk: { col: fclass_pk }
+    fclass_de: { col: fclass_de }
+    fclass_gb: { col: fclass_gb }
+    fclass_br: { col: fclass_br }
+    fclass_il: { col: fclass_il }
+    fclass_ps: { col: fclass_ps }
+    fclass_sa: { col: fclass_sa }
+    fclass_eg: { col: fclass_eg }
+    fclass_ma: { col: fclass_ma }
+    fclass_pt: { col: fclass_pt }
+    fclass_ar: { col: fclass_ar }
+    fclass_jp: { col: fclass_jp }
+    fclass_ko: { col: fclass_ko }
+    fclass_vn: { col: fclass_vn }
+    fclass_tr: { col: fclass_tr }
+    fclass_id: { col: fclass_id }
+    fclass_pl: { col: fclass_pl }
+    fclass_gr: { col: fclass_gr }
+    fclass_it: { col: fclass_it }
+    fclass_nl: { col: fclass_nl }
+    fclass_se: { col: fclass_se }
+    fclass_bd: { col: fclass_bd }
+
 filters:
   - filter:
       meta.source: wof
@@ -156,19 +192,21 @@ filters:
 
   - filter:
       scalerank: true
-      featurecla: [Admin-0 region capital, Admin-0 capital alt, Admin-0 capital]
+      featurecla: *ne_country_capital
     min_zoom: *ne_places_min_zoom
     output:
       <<: *output_properties
+      <<: *alternate_fclass
       kind: locality
       country_capital: true
     table: ne
   - filter:
       scalerank: true
-      featurecla: [Admin-1 capital, Admin-1 region capital]
+      featurecla: *ne_region_capital
     min_zoom: *ne_places_min_zoom
     output:
       <<: *output_properties
+      <<: *alternate_fclass
       kind: locality
       region_capital: true
     table: ne
@@ -176,6 +214,7 @@ filters:
     min_zoom: *ne_places_min_zoom
     output:
       <<: *output_properties
+      <<: *alternate_fclass
       kind: locality
     table: ne
 

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -39,7 +39,7 @@ global:
         - [ 9, 9 ]
       default: 10
 
-  - &ne_country_capital [Admin-0 region capital, Admin-0 capital alt, Admin-0 capital]
+  - &ne_country_capital [Admin-0 capital, Admin-0 capital alt, Admin-0 region capital]
   - &ne_region_capital [Admin-1 capital, Admin-1 region capital]
 
   - &alternate_fclass

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -44,36 +44,36 @@ global:
 
   - &alternate_fclass
     fclass_iso: { col: fclass_iso }
-    fclass_us: { col: fclass_us }
-    fclass_fr: { col: fclass_fr }
-    fclass_ru: { col: fclass_ru }
-    fclass_es: { col: fclass_es }
-    fclass_cn: { col: fclass_cn }
-    fclass_tw: { col: fclass_tw }
-    fclass_in: { col: fclass_in }
-    fclass_np: { col: fclass_np }
-    fclass_pk: { col: fclass_pk }
-    fclass_de: { col: fclass_de }
-    fclass_gb: { col: fclass_gb }
-    fclass_br: { col: fclass_br }
-    fclass_il: { col: fclass_il }
-    fclass_ps: { col: fclass_ps }
-    fclass_sa: { col: fclass_sa }
-    fclass_eg: { col: fclass_eg }
-    fclass_ma: { col: fclass_ma }
-    fclass_pt: { col: fclass_pt }
     fclass_ar: { col: fclass_ar }
+    fclass_bd: { col: fclass_bd }
+    fclass_br: { col: fclass_br }
+    fclass_cn: { col: fclass_cn }
+    fclass_de: { col: fclass_de }
+    fclass_eg: { col: fclass_eg }
+    fclass_es: { col: fclass_es }
+    fclass_fr: { col: fclass_fr }
+    fclass_gb: { col: fclass_gb }
+    fclass_gr: { col: fclass_gr }
+    fclass_id: { col: fclass_id }
+    fclass_il: { col: fclass_il }
+    fclass_in: { col: fclass_in }
+    fclass_it: { col: fclass_it }
     fclass_jp: { col: fclass_jp }
     fclass_ko: { col: fclass_ko }
-    fclass_vn: { col: fclass_vn }
-    fclass_tr: { col: fclass_tr }
-    fclass_id: { col: fclass_id }
-    fclass_pl: { col: fclass_pl }
-    fclass_gr: { col: fclass_gr }
-    fclass_it: { col: fclass_it }
+    fclass_ma: { col: fclass_ma }
     fclass_nl: { col: fclass_nl }
+    fclass_np: { col: fclass_np }
+    fclass_pk: { col: fclass_pk }
+    fclass_pl: { col: fclass_pl }
+    fclass_ps: { col: fclass_ps }
+    fclass_pt: { col: fclass_pt }
+    fclass_ru: { col: fclass_ru }
+    fclass_sa: { col: fclass_sa }
     fclass_se: { col: fclass_se }
-    fclass_bd: { col: fclass_bd }
+    fclass_tr: { col: fclass_tr }
+    fclass_tw: { col: fclass_tw }
+    fclass_us: { col: fclass_us }
+    fclass_vn: { col: fclass_vn }
 
 filters:
   - filter:


### PR DESCRIPTION
Adds viewpoint data from the v5.0-pre4 version. This extends disputed information to admin-1 (state) boundaries and populated places. In the case of the boundary lines, the data is the same (`kind:xx` overrides) as for previous 1:10m disputed boundary work.
    
In the case of populated places, the dispute data is used to set overrides for the `country_capital` and `region_capital` properties, i.e: `country_capital:xx=True/False`.

Note: The new v5.0-pre4 data means a new asset bundle version `20190517` was created.

Connects to #1840.