### PR TITLE
admin level 3 + state/country = disputed_reference_line

### DIFF
--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -86,6 +86,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 909074085,
+                'kind': 'disputed_country'
             })
 
     def test_admin_level_3_country(self):
@@ -93,7 +94,6 @@ class DisputedBoundariesTest(FixtureTest):
 
         self.generate_fixtures(
             # this one is made up - just place = country
-            # TODO - this is currently confused by these lines overlapping.  Need to fix
             dsl.way(123456, dsl.tile_diagonal(z, x, y), {
                 'admin_level': '3',
                 'boundary': 'administrative',
@@ -105,6 +105,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 123456,
+                'kind': 'disputed_country'
             })
 
     def test_admin_level_3_other_place(self):

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -74,13 +74,16 @@ class DisputedBoundariesTest(FixtureTest):
                 'boundary': 'administrative',
                 'place': 'state',
                 'source': 'openstreetmap.org',
+                'admin_level:XX': '2'
             }),
         )
 
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 909074085,
-                'kind': 'disputed_country'
+                'kind': 'disputed_country',
+                'kind:xx': 'country',
+                'disputed': True,
             })
 
     def test_admin_level_3_country(self):
@@ -93,13 +96,16 @@ class DisputedBoundariesTest(FixtureTest):
                 'boundary': 'administrative',
                 'place': 'country',
                 'source': 'openstreetmap.org',
+                'admin_level:YY': '2'
             }),
         )
 
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 123456,
-                'kind': 'disputed_country'
+                'kind': 'disputed_country',
+                'kind:yy': 'country',
+                'disputed': True,
             })
 
     def test_admin_level_3_other_place(self):

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -110,7 +110,7 @@ class DisputedBoundariesTest(FixtureTest):
             dsl.way(345678, dsl.tile_diagonal(z, x, y), {
                 'admin_level': '3',
                 'boundary': 'administrative',
-                'place': 'I feel I am a country - do you agree?',
+                'place': 'Neither state nor country',
                 'source': 'openstreetmap.org',
             }),
         )

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -5,7 +5,7 @@ from . import FixtureTest
 
 
 class DisputedBoundariesTest(FixtureTest):
-    def test_add_dispute_yes(self):
+    def test_admin_level_viewpoint(self):
         z, x, y = (16, 39109, 26572)
 
         self.generate_fixtures(
@@ -69,3 +69,58 @@ class DisputedBoundariesTest(FixtureTest):
             'id': 726514231,
             'kind:VN': None
         })
+
+    def test_admin_level_3_state(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/way/909074085
+            dsl.way(909074085, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '3',
+                'boundary': 'administrative',
+                'place': 'state',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 909074085,
+            })
+
+    def test_admin_level_3_country(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # this one is made up - just place = country
+            # TODO - this is currently confused by these lines overlapping.  Need to fix
+            dsl.way(123456, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '3',
+                'boundary': 'administrative',
+                'place': 'country',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 123456,
+            })
+
+    def test_admin_level_3_other_place(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # also made up - we should ignore other place values
+            dsl.way(345678, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '3',
+                'boundary': 'administrative',
+                'place': 'I feel I am a country - do you agree?',
+                'source': 'openstreetmap.org',
+            }),
+        )
+
+        self.assert_no_matching_feature(
+            z, x, y, 'boundaries', {
+                'id': 345678,
+            })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -81,7 +81,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 909074085,
-                'kind': 'disputed_country',
+                'kind': 'disputed_reference_line',
                 'kind:xx': 'country',
                 'disputed': True,
             })
@@ -103,7 +103,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 123456,
-                'kind': 'disputed_country',
+                'kind': 'disputed_reference_line',
                 'kind:yy': 'country',
                 'disputed': True,
             })
@@ -118,6 +118,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'boundary': 'administrative',
                 'place': 'Neither state nor country',
                 'source': 'openstreetmap.org',
+                'admin_level:ZZ': '2'
             }),
         )
 

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -186,6 +186,7 @@ filters:
     output:
       <<: *output_properties
       kind: disputed_country
+      disputed: True
     table: osm
   - filter:
       all:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -175,6 +175,18 @@ filters:
   - filter:
       all:
         - geom_type: line
+        - admin_level: '3'
+        - any:
+            - place: 'state'
+            - place: 'country'
+    min_zoom: 8
+    output:
+      <<: *output_properties
+      kind: disputed_country
+    table: osm
+  - filter:
+      all:
+        - geom_type: line
         - disputed_by: true
         - any:
             - dispute: 'yes'

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -185,7 +185,7 @@ filters:
     min_zoom: 8
     output:
       <<: *output_properties
-      kind: disputed_country
+      kind: disputed_reference_line
       disputed: True
     table: osm
   - filter:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -175,6 +175,8 @@ filters:
       <<: *output_properties
       kind: county
     table: osm
+  # this filter covers admin_level 3 boundaries for countries and states,
+  # turning them into disputed_reference_lines
   - filter:
       all:
         - geom_type: line


### PR DESCRIPTION
Need to handle hong kong / cyprus and a few other disputed admin_level 3 boundaries.  This turns any admin_level 3 place=state/country into a place=disputed_reference_line using a new filter in boundaries.yaml