### PR TITLE
Removes vestigial code for outdated `mz_min_pixels` property

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -524,21 +524,6 @@ post_process:
       source_layer: water
       target_value_type: int
 
-  # drop all polygonal features that don't meet the minimum area
-  # threshold. this depends on the mz_min_pixels property to be set on
-  # features first
-  - fn: vectordatasource.transform.drop_features_mz_min_pixels
-    params:
-      property: mz_min_pixels
-      source_layers:
-        # all layers that have polygonal geometries
-        - boundaries
-        - buildings
-        - earth
-        - landuse
-        - transit
-        - water
-
   - fn: vectordatasource.transform.drop_properties
     params:
       source_layer: roads

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -205,62 +205,6 @@ class TagsPriorityI18nTest(unittest.TestCase):
         self.assertFalse('name:en_CT' in props)
 
 
-class DropFeaturesMinPixelsTest(unittest.TestCase):
-
-    def _make_feature_layers(self, pixel_threshold, shape):
-        props = dict(mz_min_pixels=pixel_threshold)
-        fid = None
-        feature = shape, props, fid
-        features = [feature]
-        feature_layers = [dict(name='layer-name', features=features)]
-        return feature_layers
-
-    def _call_fut(self, feature_layers, zoom):
-        from tilequeue.process import Context
-        from vectordatasource.transform import drop_features_mz_min_pixels
-        params = dict(property='mz_min_pixels', source_layers=('layer-name',))
-        ctx = Context(
-            feature_layers=feature_layers,
-            nominal_zoom=zoom,
-            params=params,
-            unpadded_bounds=None,
-            resources=None,
-            log=None,
-        )
-        result = drop_features_mz_min_pixels(ctx)
-        return result
-
-    def test_feature_drops(self):
-        import shapely.geometry
-        exterior_ring = [
-            (0, 0),
-            (0, 1),
-            (1, 1),
-            (0, 0),
-        ]
-        polygon = shapely.geometry.Polygon(exterior_ring)
-        feature_layers = self._make_feature_layers(1, polygon)
-        zoom = 1
-        self._call_fut(feature_layers, zoom)
-        features = feature_layers[0]['features']
-        self.assertEquals(0, len(features))
-
-    def test_feature_remains(self):
-        import shapely.geometry
-        exterior_ring = [
-            (0, 0),
-            (0, 1),
-            (1, 1),
-            (0, 0),
-        ]
-        polygon = shapely.geometry.Polygon(exterior_ring)
-        feature_layers = self._make_feature_layers(1, polygon)
-        zoom = 20
-        self._call_fut(feature_layers, zoom)
-        features = feature_layers[0]['features']
-        self.assertEquals(1, len(features))
-
-
 class LanduseSortKeysAreUniqueTest(unittest.TestCase):
 
     def _check_unique(self, csv_name):

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -4935,53 +4935,6 @@ def drop_properties_with_prefix(ctx):
                     del props[k]
 
 
-def drop_features_mz_min_pixels(ctx):
-    """
-    Drop all features that have a mz_min_pixels set whose area doesn't
-    meet the threshold.
-    """
-    source_layers = ctx.params.get('source_layers')
-    assert source_layers, 'drop_features_mz_min_pixels: missing source_layers'
-    source_layer_names = set(source_layers)  # set to speed up lookups
-
-    prop_name = ctx.params.get('property')
-    assert prop_name, 'drop_features_mz_min_pixels: missing property'
-
-    meters_per_pixel_area = calc_meters_per_pixel_area(ctx.nominal_zoom)
-
-    feature_layers = ctx.feature_layers
-    for source_layer_name in source_layer_names:
-        for feature_layer in feature_layers:
-            if feature_layer['name'] not in source_layer_names:
-                continue
-
-            features_to_keep = []
-            for feature in feature_layer['features']:
-                shape, props, fid = feature
-                pixel_threshold = props.get(prop_name)
-                if pixel_threshold is None:
-                    features_to_keep.append(feature)
-                    continue
-
-                assert isinstance(pixel_threshold, Number)
-
-                if shape.type not in ('Polygon', 'MultiPolygon'):
-                    features_to_keep.append(feature)
-                    continue
-
-                area_threshold = meters_per_pixel_area * pixel_threshold
-                area = props.get('area')
-                if area is None:
-                    area = shape.area
-                else:
-                    assert isinstance(area, Number)
-
-                if area >= area_threshold:
-                    features_to_keep.append(feature)
-
-            feature_layer['features'] = features_to_keep
-
-
 def _drop_small_inners(poly, area_tolerance):
     ext = poly.exterior
 


### PR DESCRIPTION
Removes the `vectordatasource.transform.drop_features_mz_min_pixels` transform and associated tests, which were previously used for filtering polygons by area with the `mz_min_pixels` parameter, but that was removed and this code was left behind. Resolves #1917 