### PR TITLE
Don't output feature to water layer if covered='yes'

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -2463,6 +2463,8 @@ Also includes water `line` geometries for river and stream centerlines and "labe
 
 Tilezen calculates the composite exterior edge for overlapping water polygons and marks the resulting line `boundary=true`. Set to `true` when present on `line` geometry, or from Natural Earth line source.
 
+Also Covered water is not included.
+
 #### Water properties (common):
 
 * `name`: including localized name variants

--- a/integration-test/1982-covered-water.py
+++ b/integration-test/1982-covered-water.py
@@ -1,7 +1,5 @@
 # -*- encoding: utf-8 -*-
 import dsl
-from shapely.wkt import loads as wkt_loads
-from tilequeue.tile import deg2num
 from . import FixtureTest
 
 

--- a/integration-test/1982-covered-water.py
+++ b/integration-test/1982-covered-water.py
@@ -21,4 +21,4 @@ class CoveredWaterOSMTest(FixtureTest):
 
         self.assert_no_matching_feature(
             16, 33199, 22547, 'water',
-            {"id": 236735251})
+            {"id": 28575415})

--- a/integration-test/1982-covered-water.py
+++ b/integration-test/1982-covered-water.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+import dsl
+from shapely.wkt import loads as wkt_loads
+from tilequeue.tile import deg2num
+from . import FixtureTest
+
+class CoveredWaterOSMTest(FixtureTest):
+    def test_water_level_1(self):
+        z, x, y = (16, 33199, 22547)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/236735251
+            dsl.way(236735251, dsl.tile_box(z, x, y), {
+                'covered': 'yes',
+                'name': u'Sutro Reservoir',
+                'source': 'openstreetmap.org',
+                'man_made': 'reservoir_covered',
+                'water': 'reservoir',
+                'natural': 'water',
+            }),
+        )
+
+        self.assert_no_matching_feature(
+            16, 33199, 22547, 'water',
+            {"id": 236735251})

--- a/integration-test/1982-covered-water.py
+++ b/integration-test/1982-covered-water.py
@@ -4,13 +4,14 @@ from shapely.wkt import loads as wkt_loads
 from tilequeue.tile import deg2num
 from . import FixtureTest
 
+
 class CoveredWaterOSMTest(FixtureTest):
     def test_water_level_1(self):
         z, x, y = (16, 33199, 22547)
 
         self.generate_fixtures(
-            # https://www.openstreetmap.org/way/236735251
-            dsl.way(236735251, dsl.tile_box(z, x, y), {
+            # to represent https://www.openstreetmap.org/way/28575415
+            dsl.way(28575415, dsl.tile_box(z, x, y), {
                 'covered': 'yes',
                 'name': u'Sutro Reservoir',
                 'source': 'openstreetmap.org',

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -1142,6 +1142,7 @@ class Assertions(object):
 
     def assert_has_feature(self, z, x, y, layer, properties):
         with self.ff.features_in_tile_layer(z, x, y, layer) as features:
+            print(features)
             num_features, num_matching = count_matching(
                 features, properties)
 

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -1142,7 +1142,6 @@ class Assertions(object):
 
     def assert_has_feature(self, z, x, y, layer, properties):
         with self.ff.features_in_tile_layer(z, x, y, layer) as features:
-            print(features)
             num_features, num_matching = count_matching(
                 features, properties)
 

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -45,6 +45,12 @@ globals:
       - else: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 1.066 ] } } }
 
 filters:
+  # to not show covered water in the water layer. This filter has to be placed before filter: {natural: water}
+  - filter:
+      covered: yes
+    min_zoom: null
+    output:
+      kind: null
   - filter: {waterway: riverbank}
     min_zoom: *water_polygon_min_zoom
     output:
@@ -152,11 +158,6 @@ filters:
           - when: { reef: [coral, rock, sand] }
             then: { col: reef }
     table: osm
-  - filter:
-      - covered: yes
-    min_zoom: null
-    output:
-      kind: null
 
   #
   # NE features

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -152,6 +152,11 @@ filters:
           - when: { reef: [coral, rock, sand] }
             then: { col: reef }
     table: osm
+  - filter:
+      - covered: yes
+    min_zoom: null
+    output:
+      kind: null
 
   #
   # NE features

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -45,7 +45,7 @@ globals:
       - else: { clamp: { min: 0, max: 16, value: { sum: [ { col: zoom }, 1.066 ] } } }
 
 filters:
-  # to not show covered water in the water layer. This filter has to be placed before filter: {natural: water}
+  # Not show covered water in the water layer. This filter has to be placed before filter: {natural: water}
   - filter:
       covered: yes
     min_zoom: null

--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -47,7 +47,7 @@ globals:
 filters:
   # Not show covered water in the water layer. This filter has to be placed before filter: {natural: water}
   - filter:
-      covered: yes
+      covered: "yes"
     min_zoom: null
     output:
       kind: null


### PR DESCRIPTION
Don't output features to water layer when there is covered=yes tag to not display blue for covered reservoirs.

- [x] Update tests
- [x] Update docs

#1982 