### PR TITLE
Estimate population for null pop OSM places

### DIFF
--- a/integration-test/1993-estimate-null-populations.py
+++ b/integration-test/1993-estimate-null-populations.py
@@ -4,14 +4,14 @@ from . import FixtureTest
 
 class EstimatePopulationsTest(FixtureTest):
 
-    def validate_est_population(self, point, min_zoom_with_pop, est_pop, min_zoom_with_est_pop):
-        z, x, y = (9, 259, 175)
+    def validate_est_population(self, point, tile_coord, min_zoom_with_pop, min_zoom_with_est_pop, est_pop):
+        z, x, y = tile_coord
 
         self.generate_fixtures(point)
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': point.fid,
-                'population': int(point.features['population']),
+                'population': int(point.properties['population']),
                 'min_zoom': min_zoom_with_pop
             })
 
@@ -26,17 +26,19 @@ class EstimatePopulationsTest(FixtureTest):
             })
 
     def test_city(self):
+        z, x, y = (10, 518, 351)
         # https://www.openstreetmap.org/node/26691955
         city = dsl.point(26691955, (2.2481797, 48.9479069),
-                          {'addr:postcode': u'95100', 'capital': u'7', 'name': u'Argenteuil',
-                           'place': u'city', 'population': u'104282',
-                           'ref:SIREN': u'219500188', 'source': u'openstreetmap.org',
-                           'source:population': u'INSEE 2007', 'wikidata': u'Q181946',
-                           'wikipedia': u'fr:Argenteuil (Val-dOise)', })
+                         {'addr:postcode': u'95100', 'capital': u'7', 'name': u'Argenteuil',
+                          'place': u'city', 'population': u'104282',
+                          'ref:SIREN': u'219500188', 'source': u'openstreetmap.org',
+                          'source:population': u'INSEE 2007', 'wikidata': u'Q181946',
+                          'wikipedia': u'fr:Argenteuil (Val-dOise)', })
 
-        self.validate_est_population(city, 8, 10000, 9)
+        self.validate_est_population(city, (z, x, y), 8, 9, 10000)
 
     def test_town(self):
+        z, x, y = (11, 1036, 703)
         # https://www.openstreetmap.org/node/26691480
         town = dsl.point(26691480, (2.2303498, 48.986025), {
             'alt_name': u'Franconville',
@@ -46,6 +48,47 @@ class EstimatePopulationsTest(FixtureTest):
             'source': u'openstreetmap.org',
             'source:population': u'INSEE 2013',
             'wikidata': u'Q237333',
-        }),
+        })
+        self.validate_est_population(town, (z, x, y), 10, 11, 5000)
 
-        self.validate_est_population(town, 9, 5000, 10)
+    def test_locality(self):
+        z, x, y = (14, 8296, 5638)
+        # https://www.openstreetmap.org/node/442197
+        locality = dsl.point(442197, (2.2883604, 48.8326932),
+                             {'name': u'Porte de Versailles', 'place': u'locality', 'population': u'1121',
+                              'source': u'openstreetmap.org',
+                              'unsigned': u'no', })
+        self.validate_est_population(locality, (z, x, y), 13, 14, 1000)
+
+    def test_village(self):
+        z, x, y = (13, 4141, 2827)
+        # https://www.openstreetmap.org/node/602470737
+        village = dsl.point(602470737, (1.9878964, 48.5872266),
+                          {'addr:postcode': u'78730', 'name': u'Rochefort-en-Yvelines', 'place': u'village',
+                           'population': u'956', 'source': u'openstreetmap.org', })
+
+        self.validate_est_population(village, (z, x, y), 12, 13, 2000)
+
+    def test_hamlet(self):
+        z, x, y = (15, 16563, 11302)
+        # https://www.openstreetmap.org/node/534228360
+        hamlet = dsl.point(534228360, (1.967011, 48.6425931),
+                           {'name': u'Les Bordes', 'place': u'hamlet', 'population': u'816',
+                            'source': u'openstreetmap.org', })
+        self.validate_est_population(hamlet, (z, x, y), 14, 15, 200)
+
+    def test_isolated_dwelling(self):
+        z, x, y = (16, 33142, 22608)
+        # https://www.openstreetmap.org/node/5111001636
+        dwelling = dsl.point(5111001636, (2.0597882, 48.6321613),
+                             {'name': u'La Maison Grise', 'place': u'isolated_dwelling', 'population': u'220',
+                              'source': u'openstreetmap.org', })
+        self.validate_est_population(dwelling, (z, x, y), 15, 15.5, 100)
+
+    def test_farm(self):
+        z, x, y = (16, 33137, 22614)
+        # https://www.openstreetmap.org/node/5922383856
+        farm = dsl.point(5922383856, (2.0303734, 48.6082567),
+                         {'contact:website': u'https://www.fermedesclos.com/', 'name': u'Ferme des Clos',
+                          'place': u'farm', 'population': u'91', 'source': u'openstreetmap.org', })
+        self.validate_est_population(farm, (z, x, y), 15, 15.5, 50)

--- a/integration-test/1993-estimate-null-populations.py
+++ b/integration-test/1993-estimate-null-populations.py
@@ -49,7 +49,7 @@ class EstimatePopulationsTest(FixtureTest):
             'source:population': u'INSEE 2013',
             'wikidata': u'Q237333',
         })
-        self.validate_est_population(town, (z, x, y), 10, 11, 5000)
+        self.validate_est_population(town, (z, x, y), 8, 10, 5000)
 
     def test_locality(self):
         z, x, y = (14, 8296, 5638)
@@ -75,7 +75,7 @@ class EstimatePopulationsTest(FixtureTest):
         hamlet = dsl.point(534228360, (1.967011, 48.6425931),
                            {'name': u'Les Bordes', 'place': u'hamlet', 'population': u'816',
                             'source': u'openstreetmap.org', })
-        self.validate_est_population(hamlet, (z, x, y), 14, 15, 200)
+        self.validate_est_population(hamlet, (z, x, y), 13, 14, 200)
 
     def test_isolated_dwelling(self):
         z, x, y = (16, 33142, 22608)
@@ -83,7 +83,7 @@ class EstimatePopulationsTest(FixtureTest):
         dwelling = dsl.point(5111001636, (2.0597882, 48.6321613),
                              {'name': u'La Maison Grise', 'place': u'isolated_dwelling', 'population': u'220',
                               'source': u'openstreetmap.org', })
-        self.validate_est_population(dwelling, (z, x, y), 15, 15.5, 100)
+        self.validate_est_population(dwelling, (z, x, y), 14, 15, 100)
 
     def test_farm(self):
         z, x, y = (16, 33137, 22614)
@@ -91,4 +91,4 @@ class EstimatePopulationsTest(FixtureTest):
         farm = dsl.point(5922383856, (2.0303734, 48.6082567),
                          {'contact:website': u'https://www.fermedesclos.com/', 'name': u'Ferme des Clos',
                           'place': u'farm', 'population': u'91', 'source': u'openstreetmap.org', })
-        self.validate_est_population(farm, (z, x, y), 15, 15.5, 50)
+        self.validate_est_population(farm, (z, x, y), 14, 15, 50)

--- a/integration-test/1993-estimate-null-populations.py
+++ b/integration-test/1993-estimate-null-populations.py
@@ -1,0 +1,38 @@
+import dsl
+from . import FixtureTest
+
+
+class EstimatePopulationsTest(FixtureTest):
+
+    def test_city(self):
+        import dsl
+
+        z, x, y = (9, 259, 175)
+
+        # https://www.openstreetmap.org/node/26691955
+        point = dsl.point(26691955, (2.2481797, 48.9479069),
+                          {'addr:postcode': u'95100', 'capital': u'7', 'name': u'Argenteuil',
+                           'place': u'city', 'population': u'104282',
+                           'ref:SIREN': u'219500188', 'source': u'openstreetmap.org',
+                           'source:population': u'INSEE 2007', 'wikidata': u'Q181946',
+                           'wikipedia': u'fr:Argenteuil (Val-dOise)', })
+
+        self.generate_fixtures(point)
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 26691955,
+                'population': 104282,
+                'min_zoom': 8
+            })
+
+        del point.properties['population']
+
+        self.generate_fixtures(point)
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 26691955,
+                'population': 10000,
+                'min_zoom': 9
+            })

--- a/integration-test/1993-estimate-null-populations.py
+++ b/integration-test/1993-estimate-null-populations.py
@@ -4,35 +4,48 @@ from . import FixtureTest
 
 class EstimatePopulationsTest(FixtureTest):
 
-    def test_city(self):
-        import dsl
-
+    def validate_est_population(self, point, min_zoom_with_pop, est_pop, min_zoom_with_est_pop):
         z, x, y = (9, 259, 175)
 
+        self.generate_fixtures(point)
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': point.fid,
+                'population': int(point.features['population']),
+                'min_zoom': min_zoom_with_pop
+            })
+
+        del point.properties['population']
+
+        self.generate_fixtures(point)
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': point.fid,
+                'population': est_pop,
+                'min_zoom': min_zoom_with_est_pop
+            })
+
+    def test_city(self):
         # https://www.openstreetmap.org/node/26691955
-        point = dsl.point(26691955, (2.2481797, 48.9479069),
+        city = dsl.point(26691955, (2.2481797, 48.9479069),
                           {'addr:postcode': u'95100', 'capital': u'7', 'name': u'Argenteuil',
                            'place': u'city', 'population': u'104282',
                            'ref:SIREN': u'219500188', 'source': u'openstreetmap.org',
                            'source:population': u'INSEE 2007', 'wikidata': u'Q181946',
                            'wikipedia': u'fr:Argenteuil (Val-dOise)', })
 
-        self.generate_fixtures(point)
+        self.validate_est_population(city, 8, 10000, 9)
 
-        self.assert_has_feature(
-            z, x, y, 'places', {
-                'id': 26691955,
-                'population': 104282,
-                'min_zoom': 8
-            })
+    def test_town(self):
+        # https://www.openstreetmap.org/node/26691480
+        town = dsl.point(26691480, (2.2303498, 48.986025), {
+            'alt_name': u'Franconville',
+            'name': u'Franconville-la-Garenne',
+            'place': u'town',
+            'population': u'33097',
+            'source': u'openstreetmap.org',
+            'source:population': u'INSEE 2013',
+            'wikidata': u'Q237333',
+        }),
 
-        del point.properties['population']
-
-        self.generate_fixtures(point)
-
-        self.assert_has_feature(
-            z, x, y, 'places', {
-                'id': 26691955,
-                'population': 10000,
-                'min_zoom': 9
-            })
+        self.validate_est_population(town, 9, 5000, 10)

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -157,7 +157,7 @@ filters:
       kind: locality
       kind_detail: {col: place}
     table: osm
-  - filter: {name: true, place: [city]}
+  - filter: {name: true, place: city}
     min_zoom: 9.5
     output:
       <<: *output_properties
@@ -166,7 +166,7 @@ filters:
       kind_detail: city
       population: 10000
     table: osm
-  - filter: {name: true, place: [town]}
+  - filter: {name: true, place: town}
     min_zoom: 10
     output:
       <<: *output_properties

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -141,7 +141,7 @@ filters:
       __ne_min_zoom: {col: __ne_min_zoom}
       __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
-  - filter: {name: true, population: true, place: city}
+  - filter: {name: true, population: true, place: [city,town]}
     min_zoom: 8
     output:
       <<: *output_properties
@@ -158,16 +158,8 @@ filters:
       kind_detail: city
       population: 10000
     table: osm
-  - filter: {name: true, population: true, place: town}
-    min_zoom: 10
-    output:
-      <<: *output_properties
-      <<: *alternate_fclass
-      kind: locality
-      kind_detail: {col: place}
-    table: osm
   - filter: {name: true, place: town}
-    min_zoom: 11
+    min_zoom: 10
     output:
       <<: *output_properties
       <<: *alternate_fclass

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -149,13 +149,31 @@ filters:
       kind: locality
       kind_detail: {col: place}
     table: osm
-  - filter: {name: true, place: [city, town]}
-    min_zoom: 9
+  - filter: {name: true, population: true, place: [city, town]}
+    min_zoom: 8
     output:
       <<: *output_properties
       <<: *alternate_fclass
       kind: locality
       kind_detail: {col: place}
+    table: osm
+  - filter: {name: true, place: [city]}
+    min_zoom: 9
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: city
+      population: 10000
+    table: osm
+  - filter: {name: true, place: [town]}
+    min_zoom: 9
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: town
+      population: 5000
     table: osm
   - filter: {name: true, population: true, place: village}
     min_zoom: 11
@@ -172,6 +190,7 @@ filters:
       <<: *alternate_fclass
       kind: locality
       kind_detail: village
+      population: 2000
     table: osm
   - filter: {name: true, population: true, place: hamlet}
     min_zoom: 12
@@ -181,13 +200,23 @@ filters:
       kind: locality
       kind_detail: hamlet
     table: osm
-  - filter: {name: true, place: [locality, hamlet]}
+  - filter: {name: true, place: locality}
     min_zoom: 13
     output:
       <<: *output_properties
       <<: *alternate_fclass
       kind: locality
-      kind_detail: {col: place}
+      kind_detail: locality
+      population: 1000
+    table: osm
+  - filter: {name: true, place: hamlet}
+    min_zoom: 13
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: hamlet
+      population: 200
     table: osm
   - filter: {name: true, place: isolated_dwelling}
     min_zoom: 13

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -202,7 +202,7 @@ filters:
       population: 1000
     table: osm
   - filter: {name: true, population: true, place: hamlet}
-    min_zoom: 14
+    min_zoom: 13
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -210,7 +210,7 @@ filters:
       kind_detail: hamlet
     table: osm
   - filter: {name: true, place: hamlet}
-    min_zoom: 15
+    min_zoom: 14
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -219,7 +219,7 @@ filters:
       population: 200
     table: osm
   - filter: {name: true, population: true, place: isolated_dwelling}
-    min_zoom: 15
+    min_zoom: 14
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -227,7 +227,7 @@ filters:
       kind_detail: isolated_dwelling
     table: osm
   - filter: { name: true, place: isolated_dwelling }
-    min_zoom: 15.5
+    min_zoom: 15
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -236,7 +236,7 @@ filters:
       population: 100
     table: osm
   - filter: { name: true, population: true, place: farm }
-    min_zoom: 15
+    min_zoom: 14
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -244,7 +244,7 @@ filters:
       kind_detail: farm
     table: osm
   - filter: {name: true, place: farm}
-    min_zoom: 15.5
+    min_zoom: 15
     output:
       <<: *output_properties
       <<: *alternate_fclass

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -150,7 +150,7 @@ filters:
       kind_detail: {col: place}
     table: osm
   - filter: {name: true, population: true, place: [city, town]}
-    min_zoom: 8
+    min_zoom: 9
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -158,7 +158,7 @@ filters:
       kind_detail: {col: place}
     table: osm
   - filter: {name: true, place: [city]}
-    min_zoom: 9
+    min_zoom: 9.5
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -167,7 +167,7 @@ filters:
       population: 10000
     table: osm
   - filter: {name: true, place: [town]}
-    min_zoom: 9
+    min_zoom: 10
     output:
       <<: *output_properties
       <<: *alternate_fclass

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -253,7 +253,6 @@ filters:
       population: 50
     table: osm
 
-
   - filter:
       scalerank: true
       featurecla: *ne_country_capital

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -141,7 +141,7 @@ filters:
       __ne_min_zoom: {col: __ne_min_zoom}
       __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
-  - filter: {name: true, population: true, place: [city, town]}
+  - filter: {name: true, population: true, place: city}
     min_zoom: 8
     output:
       <<: *output_properties
@@ -149,7 +149,7 @@ filters:
       kind: locality
       kind_detail: {col: place}
     table: osm
-  - filter: {name: true, population: true, place: [city, town]}
+  - filter: {name: true, population: true, place: town}
     min_zoom: 9
     output:
       <<: *output_properties
@@ -158,7 +158,7 @@ filters:
       kind_detail: {col: place}
     table: osm
   - filter: {name: true, place: city}
-    min_zoom: 9.5
+    min_zoom: 9
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -193,13 +193,13 @@ filters:
       population: 2000
     table: osm
   - filter: {name: true, population: true, place: locality}
-      min_zoom: 12
-      output:
-        <<: *output_properties
-        <<: *alternate_fclass
-        kind: locality
-        kind_detail: locality
-      table: osm
+    min_zoom: 12
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: locality
+    table: osm
   - filter: {name: true, population: true, place: hamlet}
     min_zoom: 12
     output:
@@ -235,22 +235,22 @@ filters:
       kind_detail: isolated_dwelling
     table: osm
   - filter: { name: true, population: true, place: farm }
-      min_zoom: 13
-      output:
-        <<: *output_properties
-        <<: *alternate_fclass
-        kind: locality
-        kind_detail: farm
-      table: osm
+    min_zoom: 13
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: farm
+    table: osm
   - filter: { name: true, place: isolated_dwelling }
-      min_zoom: 14
-      output:
-        <<: *output_properties
-        <<: *alternate_fclass
-        kind: locality
-        kind_detail: isolated_dwelling
-        population: 100
-      table: osm
+    min_zoom: 14
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: isolated_dwelling
+      population: 100
+    table: osm
   - filter: {name: true, place: farm}
     min_zoom: 14
     output:

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -192,6 +192,14 @@ filters:
       kind_detail: village
       population: 2000
     table: osm
+  - filter: {name: true, population: true, place: locality}
+      min_zoom: 12
+      output:
+        <<: *output_properties
+        <<: *alternate_fclass
+        kind: locality
+        kind_detail: locality
+      table: osm
   - filter: {name: true, population: true, place: hamlet}
     min_zoom: 12
     output:
@@ -218,7 +226,7 @@ filters:
       kind_detail: hamlet
       population: 200
     table: osm
-  - filter: {name: true, place: isolated_dwelling}
+  - filter: {name: true, population: true, place: isolated_dwelling}
     min_zoom: 13
     output:
       <<: *output_properties
@@ -226,14 +234,33 @@ filters:
       kind: locality
       kind_detail: isolated_dwelling
     table: osm
+  - filter: { name: true, population: true, place: farm }
+      min_zoom: 13
+      output:
+        <<: *output_properties
+        <<: *alternate_fclass
+        kind: locality
+        kind_detail: farm
+      table: osm
+  - filter: { name: true, place: isolated_dwelling }
+      min_zoom: 14
+      output:
+        <<: *output_properties
+        <<: *alternate_fclass
+        kind: locality
+        kind_detail: isolated_dwelling
+        population: 100
+      table: osm
   - filter: {name: true, place: farm}
-    min_zoom: 13
+    min_zoom: 14
     output:
       <<: *output_properties
       <<: *alternate_fclass
       kind: locality
       kind_detail: farm
+      population: 50
     table: osm
+
 
   - filter:
       scalerank: true

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -149,14 +149,6 @@ filters:
       kind: locality
       kind_detail: {col: place}
     table: osm
-  - filter: {name: true, population: true, place: town}
-    min_zoom: 9
-    output:
-      <<: *output_properties
-      <<: *alternate_fclass
-      kind: locality
-      kind_detail: {col: place}
-    table: osm
   - filter: {name: true, place: city}
     min_zoom: 9
     output:
@@ -166,8 +158,16 @@ filters:
       kind_detail: city
       population: 10000
     table: osm
-  - filter: {name: true, place: town}
+  - filter: {name: true, population: true, place: town}
     min_zoom: 10
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: {col: place}
+    table: osm
+  - filter: {name: true, place: town}
+    min_zoom: 11
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -176,7 +176,7 @@ filters:
       population: 5000
     table: osm
   - filter: {name: true, population: true, place: village}
-    min_zoom: 11
+    min_zoom: 12
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -184,7 +184,7 @@ filters:
       kind_detail: village
     table: osm
   - filter: {name: true, place: village}
-    min_zoom: 12
+    min_zoom: 13
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -193,23 +193,15 @@ filters:
       population: 2000
     table: osm
   - filter: {name: true, population: true, place: locality}
-    min_zoom: 12
+    min_zoom: 13
     output:
       <<: *output_properties
       <<: *alternate_fclass
       kind: locality
       kind_detail: locality
     table: osm
-  - filter: {name: true, population: true, place: hamlet}
-    min_zoom: 12
-    output:
-      <<: *output_properties
-      <<: *alternate_fclass
-      kind: locality
-      kind_detail: hamlet
-    table: osm
   - filter: {name: true, place: locality}
-    min_zoom: 13
+    min_zoom: 14
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -217,8 +209,16 @@ filters:
       kind_detail: locality
       population: 1000
     table: osm
+  - filter: {name: true, population: true, place: hamlet}
+    min_zoom: 14
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: hamlet
+    table: osm
   - filter: {name: true, place: hamlet}
-    min_zoom: 13
+    min_zoom: 15
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -227,23 +227,15 @@ filters:
       population: 200
     table: osm
   - filter: {name: true, population: true, place: isolated_dwelling}
-    min_zoom: 13
+    min_zoom: 15
     output:
       <<: *output_properties
       <<: *alternate_fclass
       kind: locality
       kind_detail: isolated_dwelling
     table: osm
-  - filter: { name: true, population: true, place: farm }
-    min_zoom: 13
-    output:
-      <<: *output_properties
-      <<: *alternate_fclass
-      kind: locality
-      kind_detail: farm
-    table: osm
   - filter: { name: true, place: isolated_dwelling }
-    min_zoom: 14
+    min_zoom: 15.5
     output:
       <<: *output_properties
       <<: *alternate_fclass
@@ -251,8 +243,16 @@ filters:
       kind_detail: isolated_dwelling
       population: 100
     table: osm
+  - filter: { name: true, population: true, place: farm }
+    min_zoom: 15
+    output:
+      <<: *output_properties
+      <<: *alternate_fclass
+      kind: locality
+      kind_detail: farm
+    table: osm
   - filter: {name: true, place: farm}
-    min_zoom: 14
+    min_zoom: 15.5
     output:
       <<: *output_properties
       <<: *alternate_fclass

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -141,7 +141,7 @@ filters:
       __ne_min_zoom: {col: __ne_min_zoom}
       __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
-  - filter: {name: true, population: true, place: [city,town]}
+  - filter: {name: true, population: true, place: [city, town]}
     min_zoom: 8
     output:
       <<: *output_properties


### PR DESCRIPTION
For #1992
Break out filters in landuse.yaml for different localities by whether they have a population listed or not.  If they don't, make the min_zoom higher and estimate the population.  
- [X] Update tests

