### PR TITLE
Update to NE v5-pre5 and bump tile assets version.

### DIFF
--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
 bucket: tilezen-assets
-datestamp: 20190517
+datestamp: 20190531
 
 shapefiles:
 
@@ -118,55 +118,55 @@ shapefiles:
 
   - name: ne_10m_populated_places
     shapefile-name: ne_10m_populated_places.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: &ne_pre_release_url https://github.com/tilezen/vector-datasource/files/3239842/ne_v5.0.0-pre5-boundaries-pov.zip
     prj: 4326
     junk_dirs: yes
 
   - name: ne_110m_admin_0_boundary_lines_land
     shapefile-name: ne_110m_admin_0_boundary_lines_land.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 
   - name: ne_50m_admin_0_boundary_lines_land
     shapefile-name: ne_50m_admin_0_boundary_lines_land.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 
   - name: ne_50m_admin_0_boundary_lines_disputed_areas
     shapefile-name: ne_50m_admin_0_boundary_lines_disputed_areas.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 
   - name: ne_10m_admin_0_boundary_lines_disputed_areas
     shapefile-name: ne_10m_admin_0_boundary_lines_disputed_areas.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 
   - name: ne_10m_admin_0_boundary_lines_land
     shapefile-name: ne_10m_admin_0_boundary_lines_land.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 
   - name: ne_10m_admin_0_boundary_lines_map_units
     shapefile-name: ne_10m_admin_0_boundary_lines_map_units.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 
   - name: ne_50m_admin_1_states_provinces_lines
     shapefile-name: ne_50m_admin_1_states_provinces_lines.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 
   - name: ne_10m_admin_1_states_provinces_lines
     shapefile-name: ne_10m_admin_1_states_provinces_lines.shp
-    url: https://github.com/tilezen/vector-datasource/files/3185025/ne_v5.0.0-pre4-boundaries-pov.zip
+    url: *ne_pre_release_url
     prj: 4326
     junk_dirs: yes
 


### PR DESCRIPTION
Tile assets bundle version `20190531` has been uploaded, incorporating the latest [Natural Earth v5-pre5](https://github.com/tilezen/vector-datasource/issues/1840#issuecomment-497583012).

Tangentially related to #1840.