### PR TITLE
Backfill region capital status from Natural Earth

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1105,6 +1105,7 @@ BEGIN
   IF wikidata_id IS NOT NULL THEN
     SELECT w.tags INTO tags FROM wikidata w WHERE w.id = wikidata_id;
     SELECT hstore(ARRAY[
+      'featurecla', ne_pp.featurecla,
       'fclass_iso', ne_pp.fclass_iso,
       'fclass_ar', ne_pp.fclass_ar,
       'fclass_bd', ne_pp.fclass_bd,

--- a/integration-test/1906-missing-region-capital-pov.py
+++ b/integration-test/1906-missing-region-capital-pov.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class RegionCapital(FixtureTest):
+
+    def test_taichung(self):
+        import dsl
+
+        z, x, y = (10, 855, 441)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/60655918
+            dsl.point(60655918, (120.6478282, 24.163162), {
+                'name': u'臺中市',
+                'name:en': u'Taichung',
+                'place': u'city',
+                'population': u'2767239',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q245023',
+                'wikipedia': u'zh:臺中市',
+
+                # these come from NE data joined on wikidataid
+                'featurecla': 'Admin-1 capital',
+                'fclass_cn': 'Populated place',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 60655918,
+                'region_capital': type(True),
+                'region_capital:cn': type(False),
+            })

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -1,4 +1,7 @@
 global:
+  - &ne_country_capital [Admin-0 capital, Admin-0 capital alt, Admin-0 region capital]
+  - &ne_region_capital [Admin-1 capital, Admin-1 region capital]
+
   - &output_properties
     name: {col: name}
     source: {col: source}
@@ -9,9 +12,13 @@ global:
         func: util.tag_str_to_bool
         args: [ { col: capital } ]
     region_capital:
-      call:
-        func: util.tag_str_to_bool
-        args: [ { col: state_capital } ]
+      case:
+        - when: {featurecla: *ne_region_capital}
+          then: true
+        - else:
+            call:
+              func: util.tag_str_to_bool
+              args: [ { col: state_capital } ]
     mz_n_photos: {col: mz_n_photos}
     area:
       call:
@@ -38,9 +45,6 @@ global:
         - [ 7, 7 ]
         - [ 9, 9 ]
       default: 10
-
-  - &ne_country_capital [Admin-0 capital, Admin-0 capital alt, Admin-0 region capital]
-  - &ne_region_capital [Admin-1 capital, Admin-1 region capital]
 
   - &alternate_fclass
     fclass_iso: { col: fclass_iso }

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -8,9 +8,13 @@ global:
     admin_level: {col: admin_level}
     population: {col: population}
     country_capital:
-      call:
-        func: util.tag_str_to_bool
-        args: [ { col: capital } ]
+      case:
+        - when: {featurecla: *ne_country_capital}
+          then: true
+        - else:
+            call:
+              func: util.tag_str_to_bool
+              args: [ { col: capital } ]
     region_capital:
       case:
         - when: {featurecla: *ne_region_capital}


### PR DESCRIPTION
To figure out if a place (`city` or `town`) is a region or state capital, we have previously only looked at the OSM `state_capital` tag. However, some region capitals aren't tagged as such in OSM and this leads to changes across the boundary between Natural Earth and OSM data.

This patch back-fills the `region_capital` status from Natural Earth, so that if _either_ the OSM `state_capital` or the Natural Earth `featurecla` have appropriate values, then the `region_capital` flag will be set.

Connects to #1906.

