### PR TITLE
OSM localities joins NE and prefers NE population to calculate population_rank

### DIFF
--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1035,7 +1035,7 @@ BEGIN
     SELECT
       pp.min_zoom, NULL INTO min_zoom, max_zoom
       FROM ne_10m_populated_places pp
-      WHERE pp.wikidataid = wikidata_id
+      WHERE pp.wikidataid = wikidata_id;
   END IF;
 
   -- return an empty JSONB rather than null, so that it can be safely

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1021,12 +1021,20 @@ BEGIN
       WHERE mu.wikidataid = wikidata_id;
   END IF;
 
-  -- finally, try states and provinces
+  -- try states and provinces
   IF NOT FOUND THEN
     SELECT
       min_label, max_label INTO min_zoom, max_zoom
       FROM ne_10m_admin_1_states_provinces sp
       WHERE sp.wikidataid = wikidata_id;
+  END IF;
+
+  -- finally, try localities
+  IF NOT FOUND THEN
+    SELECT
+      rank_min, rank_max INTO min_zoom, max_zoom
+      FROM ne_10m_populated_places pp
+      WHERE pp.wikidataid = wikidata_id
   END IF;
 
   -- return an empty JSONB rather than null, so that it can be safely

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1064,7 +1064,7 @@ BEGIN
   END IF;
 
   SELECT
-    pop_min, pop_max INTO pop_min, pop_max
+    pp.pop_min, pp.pop_max INTO pop_min, pop_max
     FROM ne_10m_populated_places pp
     WHERE pp.wikidataid = wikidata_id;
 
@@ -1078,7 +1078,7 @@ BEGIN
     '__ne_pop_min', pop_min,
     '__ne_pop_max', pop_max
   );
-END
+END;
 $$ LANGUAGE plpgsql STABLE;
 
 -- return the min zoom for a node that looks like a service area.

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1032,7 +1032,8 @@ BEGIN
   -- finally, try localities
   IF NOT FOUND THEN
     SELECT
-      rank_min, rank_max INTO min_zoom, max_zoom
+      -- There is no concept of max_zoom for ne_10m_populated_places
+      min_zoom, NULL INTO min_zoom, max_zoom
       FROM ne_10m_populated_places pp
       WHERE pp.wikidataid = wikidata_id
   END IF;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1033,7 +1033,7 @@ BEGIN
   -- There is no concept of max_zoom for ne_10m_populated_places
   IF NOT FOUND THEN
     SELECT
-      min_zoom, NULL INTO min_zoom, max_zoom
+      pp.min_zoom, NULL INTO min_zoom, max_zoom
       FROM ne_10m_populated_places pp
       WHERE pp.wikidataid = wikidata_id
   END IF;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1052,7 +1052,7 @@ $$ LANGUAGE plpgsql STABLE;
 
 
 -- returns a JSONB object containing __ne_pop_min and __ne_pop_max
-CREATE OR REPLACE FUNCTION tz_get_ne_min_max_pop(wikidata_id TEXT)
+CREATE OR REPLACE FUNCTION tz_get_ne_pop_min_max(wikidata_id TEXT)
 RETURNS JSONB AS $$
 DECLARE
   pop_min REAL;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1030,9 +1030,9 @@ BEGIN
   END IF;
 
   -- finally, try localities
+  -- There is no concept of max_zoom for ne_10m_populated_places
   IF NOT FOUND THEN
     SELECT
-      -- There is no concept of max_zoom for ne_10m_populated_places
       min_zoom, NULL INTO min_zoom, max_zoom
       FROM ne_10m_populated_places pp
       WHERE pp.wikidataid = wikidata_id
@@ -1048,7 +1048,7 @@ BEGIN
     '__ne_min_zoom', min_zoom,
     '__ne_max_zoom', max_zoom
   );
-END
+END;
 $$ LANGUAGE plpgsql STABLE;
 
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -804,7 +804,7 @@ Places with `kind` values of `continent`, `country`, with others added starting 
 * `name`
 * `id`: The `osm_id` from OpenStreetMap or Natural Earth id
 * `kind`: normalized values between OpenStreetMap and Natural Earth
-* `population`: population integer values from OpenStreetMap or Natural Earth's minimum population value(`pop_min`) if the place has a join from OpenStreetMap and NatualEarth or an estimate value hardcoded in the transform function `tags_set_ne_pop_min_max_default` in this repo.
+* `population`: population integer values from OpenStreetMap or Natural Earth's minimum population value(`pop_min`) if the place has a join from OpenStreetMap and NatualEarth or an estimate based on the type of place.
 * `population_rank`: A value from 18 down to 0, indicating how large the population is on a particular place. A larger value indicates a bigger population. See "Population Rank" below for more details.
 * `source`: `openstreetmap`, `naturalearthdata.com`, or `whosonfirst.org`
 * `min_zoom`: a suggested minimum zoom at which the place should become visible based on scalerank and population values from Natural Earth, and invented for OpenStreetMap. Note that this is not an integer, and may contain fractional parts.
@@ -869,7 +869,7 @@ The values of population rank are derived from the `population` value as follows
 * 1: Less than 200
 * 0: No `population` value available or `population` value zero.
 
-OSM localities gets their population_rank from NaturalEarth's `pop_max` tag because NaturalEarth `pop_max` is for the metro area and is more useful for label grading in the stylesheet.
+When available, for the largest cities, OSM localities gets their population_rank from NaturalEarth's `pop_max` tag because NaturalEarth `pop_max` is for the metro area and is more useful for label grading in the stylesheet.
 
 ## Points of Interest
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -804,7 +804,7 @@ Places with `kind` values of `continent`, `country`, with others added starting 
 * `name`
 * `id`: The `osm_id` from OpenStreetMap or Natural Earth id
 * `kind`: normalized values between OpenStreetMap and Natural Earth
-* `population`: population integer values from OpenStreetMap or Natural Earth's maximum population value.
+* `population`: population integer values from OpenStreetMap or Natural Earth's minimum population value(`pop_min`) if the place has a join from OpenStreetMap and NatualEarth or an estimate value hardcoded in the transform function `tags_set_ne_pop_min_max_default` in this repo.
 * `population_rank`: A value from 18 down to 0, indicating how large the population is on a particular place. A larger value indicates a bigger population. See "Population Rank" below for more details.
 * `source`: `openstreetmap`, `naturalearthdata.com`, or `whosonfirst.org`
 * `min_zoom`: a suggested minimum zoom at which the place should become visible based on scalerank and population values from Natural Earth, and invented for OpenStreetMap. Note that this is not an integer, and may contain fractional parts.
@@ -867,7 +867,9 @@ The values of population rank are derived from the `population` value as follows
 * 3: 1k to 2k
 * 2: 200 to 1k
 * 1: Less than 200
-* 0: No `population` value available.
+* 0: No `population` value available or `population` value zero.
+
+OSM localities gets their population_rank from NaturalEarth's `pop_max` tag because NaturalEarth `pop_max` is for the metro area and is more useful for label grading in the stylesheet.
 
 ## Points of Interest
 

--- a/integration-test/2020-locality-osm-ne-join.py
+++ b/integration-test/2020-locality-osm-ne-join.py
@@ -141,6 +141,8 @@ class OSMNEJoinTest(FixtureTest):
         # without __ne_min_zoom, the min_zoom should be 8 which is from the
         # https://github.com/tilezen/vector-datasource/blob/80799e74e0283a96b520c6fea8fa00455095e09b/yaml/places.yaml#L145
         # but with __ne_min_zoom override, it is 2.7
+        # because of the logic in tags_set_ne_min_max_zoom, the expected
+        # value is converted from 2.7 to 3.0
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 26819236,

--- a/integration-test/2020-locality-osm-ne-join.py
+++ b/integration-test/2020-locality-osm-ne-join.py
@@ -78,16 +78,18 @@ class OSMNEJoinTest(FixtureTest):
                 'source': u'openstreetmap.org',
                 'wikidata': u'Q62',
                 'wikipedia': u'en:San Francisco',
+                '__ne_min_zoom': 10,
             }),
         )
 
         # without __ne_min_zoom, the min_zoom should be 8 which is from the
-        # yaml/places.yaml file
+        # https://github.com/tilezen/vector-datasource/blob/80799e74e0283a96b520c6fea8fa00455095e09b/yaml/places.yaml#L145
+        # but with __ne_min_zoom override, it is 10
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 26819236,
                 'kind': 'locality',
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
-                'min_zoom': 8,
+                'min_zoom': 10,
             })

--- a/integration-test/2020-locality-osm-ne-join.py
+++ b/integration-test/2020-locality-osm-ne-join.py
@@ -1,0 +1,93 @@
+# -*- encoding: utf-8 -*-
+import dsl
+
+from . import FixtureTest
+
+
+class OSMNEJoinTest(FixtureTest):
+    # test that the population_rank is overridden by __ne_pop_max
+    def test_ne_pop_max_override(self):
+        z, x, y = (16, 10482, 25330)
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/26819236
+            dsl.point(26819236, (-122.4199061, 37.7790262), {
+                'name': u'San Francisco',
+                'place': u'city',
+                'population': u'864816',
+                'rank': u'10',
+                'short_name': u'SF',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q62',
+                'wikipedia': u'en:San Francisco',
+                '__ne_pop_max': u'1000000000'
+            }),
+        )
+
+        # population is directly from 'population' property
+        # however the population_rank is calculated from '__ne_pop_max'
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata_id': 'Q62',
+                'population': 864816,
+                'population_rank': 18
+            })
+
+    # test that the population is overridden by __ne_pop_min
+    def test_ne_pop_min_override(self):
+        z, x, y = (16, 10482, 25330)
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/26819236
+            dsl.point(26819236, (-122.4199061, 37.7790262), {
+                'name': u'San Francisco',
+                'place': u'city',
+                'rank': u'10',
+                'short_name': u'SF',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q62',
+                'wikipedia': u'en:San Francisco',
+                '__ne_pop_min': u'50000000',
+            }),
+        )
+
+        # population is not available from 'population' property
+        # however '__ne_pop_min' should backfill it and be used to calculate
+        # population_rank
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata_id': 'Q62',
+                'population': 50000000,
+                'population_rank': 16
+            })
+
+    # test that the min_zoom is overridden by __ne_min_zoom
+    def test_ne_min_zoom(self):
+        z, x, y = (16, 10482, 25330)
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/26819236
+            dsl.point(26819236, (-122.4199061, 37.7790262), {
+                'name': u'San Francisco',
+                'place': u'city',
+                'rank': u'10',
+                'short_name': u'SF',
+                'source': u'openstreetmap.org',
+                'wikidata': u'Q62',
+                'wikipedia': u'en:San Francisco',
+            }),
+        )
+
+        # without __ne_min_zoom, the min_zoom should be 8 which is from the
+        # yaml/places.yaml file
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata_id': 'Q62',
+                'min_zoom': 8,
+            })

--- a/integration-test/2020-locality-osm-ne-join.py
+++ b/integration-test/2020-locality-osm-ne-join.py
@@ -18,7 +18,7 @@ class OSMNEJoinTest(FixtureTest):
                 'source': u'openstreetmap.org',
                 'wikidata': u'Q62',
                 'wikipedia': u'en:San Francisco',
-                '__ne_pop_max': u'1000000000'
+                '__ne_pop_max': u'20000000'
             }),
         )
 
@@ -31,7 +31,7 @@ class OSMNEJoinTest(FixtureTest):
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
                 'population': 864816,
-                'population_rank': 18
+                'population_rank': 15
             })
 
     def test_ne_pop_min_override_estimate(self):
@@ -76,7 +76,7 @@ class OSMNEJoinTest(FixtureTest):
                 'source': u'openstreetmap.org',
                 'wikidata': u'Q62',
                 'wikipedia': u'en:San Francisco',
-                '__ne_pop_max': u'1000000000'
+                '__ne_pop_max': u'20000000'
             }),
         )
 
@@ -90,7 +90,7 @@ class OSMNEJoinTest(FixtureTest):
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
                 'population': 10000,
-                'population_rank': 18
+                'population_rank': 15
             })
 
     # test that the min_zoom is overridden by __ne_min_zoom

--- a/integration-test/2020-locality-osm-ne-join.py
+++ b/integration-test/2020-locality-osm-ne-join.py
@@ -18,7 +18,7 @@ class OSMNEJoinTest(FixtureTest):
                 'source': u'openstreetmap.org',
                 'wikidata': u'Q62',
                 'wikipedia': u'en:San Francisco',
-                '__ne_pop_max': u'20000000'
+                '__ne_pop_max': u'3450000'
             }),
         )
 
@@ -31,7 +31,7 @@ class OSMNEJoinTest(FixtureTest):
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
                 'population': 864816,
-                'population_rank': 15
+                'population_rank': 12
             })
         # __ne_pop_max shouldn't appear in the final result
         self.assert_no_matching_feature(
@@ -40,7 +40,7 @@ class OSMNEJoinTest(FixtureTest):
                 'kind': 'locality',
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
-                '__ne_pop_max': 20000000,
+                '__ne_pop_max': 3450000,
             })
 
     def test_ne_pop_min_override_estimate(self):
@@ -55,7 +55,7 @@ class OSMNEJoinTest(FixtureTest):
                 'source': u'openstreetmap.org',
                 'wikidata': u'Q62',
                 'wikipedia': u'en:San Francisco',
-                '__ne_pop_min': u'50000000'
+                '__ne_pop_min': u'732072'
             }),
         )
 
@@ -69,8 +69,8 @@ class OSMNEJoinTest(FixtureTest):
                 'kind': 'locality',
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
-                'population': 50000000,
-                'population_rank': 16
+                'population': 732072,
+                'population_rank': 11
             })
 
         # __ne_pop_min shouldn't appear in the final result
@@ -80,7 +80,7 @@ class OSMNEJoinTest(FixtureTest):
                 'kind': 'locality',
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
-                '__ne_pop_min': 50000000,
+                '__ne_pop_min': 732072,
             })
 
     def test_ne_pop_max_override_estimate_pop_rank(self):
@@ -95,7 +95,7 @@ class OSMNEJoinTest(FixtureTest):
                 'source': u'openstreetmap.org',
                 'wikidata': u'Q62',
                 'wikipedia': u'en:San Francisco',
-                '__ne_pop_max': u'20000000'
+                '__ne_pop_max': u'3450000'
             }),
         )
 
@@ -109,7 +109,7 @@ class OSMNEJoinTest(FixtureTest):
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
                 'population': 10000,
-                'population_rank': 15
+                'population_rank': 12
             })
         # __ne_pop_max shouldn't appear in the final result
         self.assert_no_matching_feature(
@@ -118,7 +118,7 @@ class OSMNEJoinTest(FixtureTest):
                 'kind': 'locality',
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
-                '__ne_pop_max': 20000000,
+                '__ne_pop_max': 3450000,
             })
 
     # test that the min_zoom is overridden by __ne_min_zoom
@@ -134,20 +134,20 @@ class OSMNEJoinTest(FixtureTest):
                 'source': u'openstreetmap.org',
                 'wikidata': u'Q62',
                 'wikipedia': u'en:San Francisco',
-                '__ne_min_zoom': 10,
+                '__ne_min_zoom': 2.7,
             }),
         )
 
         # without __ne_min_zoom, the min_zoom should be 8 which is from the
         # https://github.com/tilezen/vector-datasource/blob/80799e74e0283a96b520c6fea8fa00455095e09b/yaml/places.yaml#L145
-        # but with __ne_min_zoom override, it is 10
+        # but with __ne_min_zoom override, it is 2.7
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 26819236,
                 'kind': 'locality',
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
-                'min_zoom': 10,
+                'min_zoom': 3.0,
             })
 
         # __ne_min_zoom shouldn't appear in the final result
@@ -157,5 +157,5 @@ class OSMNEJoinTest(FixtureTest):
                 'kind': 'locality',
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
-                '__ne_min_zoom': 10,
+                '__ne_min_zoom': 2.7,
             })

--- a/integration-test/2020-locality-osm-ne-join.py
+++ b/integration-test/2020-locality-osm-ne-join.py
@@ -33,6 +33,15 @@ class OSMNEJoinTest(FixtureTest):
                 'population': 864816,
                 'population_rank': 15
             })
+        # __ne_pop_max shouldn't appear in the final result
+        self.assert_no_matching_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata_id': 'Q62',
+                '__ne_pop_max': 20000000,
+            })
 
     def test_ne_pop_min_override_estimate(self):
         z, x, y = (16, 10482, 25330)
@@ -64,6 +73,16 @@ class OSMNEJoinTest(FixtureTest):
                 'population_rank': 16
             })
 
+        # __ne_pop_min shouldn't appear in the final result
+        self.assert_no_matching_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata_id': 'Q62',
+                '__ne_pop_min': 50000000,
+            })
+
     def test_ne_pop_max_override_estimate_pop_rank(self):
         z, x, y = (16, 10482, 25330)
         self.generate_fixtures(
@@ -91,6 +110,15 @@ class OSMNEJoinTest(FixtureTest):
                 'wikidata_id': 'Q62',
                 'population': 10000,
                 'population_rank': 15
+            })
+        # __ne_pop_max shouldn't appear in the final result
+        self.assert_no_matching_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata_id': 'Q62',
+                '__ne_pop_max': 20000000,
             })
 
     # test that the min_zoom is overridden by __ne_min_zoom
@@ -120,4 +148,14 @@ class OSMNEJoinTest(FixtureTest):
                 'kind_detail': 'city',
                 'wikidata_id': 'Q62',
                 'min_zoom': 10,
+            })
+
+        # __ne_min_zoom shouldn't appear in the final result
+        self.assert_no_matching_feature(
+            z, x, y, 'places', {
+                'id': 26819236,
+                'kind': 'locality',
+                'kind_detail': 'city',
+                'wikidata_id': 'Q62',
+                '__ne_min_zoom': 10,
             })

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -121,10 +121,10 @@ class PopulationRankTest(FixtureTest):
             return features[0]['properties'].get('collision_rank')
 
     def test_collision_rank_decreasing(self):
-        last = self._rank_for_pop(None)
+        last = self._rank_for_pop(1 << 0)
         self.assertGreater(last, 0)
 
-        for exp in xrange(30):
+        for exp in xrange(1, 30):
             population = 1 << exp
             rank = self._rank_for_pop(population)
             self.assertLessEqual(rank, last)

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -105,7 +105,7 @@ class PopulationRankTest(FixtureTest):
 
         tags = {
             'place': 'city',
-            'population': population,
+            # 'population': population,
             'name': 'Fooville',
             'source': 'openstreetmap.org',
         }
@@ -118,17 +118,21 @@ class PopulationRankTest(FixtureTest):
 
         with self.features_in_tile_layer(z, x, y, 'places') as features:
             self.assertEqual(len(features), 1)
+            print('collision')
+            print(features[0]['properties'].get('population'))
+            print(features[0]['properties'].get('population_rank'))
+            print(features[0]['properties'].get('collision_rank'))
             return features[0]['properties'].get('collision_rank')
 
     def test_collision_rank_decreasing(self):
-        last = self._rank_for_pop(1 << 0)
+        last = self._rank_for_pop(None)
         self.assertGreater(last, 0)
 
-        for exp in xrange(1, 30):
-            population = 1 << exp
-            rank = self._rank_for_pop(population)
-            self.assertLessEqual(rank, last)
-            last = rank
+        # for exp in xrange(0, 30):
+        #     population = 1 << exp
+        #     rank = self._rank_for_pop(population)
+        #     self.assertLessEqual(rank, last)
+        #     last = rank
 
     def test_capital_ranks_earlier(self):
         population = 10000000

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -94,8 +94,8 @@ class PopulationRankTest(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'places', {
-                'population': type(None),
-                'population_rank': 0,
+                'population': 10000,  # from hardcode estimate for city
+                'population_rank': 6,
             })
 
     def _rank_for_pop(self, population, capital=None):

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -105,7 +105,7 @@ class PopulationRankTest(FixtureTest):
 
         tags = {
             'place': 'city',
-            # 'population': population,
+            'population': population,
             'name': 'Fooville',
             'source': 'openstreetmap.org',
         }
@@ -118,21 +118,17 @@ class PopulationRankTest(FixtureTest):
 
         with self.features_in_tile_layer(z, x, y, 'places') as features:
             self.assertEqual(len(features), 1)
-            print('collision')
-            print(features[0]['properties'].get('population'))
-            print(features[0]['properties'].get('population_rank'))
-            print(features[0]['properties'].get('collision_rank'))
             return features[0]['properties'].get('collision_rank')
 
     def test_collision_rank_decreasing(self):
-        last = self._rank_for_pop(None)
+        last = self._rank_for_pop(0)
         self.assertGreater(last, 0)
 
-        # for exp in xrange(0, 30):
-        #     population = 1 << exp
-        #     rank = self._rank_for_pop(population)
-        #     self.assertLessEqual(rank, last)
-        #     last = rank
+        for exp in xrange(1, 30):
+            population = 1 << exp
+            rank = self._rank_for_pop(population)
+            self.assertLessEqual(rank, last)
+            last = rank
 
     def test_capital_ranks_earlier(self):
         population = 10000000

--- a/queries.yaml
+++ b/queries.yaml
@@ -35,7 +35,9 @@ sources:
   ne:
     ## places
     # ne_10m_populated_places
+    # Note: we add start_zoom 2 here otherwise the zoom 0/0/0 tile at 512px(or zoom1 tile at 256px) tile size will get a lot bigger because there are 11 features with min_zoom of 1.7 as of Jan 2022.
     - template: ne-places.jinja2
+      start_zoom: 2
 
     ## boundaries
 

--- a/queries.yaml
+++ b/queries.yaml
@@ -675,7 +675,7 @@ post_process:
       where: kind == 'region'
 
   # IMPORTANT! do this _after_ the YAMLToDict default stuff, otherwise the
-  # default will overwrite the value fron Natural Earth.
+  # default will overwrite the value from Natural Earth.
   - fn: vectordatasource.transform.tags_set_ne_min_max_zoom
     params:
       layer: places

--- a/queries.yaml
+++ b/queries.yaml
@@ -680,6 +680,10 @@ post_process:
     params:
       layer: places
 
+  - fn: vectordatasource.transform.tags_set_ne_pop_min_max_default
+    params:
+      layer: places
+
   # after we have the NE min zoom, drop features which we won't be displaying
   # at this zoom.
   - fn: vectordatasource.transform.min_zoom_filter

--- a/queries.yaml
+++ b/queries.yaml
@@ -35,7 +35,7 @@ sources:
   ne:
     ## places
     # ne_10m_populated_places
-    # Note: we add start_zoom 2 here otherwise the zoom 0/0/0 tile at 512px(or zoom1 tile at 256px) tile size will get a lot bigger because there are 11 features with min_zoom of 1.7 as of Jan 2022.
+    # Note: we add start_zoom 2 here otherwise for the zoom 0/0/0 tile at 512px (or zoom1 at 256px), the size will get a lot bigger because there are 11 features with min_zoom of 1.7 as of Jan 2022.
     - template: ne-places.jinja2
       start_zoom: 2
 

--- a/queries/planet_osm_point.jinja2
+++ b/queries/planet_osm_point.jinja2
@@ -8,7 +8,7 @@ SELECT
     'source', 'openstreetmap.org'
   ) AS __properties__,
 
-  {# The `CASE WHEN mz_xxx_min_zoom IS NOT NULL` here is used to indicate whether the current row is from a particular layer #}
+  {# Since the WHERE clause is a UNION of multiple tables the `CASE WHEN mz_building_min_zoom IS NOT NULL` here is used to conditionally operate the rows from mz_building_min_zoom table #}
   CASE WHEN mz_building_min_zoom IS NOT NULL
     THEN jsonb_build_object(
       'min_zoom', mz_building_min_zoom,

--- a/queries/planet_osm_point.jinja2
+++ b/queries/planet_osm_point.jinja2
@@ -8,6 +8,7 @@ SELECT
     'source', 'openstreetmap.org'
   ) AS __properties__,
 
+  {# The `CASE WHEN mz_xxx_min_zoom IS NOT NULL` here is used to indicate whether the current row is from a particular layer #}
   CASE WHEN mz_building_min_zoom IS NOT NULL
     THEN jsonb_build_object(
       'min_zoom', mz_building_min_zoom,
@@ -27,6 +28,8 @@ SELECT
       'min_zoom', mz_places_min_zoom
     ) ||
       tz_get_ne_min_max_zoom(tags->'wikidata')
+      ||
+      tz_get_ne_pop_min_max(tags->'wikidata')
   END AS __places_properties__,
 
   CASE WHEN mz_poi_min_zoom IS NOT NULL

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -411,6 +411,11 @@ def place_population_int(shape, properties, fid, zoom):
 
 
 def _calculate_population_rank(population):
+    population = to_float(population)
+    if population is None:
+        population = 0
+    else:
+        population = int(population)
     pop_breaks = [
         1000000000,
         100000000,
@@ -8830,6 +8835,11 @@ def tags_set_ne_pop_min_max_default(ctx):
     for _, props, _ in layer['features']:
         __ne_pop_min = props.pop('__ne_pop_min', None)
         __ne_pop_max = props.pop('__ne_pop_max', None)
+
+        print('peiti!!!!!!!!!!!!!!!!')
+        print(type(__ne_pop_min))
+        print(type(__ne_pop_max))
+
         population = props.get('population')
         if population is None:
             population = __ne_pop_min

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -165,7 +165,6 @@ filters:
       <<: *output_properties
       kind: mz_internal_dispute_mask
       disputed_by: {col: disputed_by}
-      disputed: 'yes'
     table: osm
 
   # osm

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -165,6 +165,7 @@ filters:
       <<: *output_properties
       kind: mz_internal_dispute_mask
       disputed_by: {col: disputed_by}
+      disputed: 'yes'
     table: osm
 
   # osm

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -86,6 +86,10 @@ global:
     __ne_min_zoom: { col: __ne_min_zoom }
     __ne_max_zoom: { col: __ne_max_zoom }
 
+  - &ne_pops
+    __ne_pop_min: {col: __ne_pop_min}
+    __ne_pop_max: {col: __ne_pop_max}
+
 filters:
   - filter:
       meta.source: wof
@@ -138,105 +142,103 @@ filters:
       kind: region
       kind_detail: province
     table: osm
-  - filter: {name: true, place: [city, town]}
+  - filter: {name: true, population: true, place: [city, town]}
     min_zoom: 8
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: {col: place}
-      __ne_pop_min: { col: __ne_pop_min } # pop_min(population min) from NaturalEarth
-      __ne_pop_max: { col: __ne_pop_max } # pop_max(population max) from NaturalEarth
     table: osm
   - filter: {name: true, place: city}
     min_zoom: 9
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: city
-      population: 10000
+      #population: 10000 # default population backfill
     table: osm
   - filter: {name: true, place: town}
     min_zoom: 10
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: town
-      population: 5000
+      #population: 5000 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: village}
     min_zoom: 12
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: village
     table: osm
   - filter: {name: true, place: village}
     min_zoom: 13
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: village
-      population: 2000
+      #population: 2000 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: locality}
     min_zoom: 13
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: locality
     table: osm
   - filter: {name: true, place: locality}
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: locality
-      population: 1000
+      #population: 1000 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: hamlet}
     min_zoom: 13
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: hamlet
     table: osm
   - filter: {name: true, place: hamlet}
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: hamlet
-      population: 200
+      #population: 200 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: isolated_dwelling}
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: isolated_dwelling
     table: osm
   - filter: { name: true, place: isolated_dwelling }
     min_zoom: 15
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: isolated_dwelling
-      population: 100
+      #population: 100 # default population backfill
     table: osm
   - filter: { name: true, population: true, place: farm }
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: farm
     table: osm
   - filter: {name: true, place: farm}
     min_zoom: 15
     output:
-      <<: [*output_properties, *alternate_fclass, *ne_zooms]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: farm
-      population: 50
+      #population: 50 # default population backfill
     table: osm
 
   - filter:

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -1,7 +1,6 @@
 global:
   - &ne_country_capital [Admin-0 capital, Admin-0 capital alt, Admin-0 region capital]
   - &ne_region_capital [Admin-1 capital, Admin-1 region capital]
-
   - &output_properties
     name: {col: name}
     source: {col: source}
@@ -135,18 +134,18 @@ filters:
     # which doesn't match an NE curated one.
     min_zoom: 3
     output:
-      <<: *output_properties
+      <<: [*output_properties, *ne_zooms]
       kind: region
       kind_detail: province
-      __ne_min_zoom: {col: __ne_min_zoom}
-      __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
-  - filter: {name: true, population: true, place: [city, town]}
+  - filter: {name: true, place: [city, town]}
     min_zoom: 8
     output:
       <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: {col: place}
+      __ne_pop_min: { col: __ne_pop_min } # pop_min(population min) from NaturalEarth
+      __ne_pop_max: { col: __ne_pop_max } # pop_max(population max) from NaturalEarth
     table: osm
   - filter: {name: true, place: city}
     min_zoom: 9

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -82,10 +82,12 @@ global:
     fclass_us: { col: fclass_us }
     fclass_vn: { col: fclass_vn }
 
+  # min/max zooms from NaturalEarth
   - &ne_zooms
     __ne_min_zoom: { col: __ne_min_zoom }
     __ne_max_zoom: { col: __ne_max_zoom }
 
+  # populations from NaturalEarth
   - &ne_pops
     __ne_pop_min: {col: __ne_pop_min}
     __ne_pop_max: {col: __ne_pop_max}
@@ -155,7 +157,6 @@ filters:
       <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: city
-      #population: 10000 # default population backfill
     table: osm
   - filter: {name: true, place: town}
     min_zoom: 10
@@ -163,7 +164,6 @@ filters:
       <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: town
-      #population: 5000 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: village}
     min_zoom: 12
@@ -178,7 +178,6 @@ filters:
       <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: village
-      #population: 2000 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: locality}
     min_zoom: 13
@@ -193,7 +192,6 @@ filters:
       <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: locality
-      #population: 1000 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: hamlet}
     min_zoom: 13
@@ -208,7 +206,6 @@ filters:
       <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: hamlet
-      #population: 200 # default population backfill
     table: osm
   - filter: {name: true, population: true, place: isolated_dwelling}
     min_zoom: 14
@@ -223,7 +220,6 @@ filters:
       <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: isolated_dwelling
-      #population: 100 # default population backfill
     table: osm
   - filter: { name: true, population: true, place: farm }
     min_zoom: 14
@@ -238,7 +234,6 @@ filters:
       <<: [*output_properties, *alternate_fclass, *ne_zooms, *ne_pops]
       kind: locality
       kind_detail: farm
-      #population: 50 # default population backfill
     table: osm
 
   - filter:

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -83,6 +83,10 @@ global:
     fclass_us: { col: fclass_us }
     fclass_vn: { col: fclass_vn }
 
+  - &ne_zooms
+    __ne_min_zoom: { col: __ne_min_zoom }
+    __ne_max_zoom: { col: __ne_max_zoom }
+
 filters:
   - filter:
       meta.source: wof
@@ -106,10 +110,8 @@ filters:
     # which doesn't match an NE curated one.
     min_zoom: 1
     output:
-      <<: *output_properties
+      <<: [*output_properties, *ne_zooms]
       kind: country
-      __ne_min_zoom: {col: __ne_min_zoom}
-      __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
   - filter: {name: true, place: state}
     # note: min_zoom needs to be smaller than any min_label in
@@ -120,11 +122,9 @@ filters:
     # which doesn't match an NE curated one.
     min_zoom: 3
     output:
-      <<: *output_properties
+      <<: [*output_properties, *ne_zooms]
       kind: region
       kind_detail: state
-      __ne_min_zoom: {col: __ne_min_zoom}
-      __ne_max_zoom: {col: __ne_max_zoom}
     table: osm
   - filter: {name: true, place: province}
     # note: min_zoom needs to be smaller than any min_label in
@@ -144,14 +144,14 @@ filters:
   - filter: {name: true, population: true, place: [city, town]}
     min_zoom: 8
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: {col: place}
     table: osm
   - filter: {name: true, place: city}
     min_zoom: 9
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: city
       population: 10000
@@ -159,7 +159,7 @@ filters:
   - filter: {name: true, place: town}
     min_zoom: 10
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: town
       population: 5000
@@ -167,14 +167,14 @@ filters:
   - filter: {name: true, population: true, place: village}
     min_zoom: 12
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: village
     table: osm
   - filter: {name: true, place: village}
     min_zoom: 13
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: village
       population: 2000
@@ -182,14 +182,14 @@ filters:
   - filter: {name: true, population: true, place: locality}
     min_zoom: 13
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: locality
     table: osm
   - filter: {name: true, place: locality}
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: locality
       population: 1000
@@ -197,14 +197,14 @@ filters:
   - filter: {name: true, population: true, place: hamlet}
     min_zoom: 13
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: hamlet
     table: osm
   - filter: {name: true, place: hamlet}
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: hamlet
       population: 200
@@ -212,14 +212,14 @@ filters:
   - filter: {name: true, population: true, place: isolated_dwelling}
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: isolated_dwelling
     table: osm
   - filter: { name: true, place: isolated_dwelling }
     min_zoom: 15
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: isolated_dwelling
       population: 100
@@ -227,14 +227,14 @@ filters:
   - filter: { name: true, population: true, place: farm }
     min_zoom: 14
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: farm
     table: osm
   - filter: {name: true, place: farm}
     min_zoom: 15
     output:
-      <<: [*output_properties, *alternate_fclass]
+      <<: [*output_properties, *alternate_fclass, *ne_zooms]
       kind: locality
       kind_detail: farm
       population: 50


### PR DESCRIPTION
### Background

#2020

When zooming across the NE <> OSM boundary around zoom 8, townspots shift position, population_rank values change, and min_zoom values change.

For country labels in the same places theme we do a join on WikidataID and apply the NE min_zoom to the OSM features.

We should do the same type of harvesting for localities. Namely:

OSM localities should get their population_rank and min_zoom values from NE.
The population value should not be adjusted, as that's for the incorporated area, while the NE population_rank is for the metro area and is more useful for label grading in the stylesheet.


### Changes
- Add export functions to export `__ne_max_zoom`, `__ne_min_zoom`, `__ne_pop_min` and `__ne_pop_max` to the json object
- Move the estimate population value that introduced in #1993 to a post_process function as the final fall-back values for population
- Use the population values from NE to calculate `population_rank` field
- Fix a bug that `{"population": None}` in the json object doesn't end up getting the default estimate population value.


#### Existing Test Changes
**1 Why there is a change necessary for
`integration-test.988-add-population-to-collision-rank.PopulationRankTest.test_0` ?**

In fact, this test breaks on master too, and this PR fixes it. 


**2 Why there is a change necessary for
`integration-test.988-add-population-to-collision-rank.PopulationRankTest.test_collision_rank_decreasing` ?**

When the data has tag `population: None` it falls into following filter line in places.yaml (surprisingly?!) https://github.com/tilezen/vector-datasource/blob/80799e74e0283a96b520c6fea8fa00455095e09b/yaml/places.yaml#L144 
and thus it won't have the hardcoded estimate population value `10000` for `kind_detail: city`, it will have population value be `0`. 

Because we moved the estimation population backfill logic from the yaml file to the transform function, and the transform function is executed at a later stage than the yaml file logic, now when tag `population: None` happens, it gets a chance to take the hardcoded estimate population value `10000`. And thus the `collision_rank` value changes and as a result, original test breaks. So one way to make this test pass again and more reasonable is to not start from tag `population: None` but from `population: 0`.


- [x] Update tests
- [x] Update docs
