### PR TITLE
Remove early ferry and aeroway properties

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1240,6 +1240,7 @@ post_process:
         (kind == 'major_road' and zoom <  13) or
         (kind == 'minor_road' and zoom < 15) or
         (kind == 'path' and zoom < 14) or
+        (kind == 'ferry' and zoom < 15) or
         (kind == 'rail' and zoom < 15)
 
   # drop these "detail" tags to get better merging at zoom < 16

--- a/queries.yaml
+++ b/queries.yaml
@@ -1186,6 +1186,7 @@ post_process:
         (kind_detail == 'tertiary_link' and zoom <  14) or
         (kind == 'minor_road' and zoom < 15) or
         (kind == 'path' and zoom < 14) or
+        (kind == 'ferry' and zoom < 14) or
         (kind == 'rail' and zoom < 15)
 
   - fn: vectordatasource.transform.drop_properties
@@ -1216,6 +1217,7 @@ post_process:
         (kind_detail == 'secondary_link' and zoom <  15) or
         (kind_detail == 'tertiary_link' and zoom <  15) or
         (kind == 'minor_road' and zoom < 15) or
+        (kind == 'aeroway' and zoom < 14) or
         (kind == 'path' and zoom < 14) or
         (kind == 'rail' and zoom < 15) or
         (kind == 'ferry' and zoom < 15)
@@ -1320,6 +1322,7 @@ post_process:
         - surface
       where: >-
         kind == 'minor_road' or
+        (kind == 'aeroway' and zoom < 12) or
         (kind == 'path' and zoom < 13)
 
   # drop to get better merging at mid zooms.
@@ -1772,6 +1775,7 @@ post_process:
         (kind_detail == 'secondary_link' and zoom < 15) or
         (kind_detail == 'tertiary_link' and zoom < 15) or
         (kind == 'minor_road' and zoom < 15) or
+        (kind == 'aeroway' and zoom < 13) or
         (kind == 'path' and zoom < 14) or
         (kind == 'rail' and zoom < 14)
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -1881,7 +1881,7 @@ post_process:
       # setting the following will cause lines, or parts of multi-lines,
       # shorter than 0.1px at nominal zoom to be dropped.
       drop_short_segments: true
-      drop_length_pixels: 0.1
+      drop_length_pixels: 1.0
       # integrated simplification step tolerance. NOTE: simplification is only
       # performed if junction merging is set to true! the idea is to simplify
       # away points at junctions where the road is straight, so it shouldn't
@@ -1899,7 +1899,7 @@ post_process:
       # setting the following will cause lines, or parts of multi-lines,
       # shorter than 0.1px at nominal zoom to be dropped.
       drop_short_segments: true
-      drop_length_pixels: 0.1
+      drop_length_pixels: 1.0
 
   # NOTE: want to do this _before_ buildings_unify, as after that we might not
   # have a feature ID to match buildings on!

--- a/queries.yaml
+++ b/queries.yaml
@@ -1778,6 +1778,7 @@ post_process:
         (kind == 'minor_road' and zoom < 15) or
         (kind == 'aeroway' and zoom < 13) or
         (kind == 'path' and zoom < 14) or
+        (kind == 'ferry' and zoom < 14) or
         (kind == 'rail' and zoom < 14)
 
   # drop osm_relation tag, used to indicate that shapes came from OSM relations.

--- a/queries.yaml
+++ b/queries.yaml
@@ -1879,7 +1879,7 @@ post_process:
       merge_junctions: true
       merge_junction_angle: 5.0
       # setting the following will cause lines, or parts of multi-lines,
-      # shorter than 0.1px at nominal zoom to be dropped.
+      # shorter than 1px at nominal zoom to be dropped.
       drop_short_segments: true
       drop_length_pixels: 1.0
       # integrated simplification step tolerance. NOTE: simplification is only
@@ -1897,7 +1897,7 @@ post_process:
       start_zoom: 15
       end_zoom: 16
       # setting the following will cause lines, or parts of multi-lines,
-      # shorter than 0.1px at nominal zoom to be dropped.
+      # shorter than 1px at nominal zoom to be dropped.
       drop_short_segments: true
       drop_length_pixels: 1.0
 


### PR DESCRIPTION
- [ ] Update tests
- [ ] Update docs



These two 512 px sized tiles for the ferry changes:

10/511/340 has 63 ferry lines now... but should just have 3 or 5 after (one per unique min_zoom value), though colour may come into play, there are 5 values there now.
12/2046/1362 has 58 ferry lines now... but should have 4 to 5 after, same deal
For the aeroway changes, this 512 px sized tile:

8/127/85 has 82 lines now, but should just have a couple (based if it's an international airport or not)

#2017