### PR TITLE
Treat NaN and Inf as invalid

### DIFF
--- a/test/test_meta_functions.py
+++ b/test/test_meta_functions.py
@@ -64,3 +64,22 @@ class UnitParsingTest(unittest.TestCase):
         # missing tags will be passed through as None, so we have to handle
         # that by returning None.
         self._assert_meters(None, None)
+
+    def test_finite(self):
+        # should return a finite number or None
+        self._assert_meters('NaN', None)
+        self._assert_meters('Inf', None)
+        self._assert_meters('-Inf', None)
+
+
+class ToFloatTest(unittest.TestCase):
+
+    def test_finite(self):
+        # to_float should return a finite number or None. technically, both
+        # Inf and NaN are valid values for floats, but they do strange things
+        # and may raise unexpected exceptions during arithmetic. in general,
+        # we do not expect to see valid uses of NaN or Inf in input data.
+        from vectordatasource.util import to_float
+        self.assertIsNone(to_float('NaN'))
+        self.assertIsNone(to_float('Inf'))
+        self.assertIsNone(to_float('-Inf'))

--- a/vectordatasource/util.py
+++ b/vectordatasource/util.py
@@ -1,8 +1,14 @@
+from math import isinf
+from math import isnan
+
+
 def to_float(x):
     """
-    attempts to convert x to a floating point value,
-    first removing some common punctuation. returns
-    None if conversion failed.
+    Attempts to convert x to a floating point value, first removing some
+    common punctuation.
+
+    Returns None if conversion failed, or if the converted value is not
+    finite (i.e: NaN or Inf).
     """
 
     if x is None:
@@ -13,7 +19,18 @@ def to_float(x):
         x = x.replace(';', '.').replace(',', '.')
 
     try:
-        return float(x)
+        value = float(x)
+        # although NaN and Inf are, technically, valid floating point values,
+        # they're pretty unhelpful when we're expecting finite values. in
+        # addition, they can raise unexpected exceptions when being processed
+        # by stages in the pipeline which were written with finite valus in
+        # mind. we expect that if we encounter them in input data, that's
+        # probably a mistake, so we can treat them as missing / invalid.
+        if isnan(value) or isinf(value):
+            return None
+
+        return value
+
     except ValueError:
         return None
 


### PR DESCRIPTION
Although these are, technically, valid floating point values, we don't really expect to see them in real input data - and they don't convey useful information about real-world features. Further, they can cause other stages of the pipeline which were written with finite numbers in mind to raise exceptions, breaking the build.

This changes the behaviour of `to_float` to treat `NaN` and `Inf` as if they were not valid floating point numbers, returning `None` instead.

