### PR TITLE
Fix wrong encoding for CA:PE road network

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1659,7 +1659,7 @@ Network value include:
 * `CA:NT`
 * `CA:ON:primary`
 * `CA:ON:secondary`
-* `CA:PEI`
+* `CA:PE`
 * `CA:QC:A`
 * `CA:QC:R`
 * `CA:SK:primary`


### PR DESCRIPTION
Wrong encoding used for Prince Edward Island, Canada.
It was listed as `CA:PEI` but it should be `CA:PE`.

- [ ] Update tests
- [x] Update docs
