### PR TITLE
Add separate NE config for Chinese simplified and traditional

### DIFF
--- a/queries/ne.jinja2
+++ b/queries/ne.jinja2
@@ -1,5 +1,5 @@
 {% set ne_languages = ['ar', 'bn', 'de', 'el', 'en', 'es', 'fa', 'fr', 'he', 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'nl', 'pl', 'pt', 'ru', 'sv', 'tr', 'uk', 'ur', 'vi', 'zh', 'zht'] %}
-{% set ne_viewpoints = ['iso', 'ar', 'bd', 'br', 'cn', 'de', 'eg', 'es', 'fr', 'gb', 'gr', 'id', 'il', 'in', 'it', 'jp', 'ko', 'ma', 'nl', 'np', 'pk', 'pl', 'ps', 'pt', 'ru', 'sa', 'se', 'tr', 'tw', 'us', 'vn'] %}
+{% set ne_viewpoints = ['iso', 'ar', 'bd', 'br', 'cn', 'de', 'eg', 'es', 'fr', 'gb', 'gr', 'id', 'il', 'in', 'it', 'jp', 'ko', 'ma', 'nl', 'np', 'pk', 'pl', 'ps', 'pt', 'ru', 'sa', 'se', 'tr', 'tw', 'ua', 'us', 'vn'] %}
 
 {% macro ne_common_properties() %}
 

--- a/queries/ne.jinja2
+++ b/queries/ne.jinja2
@@ -1,4 +1,4 @@
-{% set ne_languages = ['ar', 'bn', 'de', 'en', 'es', 'fr', 'el', 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'nl', 'pl', 'pt', 'ru', 'sv', 'tr', 'vi', 'zh'] %}
+{% set ne_languages = ['ar', 'bn', 'de', 'el', 'en', 'es', 'fa', 'fr', 'he', 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'nl', 'pl', 'pt', 'ru', 'sv', 'tr', 'uk', 'ur', 'vi', 'zh', 'zht'] %}
 {% set ne_viewpoints = ['iso', 'ar', 'bd', 'br', 'cn', 'de', 'eg', 'es', 'fr', 'gb', 'gr', 'id', 'il', 'in', 'it', 'jp', 'ko', 'ma', 'nl', 'np', 'pk', 'pl', 'ps', 'pt', 'ru', 'sa', 'se', 'tr', 'tw', 'us', 'vn'] %}
 
 {% macro ne_common_properties() %}


### PR DESCRIPTION
Extends work done in #1961 and #1963

During a build we discovered the live data isn't parsed correctly because the Natural Earth config is ignorant of the new `zht` name property. Because we reused `zh` for `zh-Hans` content that new data did flow thru correctly.

The fix is to extend the list of NE language codes with what's in the new beta data.