### PR TITLE
Split NE boundary filters

### DIFF
--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -549,17 +549,17 @@ class NaturalEarth(FixtureTest):
             dsl.way(1, dsl.tile_diagonal_dexter(z, x, y), {
                 'featurecla': 'Claim boundary',
                 'fclass_cn': 'International boundary (verify)',
-                'min_zoom': 5,
+                'min_zoom': 5,  # min_zoom is set to 5 in the source data
                 'scalerank': 5,
                 'source': 'naturalearthdata.com',
             }),
         )
-        for zoom in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]:
+        for zoom in range(1, 17):
             self.assert_has_feature(
                 zoom, x, y, 'boundaries', {
                     'kind': 'disputed_claim',
                     'kind:cn': 'country',
-                    'min_zoom': 1,
+                    'min_zoom': 1, # we change the min_zoom override in boundaries.yaml to 1 so we assert here  # noqa
                 })
 
     def test_country_claim(self):

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -540,6 +540,27 @@ class CountyBoundary(FixtureTest):
 
 
 class NaturalEarth(FixtureTest):
+    def test_claim_boundary(self):
+        import dsl
+
+        z, x, y = 1, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal_dexter(z, x, y), {
+                'featurecla': 'Claim boundary',
+                'fclass_cn': 'International boundary (verify)',
+                'min_zoom': 5,
+                'scalerank': 5,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+        for zoom in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]:
+            self.assert_has_feature(
+                zoom, x, y, 'boundaries', {
+                    'kind': 'disputed_claim',
+                    'kind:cn': 'country',
+                    'min_zoom': 1,
+                })
 
     def test_country_claim(self):
         # test that a boundary tagged as generally unrecognized, but a country

--- a/integration-test/1970-split-ne-boundaries-filter.py
+++ b/integration-test/1970-split-ne-boundaries-filter.py
@@ -12,15 +12,15 @@ class NaturalEarth(FixtureTest):
             dsl.way(1, dsl.tile_diagonal_dexter(z, x, y), {
                 'featurecla': 'Claim boundary',
                 'fclass_cn': 'International boundary (verify)',
-                'min_zoom': 5,
+                'min_zoom': 5,  # min_zoom is set to 5 in the source data
                 'scalerank': 5,
                 'source': 'naturalearthdata.com',
             }),
         )
-        for zoom in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]:
+        for zoom in range(1, 17):
             self.assert_has_feature(
                 zoom, x, y, 'boundaries', {
                     'kind': 'disputed_claim',
                     'kind:cn': 'country',
-                    'min_zoom': 1,  # we change the min_zoom in boundaries.yaml to 1 so we assert here  # noqa
+                    'min_zoom': 1,  # we change the min_zoom override in boundaries.yaml to 1 so we assert here  # noqa
                 })

--- a/integration-test/1970-split-ne-boundaries-filter.py
+++ b/integration-test/1970-split-ne-boundaries-filter.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+from . import FixtureTest
+
+
+class NaturalEarth(FixtureTest):
+    def test_claim_boundary(self):
+        import dsl
+
+        z, x, y = 1, 0, 0
+
+        self.generate_fixtures(
+            dsl.way(1, dsl.tile_diagonal_dexter(z, x, y), {
+                'featurecla': 'Claim boundary',
+                'fclass_cn': 'International boundary (verify)',
+                'min_zoom': 5,
+                'scalerank': 5,
+                'source': 'naturalearthdata.com',
+            }),
+        )
+        for zoom in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]:
+            self.assert_has_feature(
+                zoom, x, y, 'boundaries', {
+                    'kind': 'disputed_claim',
+                    'kind:cn': 'country',
+                    'min_zoom': 1,  # we change the min_zoom in boundaries.yaml to 1 so we assert here  # noqa
+                })

--- a/integration-test/dsl.py
+++ b/integration-test/dsl.py
@@ -70,6 +70,25 @@ def tile_diagonal(z, x, y):
     return shape
 
 
+def tile_diagonal_dexter(z, x, y):
+    """
+    Returns a Shapely LineString which goes from the upper left of the tile
+    to the lower right.
+    """
+
+    from tilequeue.tile import coord_to_bounds
+    from shapely.geometry import LineString
+    from ModestMaps.Core import Coordinate
+
+    bounds = coord_to_bounds(Coordinate(zoom=z, column=x, row=y))
+    shape = LineString([
+        [bounds[0], bounds[3]],
+        [bounds[2], bounds[1]],
+    ])
+
+    return shape
+
+
 def tile_box(z, x, y):
     """
     Returns a Shapely Polygon which covers the tile.

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -606,6 +606,16 @@ class BoundariesMinZoomTest(unittest.TestCase):
         out_min_zoom = self.boundaries.fn(shape, props, None, meta)
         self.assertEquals(8, out_min_zoom)
 
+    def test_feature_disputed(self):
+        import shapely.geometry
+        shape = shapely.geometry.LineString([(0, 0), (1, 1), (1, 0)])
+        props = {
+            'featurecla': 'Disputed (please verify)',
+        }
+        meta = make_test_metadata()
+        out_min_zoom = self.boundaries.fn(shape, props, None, meta)
+        self.assertEquals(1, out_min_zoom)
+
 
 class BuildingsMinZoomTest(unittest.TestCase):
 

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -606,15 +606,22 @@ class BoundariesMinZoomTest(unittest.TestCase):
         out_min_zoom = self.boundaries.fn(shape, props, None, meta)
         self.assertEquals(8, out_min_zoom)
 
-    def test_feature_disputed(self):
+    # ne for disputed kind:xx POV we want to always include
+    # the disputed lines early so when that POV enables them
+    # and the data is available in tiles
+    def test_feature_pov(self):
         import shapely.geometry
         shape = shapely.geometry.LineString([(0, 0), (1, 1), (1, 0)])
-        props = {
-            'featurecla': 'Disputed (please verify)',
-        }
+        props = [
+            {'featurecla': 'Breakaway'},
+            {'featurecla': 'Claim boundary'},
+            {'featurecla': 'Elusive frontier'},
+            {'featurecla': 'Reference line'},
+        ]
         meta = make_test_metadata()
-        out_min_zoom = self.boundaries.fn(shape, props, None, meta)
-        self.assertEquals(1, out_min_zoom)
+        for prop in props:
+            out_min_zoom = self.boundaries.fn(shape, prop, None, meta)
+            self.assertEquals(1, out_min_zoom)
 
 
 class BuildingsMinZoomTest(unittest.TestCase):

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -234,11 +234,24 @@ filters:
         - 'Overlay limit'
         - 'Unrecognized'
         - 'Map unit boundary'
+    min_zoom: { col: min_zoom }
+    output:
+      <<: *output_properties
+      <<: *ne_localized_kind_properties
+      kind: *ne_country_boundaries_kind
+      kind_detail: '2'
+    table: ne
+
+  # ne for disputed kind:xx POV we want to always include
+  # the disputed lines early so when that POV enables them
+  # and the data is available in tiles
+  - filter:
+      featurecla:
         - 'Breakaway'
         - 'Claim boundary'
         - 'Elusive frontier'
         - 'Reference line'
-    min_zoom: { col: min_zoom }
+    min_zoom: 1
     output:
       <<: *output_properties
       <<: *ne_localized_kind_properties


### PR DESCRIPTION
In order for disputed boundaries to show at low zooms, we need to adjust the filters settings for boundaries layer.

- [x] Update tests
- [ ] Update docs


https://github.com/tilezen/vector-datasource/issues/1970

### Test
rebuild the metatile 1/1/0 which contains the tile 3/5/3, and it shows that 3/5/3 contains disputed boundary cn and min_zoom as 1

![image](https://user-images.githubusercontent.com/62725319/140784280-5ac39d61-b21d-4b92-80bb-bbd66ecda512.png)

