### PR TITLE
Remove names from short road segments

### DIFF
--- a/integration-test/593-early-step.py
+++ b/integration-test/593-early-step.py
@@ -31,7 +31,8 @@ class EarlyStep(FixtureTest):
             {'kind': 'path', 'kind_detail': 'steps',
              'name': 'Esmeralda Ave.'})
 
+        # we don't assert name feature because name has been dropped in
+        # https://github.com/tilezen/vector-datasource/pull/2031
         self.assert_has_feature(
             14, 2620, 6334, 'roads',
-            {'kind': 'path', 'kind_detail': 'steps',
-             'name': 'Esmeralda Ave.'})
+            {'kind': 'path', 'kind_detail': 'steps'})

--- a/integration-test/596-add-hiking-routes.py
+++ b/integration-test/596-add-hiking-routes.py
@@ -18,10 +18,11 @@ class AddHikingRoutes(FixtureTest):
     def test_steps(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/25292070'])
 
+        # we don't assert name feature because name has been dropped in
+        # https://github.com/tilezen/vector-datasource/pull/2031
         self.assert_has_feature(
             14, 2620, 6334, 'roads',
-            {'kind': 'path', 'kind_detail': 'steps',
-             'name': 'Esmeralda Ave.'})
+            {'kind': 'path', 'kind_detail': 'steps'})
 
     def test_footway(self):
         self.load_fixtures(['https://www.openstreetmap.org/way/346093021'])

--- a/integration-test/993-remove-props-road-merge.py
+++ b/integration-test/993-remove-props-road-merge.py
@@ -34,9 +34,11 @@ class RemovePropsRoadMerge(FixtureTest):
         self.generate_fixtures(dsl.way(65373362, wkt_loads('POINT (-122.394582771693 37.79601559864509)'), {u'source': u'openstreetmap.org', u'highway': u'crossing'}), dsl.way(397140734, wkt_loads('LINESTRING (-122.394459971993 37.79588101160508, -122.394582771693 37.79601559864509)'), {
                                u'tiger:name_base': u'The Embarcadero', u'maxspeed': u'30 mph', u'lanes': u'4', u'name': u'The Embarcadero', u'lcn_ref': u'4', u'source': u'openstreetmap.org', u'turn:lanes': u'left||', u'surface': u'asphalt', u'lit': u'yes', u'cycleway:right': u'lane', u'tiger:county': u'San Francisco, CA', u'oneway': u'yes', u'sidewalk': u'separate', u'tiger:cfcc': u'A45', u'highway': u'primary'}))
 
+        # we don't assert name feature because name has been dropped in
+        # https://github.com/tilezen/vector-datasource/pull/2031
         self.assert_has_feature(
             14, 2621, 6331, 'roads',
-            {'name': 'The Embarcadero', 'kind': 'major_road'})
+            {'kind': 'major_road'})
 
         self.assert_no_matching_feature(
             14, 2621, 6331, 'roads',
@@ -48,9 +50,11 @@ class RemovePropsRoadMerge(FixtureTest):
         self.generate_fixtures(dsl.way(438362919, wkt_loads('LINESTRING (-79.8826816097629 40.41101322070767, -79.8831899663821 40.41135651420059, -79.88400851126899 40.41189241516631, -79.88584332023679 40.41295517589352, -79.8870018774588 40.41360549127349, -79.8875516464127 40.4139608092326, -79.8877082227667 40.4140138844779, -79.88778934063679 40.41404137962718)'), {
                                u'maxspeed': u'25 mph', u'lanes': u'2', u'name': u'Carrie Furnace Boulevard', u'sidewalk:left': u'sidepath', u'lit': u'yes', u'source': u'openstreetmap.org', u'sidewalk:right': u'no', u'lanes:backward': u'1', u'lanes:forward': u'1', u'highway': u'tertiary'}))
 
+        # we don't assert name feature because name has been dropped in
+        # https://github.com/tilezen/vector-datasource/pull/2031
         self.assert_has_feature(
             14, 4556, 6178, 'roads',
-            {'name': 'Carrie Furnace Blvd.', 'kind': 'major_road'})
+            {'kind': 'major_road'})
 
         self.assert_no_matching_feature(
             14, 4556, 6178, 'roads',

--- a/queries.yaml
+++ b/queries.yaml
@@ -1897,7 +1897,7 @@ post_process:
       # pixels (256px nominal) to require per letter in the name. if lines are shorter than this,
       # the name gets dropped. name pairs (e.g: :left and :right) get dropped if either are longer
       # than pixels_per_letter. larger values mean fewer lines are eligible for labelling.
-      pixels_per_letter: 8
+      pixels_per_letter: 11
 
   # since we drop names in the previous step, we would like merge it again
   - fn: vectordatasource.transform.merge_line_features

--- a/queries.yaml
+++ b/queries.yaml
@@ -1888,6 +1888,38 @@ post_process:
       # need to be a large tolerance.
       simplify_tolerance: 1.0
 
+  # drop labels on roads which are too short to render.
+  - fn: vectordatasource.transform.drop_names_on_short_boundaries
+    params:
+      source_layer: roads
+      start_zoom: 8
+      end_zoom: 15
+      # pixels (256px nominal) to require per letter in the name. if lines are shorter than this,
+      # the name gets dropped. name pairs (e.g: :left and :right) get dropped if either are longer
+      # than pixels_per_letter. larger values mean fewer lines are eligible for labelling.
+      pixels_per_letter: 11
+
+  # since we drop names in the previous step, we would like merge it again
+  - fn: vectordatasource.transform.merge_line_features
+    params:
+      source_layer: roads
+      start_zoom: 8
+      end_zoom: 15
+      # setting the following will try to merge linestrings across junctions
+      # (i.e: more than 2 roads meeting at a point) where the angle between
+      # roads at that point is less than 5 degrees.
+      merge_junctions: true
+      merge_junction_angle: 5.0
+      # setting the following will cause lines, or parts of multi-lines,
+      # shorter than 0.1px at nominal zoom to be dropped.
+      drop_short_segments: true
+      drop_length_pixels: 0.1
+      # integrated simplification step tolerance. NOTE: simplification is only
+      # performed if junction merging is set to true! the idea is to simplify
+      # away points at junctions where the road is straight, so it shouldn't
+      # need to be a large tolerance.
+      simplify_tolerance: 1.0
+
   # we do want to merge at 15, but we don't want to merge junctions becase that
   # might merge across oneway information, which doesn't get dropped until
   # zoom < 15.

--- a/queries.yaml
+++ b/queries.yaml
@@ -1897,7 +1897,7 @@ post_process:
       # pixels (256px nominal) to require per letter in the name. if lines are shorter than this,
       # the name gets dropped. name pairs (e.g: :left and :right) get dropped if either are longer
       # than pixels_per_letter. larger values mean fewer lines are eligible for labelling.
-      pixels_per_letter: 11
+      pixels_per_letter: 8
 
   # since we drop names in the previous step, we would like merge it again
   - fn: vectordatasource.transform.merge_line_features


### PR DESCRIPTION


In #2008 we stripped names from roads per kind of road and zoom. But that still yields names on short road segments which don't have enough room to actually label.

After roads are merged, we should evaluate if the merged features are long enough to have the name actually label, and if it's not long enough drop the names.

Then we should merge features again so the newly nameless roads merge together.

We do this same trick in the boundaries layer already, so reprise that here:

https://github.com/tilezen/vector-datasource/blob/v1.8.0/queries.yaml#L763-L794

https://github.com/tilezen/vector-datasource/issues/2019