### PR TITLE
Add support for NaturalEarth region disputes & claims 

### DIFF
--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -674,3 +674,23 @@ class NaturalEarth(FixtureTest):
                 'kind': 'region',
                 'kind:gb': 'country',
             })
+
+    def test_unrecognized_macroregion(self):
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'featurecla': 'Admin-1 region boundary',
+                'fclass_gb': 'Unrecognized Admin-1 region boundary',
+                'scalerank': 0,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'macroregion',
+                'kind:gb': 'unrecognized_macroregion',
+            })

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -585,3 +585,92 @@ class NaturalEarth(FixtureTest):
                 'kind': 'country',
                 'kind:gb': 'unrecognized_country',
             })
+
+    def test_region_claim(self):
+        # test that a boundary tagged as generally unrecognized, but a region
+        # boundary in some viewpoint, gets output with the appropriate kind:XX
+        # viewpoint property.
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'featurecla': 'Unrecognized Admin-1 boundary',
+                'fclass_gb': 'Admin-1 boundary',
+                'scalerank': 0,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'unrecognized_region',
+                'kind:gb': 'region',
+            })
+
+    def test_region_dispute(self):
+        # check that a boundary which is disputed and shouldn't be shown in
+        # some viewpoint is output with a kind:XX property reflecting that.
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'featurecla': 'Admin-1 boundary',
+                'fclass_gb': 'Unrecognized Admin-1 boundary',
+                'scalerank': 0,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'region',
+                'kind:gb': 'unrecognized_region',
+            })
+
+    def test_country_view_region(self):
+        # check that viewpoint can have kind:XX = region on a kind = country,
+        # not just unrecognized.
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'featurecla': 'International boundary (verify)',
+                'fclass_gb': 'Admin-1 boundary',
+                'min_zoom': 0,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'country',
+                'kind:gb': 'region',
+            })
+
+    def test_region_view_country(self):
+        # check that viewpoint can have kind:XX = country on a kind = region,
+        # not just unrecognized.
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'featurecla': 'Admin-1 boundary',
+                'fclass_gb': 'International boundary (verify)',
+                'min_zoom': 0,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'region',
+                'kind:gb': 'country',
+            })

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -537,3 +537,51 @@ class CountyBoundary(FixtureTest):
                 'kind': 'unrecognized_county',
                 'kind:xa': 'county',
             })
+
+
+class NaturalEarth(FixtureTest):
+
+    def test_country_claim(self):
+        # test that a boundary tagged as generally unrecognized, but a country
+        # boundary in some viewpoint, gets output with the appropriate kind:XX
+        # viewpoint property.
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'featurecla': 'Unrecognized',
+                'fclass_gb': 'International boundary (verify)',
+                'min_zoom': 0,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'unrecognized_country',
+                'kind:gb': 'country',
+            })
+
+    def test_country_dispute(self):
+        # check that a boundary which is disputed and shouldn't be shown in
+        # some viewpoint is output with a kind:XX property reflecting that.
+        import dsl
+
+        z, x, y = 8, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal(z, x, y), {
+                'featurecla': 'International boundary (verify)',
+                'fclass_gb': 'Unrecognized',
+                'min_zoom': 0,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'kind': 'country',
+                'kind:gb': 'unrecognized_country',
+            })

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8911,6 +8911,15 @@ _REMAP_VIEWPOINT_KIND = {
     'Claim boundary': 'disputed_claim',
     'Elusive frontier': 'disputed_elusive',
     'Reference line': 'disputed_reference_line',
+    'Admin-1 region boundary': 'macroregion',
+    'Admin-1 boundary': 'region',
+    'Admin-1 statistical boundary': 'region',
+    'Admin-1 statistical meta bounds': 'region',
+    '1st Order Admin Lines': 'region',
+    'Unrecognized Admin-1 region boundary': 'unrecognized_macroregion',
+    'Unrecognized Admin-1 boundary': 'unrecognized_region',
+    'Unrecognized Admin-1 statistical boundary': 'unrecognized_region',
+    'Unrecognized Admin-1 statistical meta bounds': 'unrecognized_region',
 }
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -8905,7 +8905,7 @@ _REMAP_VIEWPOINT_KIND = {
     'Lease limit': 'lease_limit',
     'Line of control (please verify)': 'line_of_control',
     'Overlay limit': 'overlay_limit',
-    'Unrecognized': 'unrecognized',
+    'Unrecognized': 'unrecognized_country',
     'Map unit boundary': 'map_unit',
     'Breakaway': 'disputed_breakaway',
     'Claim boundary': 'disputed_claim',

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -274,6 +274,16 @@ filters:
   - filter:
       featurecla:
         - Unrecognized Admin-1 region boundary
+    min_zoom: *ne_region_boundaries_min_zoom
+    extra_columns: [scalerank]
+    output:
+      <<: *output_properties
+      <<: *ne_localized_kind_properties
+      kind: unrecognized_macroregion
+      kind_detail: '4'
+    table: ne
+  - filter:
+      featurecla:
         - Unrecognized Admin-1 boundary
         - Unrecognized Admin-1 statistical boundary
         - Unrecognized Admin-1 statistical meta bounds

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -43,7 +43,7 @@ global:
         - [ 'lease_limit', 'Lease limit' ]
         - [ 'line_of_control', 'Line of control (please verify)' ]
         - [ 'overlay_limit', 'Overlay limit' ]
-        - [ 'unrecognized', 'Unrecognized' ]
+        - [ 'unrecognized_country', 'Unrecognized' ]
         - [ 'map_unit', 'Map unit boundary' ]
         - [ 'disputed_breakaway', 'Breakaway' ]
         - [ 'disputed_claim', 'Claim boundary' ]

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -246,10 +246,13 @@ filters:
       kind_detail: '2'
     table: ne
 
-  - filter: {featurecla: Admin-1 region boundary}
+  - filter:
+      featurecla:
+        - Admin-1 region boundary
     min_zoom: *ne_region_boundaries_min_zoom
     output:
       <<: *output_properties
+      <<: *ne_localized_kind_properties
       kind: macroregion
       kind_detail: '3'
     extra_columns: [scalerank]
@@ -264,6 +267,21 @@ filters:
     extra_columns: [scalerank]
     output:
       <<: *output_properties
+      <<: *ne_localized_kind_properties
       kind: region
+      kind_detail: '4'
+    table: ne
+  - filter:
+      featurecla:
+        - Unrecognized Admin-1 region boundary
+        - Unrecognized Admin-1 boundary
+        - Unrecognized Admin-1 statistical boundary
+        - Unrecognized Admin-1 statistical meta bounds
+    min_zoom: *ne_region_boundaries_min_zoom
+    extra_columns: [scalerank]
+    output:
+      <<: *output_properties
+      <<: *ne_localized_kind_properties
+      kind: unrecognized_region
       kind_detail: '4'
     table: ne


### PR DESCRIPTION
We added support for country disputes & claims in #1895 & #1896, and disputes about the status of capital cities in #1897. However, the support for region boundary lines wasn't fully implemented. This PR adds tests and changes to the kind remapping rules to support disputes & claims on regions tagged as NaturalEarth `featureclass` / `fclass_*` values.

Also, changed `kind: unrecognized` to `kind: unrecognized_country`, matching changes we'd previously made for OSM boundaries.

Connects to #1840 & #1810.