### PR TITLE
Move 'Unrecognized' to min_zoom:1 in boundaries layer

### DIFF
--- a/integration-test/1983-china-south-sea.py
+++ b/integration-test/1983-china-south-sea.py
@@ -7,7 +7,6 @@ class NaturalEarth(FixtureTest):
         import dsl
 
         z, x, y = 1, 0, 0
-
         self.generate_fixtures(
             dsl.way(1, dsl.tile_diagonal_dexter(z, x, y), {
                 'featurecla': 'Unrecognized',

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -232,7 +232,6 @@ filters:
         - 'Lease limit'
         - 'Line of control (please verify)'
         - 'Overlay limit'
-        - 'Unrecognized'
         - 'Map unit boundary'
     min_zoom: { col: min_zoom }
     output:
@@ -251,6 +250,7 @@ filters:
         - 'Claim boundary'
         - 'Elusive frontier'
         - 'Reference line'
+        - 'Unrecognized'
     min_zoom: 1
     output:
       <<: *output_properties


### PR DESCRIPTION
Move 'Unrecognized' to min_zoom:1 filter and fix the integration test of 1983-china-south-sea

- [ ] Update tests
- [ ] Update docs


#1983 