### PR TITLE
back to 1.0 tolerance for boundaries and roads

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -214,7 +214,7 @@ layers:
   roads:
     geometry_types: [LineString, MultiLineString]
     simplify_start: 8
-    tolerance: 2.0
+    tolerance: 1.0
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.tags_name_i18n
@@ -287,7 +287,7 @@ layers:
     geometry_types: [Polygon, MultiPolygon, LineString, MultiLineString]
     simplify_before_intersect: true
     simplify_start: 8
-    tolerance: 2.0
+    tolerance: 1.0
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.tags_name_i18n


### PR DESCRIPTION
This is a partial revert of a #1718.  There's an off-by-one geometry simplification issue created by tolerance being too high for boundaries and roads.  This will (reportedly) negligibly increase tile size.