### PR TITLE
Fixes to build and consume new shapefiles tar

### DIFF
--- a/data/assets.yaml
+++ b/data/assets.yaml
@@ -1,5 +1,5 @@
-bucket: tilezen-assets
-datestamp: 20190531
+bucket: nextzen-tile-assets
+datestamp: 20210819
 
 shapefiles:
 

--- a/data/tile-shapefile.py
+++ b/data/tile-shapefile.py
@@ -1,5 +1,5 @@
-import fiona
 import shapely.geometry
+import fiona
 import sys
 
 shapefile_source = sys.argv[1]
@@ -31,7 +31,7 @@ def tile(geometry, chunk_dim_meters=chunk_dim_meters):
     return tiled_polys
 
 
-with fiona.drivers():
+with fiona.Env():
 
     with fiona.open(shapefile_source) as source:
 

--- a/data/wof_snapshot.py
+++ b/data/wof_snapshot.py
@@ -12,7 +12,7 @@ import requests
 from tqdm import tqdm
 
 """
-expects s to look like "123456.geojson"
+expects input to look like "123456.geojson"
 """
 def _parse_wof_id(s):
     wof_id, ext = splitext(basename(s))
@@ -124,6 +124,7 @@ if __name__ == '__main__':
         print "Downloading %r" % (placetype)
         with tmpdownload(WOF_BUNDLE_PREFIX + fname, download_size) as fname:
             print "Parsing WOF data"
+            # 20210820: geocode.earth inventory files don't offer count, so count hardcoded to 1
             reader.add_archive(fname, version, 1)
 
     print "Writing output SQL"

--- a/data/wof_snapshot.py
+++ b/data/wof_snapshot.py
@@ -11,7 +11,9 @@ import tarfile
 import requests
 from tqdm import tqdm
 
-
+"""
+expects s to look like "123456.geojson"
+"""
 def _parse_wof_id(s):
     wof_id, ext = splitext(basename(s))
     assert ext == '.geojson'
@@ -46,7 +48,7 @@ class WOFArchiveReader(object):
         with tqdm(total=count) as pbar:
             with tarfile.open(archive) as tar:
                 for info in tar:
-                    if info.isfile() and info.name.endswith('.geojson'):
+                    if info.isfile() and info.name.endswith('.geojson') and "-" not in basename(info.name):
                         self._parse_file(
                             info.name, tar.extractfile(info).read(), file_hash)
                         pbar.update(1)
@@ -100,8 +102,8 @@ class tmpdownload(object):
         shutil.rmtree(self.tempdir)
 
 
-WOF_INVENTORY = 'https://dist.whosonfirst.org/bundles/inventory.json'
-WOF_BUNDLE_PREFIX = 'https://dist.whosonfirst.org/bundles/'
+WOF_INVENTORY = 'https://data.geocode.earth/wof/dist/legacy/inventory.json'
+WOF_BUNDLE_PREFIX = 'https://data.geocode.earth/wof/dist/legacy/'
 
 
 if __name__ == '__main__':
@@ -117,13 +119,12 @@ if __name__ == '__main__':
         item = matching[0]
 
         version = item['last_updated']
-        count = item['count']
         download_size = item['size_compressed']
 
-        print "Downloading %r with %d entries" % (placetype, count)
+        print "Downloading %r" % (placetype)
         with tmpdownload(WOF_BUNDLE_PREFIX + fname, download_size) as fname:
             print "Parsing WOF data"
-            reader.add_archive(fname, version, count)
+            reader.add_archive(fname, version, 1)
 
     print "Writing output SQL"
     with open('wof_snapshot.sql', 'w') as fh:


### PR DESCRIPTION
* Point at newest shapesfiles tar in S3
* change import order to accommodate changes to Fiona, fix deprecation warning
* don't process WOF entities that have a '-' in the name
* update WOF manifest and download URLs (longer term we should update this to not use the 'legacy' section anymore)
* remove concept of a count from parsing of inventory.json in WOF