### PR TITLE
Rework high zoom OSM disputed, disputed_claim, and disputed_reference_lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Vector tiles are served by clipping geometries to the tile bounding box, and the
 
 When changes are made to OpenStreetMap or another map [data sources](docs/data-sources.md), rather than waiting for an image tile to be redrawn, only the geometry coordinates and feature attributes for that particular building or road need to be updated in the vector tile.
 
-Depending on the URL syntax, Mapzen vector tiles can return all of the map data, or just individual [layers](docs/layers.md), or combinations of layers, including water, earth, landuse, roads, buildings and points of interest.
+Depending on the URL syntax, Mapzen vector tiles can return all of the map data, or just individual [layers](docs/layers.md), or combinations of layers, including water, earth, landuse, roads, buildings and points of interest(POI).
 
 ### Build from source
 

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -248,14 +248,14 @@ class CountryBoundaryTest(FixtureTest):
                 props = feature['properties']
                 kind = props.get('kind')
 
-                if kind == 'country':
+                if kind == 'disputed_reference_line':
                     # generally accepted viewpoint, XA should dispute
                     self.assertEqual(
-                        props.get('kind:xa'), 'unrecognized_country')
+                        props.get('kind:xa'), 'unrecognized')
                     self.assertEqual(props.get('name'), 'XB')
                     saw_xb = True
 
-                elif kind == 'unrecognized_country':
+                elif kind == 'disputed_claim':
                     # XA's viewpoint, which should claim it as part of XA
                     self.assertEqual(props.get('kind:xa'), 'country')
                     self.assertEqual(props.get('name'), "Extent of XA's claim")
@@ -439,8 +439,8 @@ class RegionBoundary(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'boundaries', {
-                'kind': 'region',
-                'kind:xb': 'unrecognized_region',
+                'kind': 'disputed_reference_line',
+                'kind:xb': 'unrecognized',
                 'name': 'XA region 2',
             })
 
@@ -469,8 +469,9 @@ class RegionBoundary(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'boundaries', {
-                'kind': 'unrecognized_region',
+                'kind': 'disputed_claim',
                 'kind:xa': 'region',
+                'kind:xb': 'unrecognized',
             })
 
 
@@ -504,8 +505,8 @@ class CountyBoundary(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'boundaries', {
-                'kind': 'county',
-                'kind:xb': 'unrecognized_county',
+                'kind': 'disputed_reference_line',
+                'kind:xb': 'unrecognized',
                 'name': 'XA county 2',
             })
 
@@ -534,7 +535,7 @@ class CountyBoundary(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'boundaries', {
-                'kind': 'unrecognized_county',
+                'kind': 'disputed_claim',
                 'kind:xa': 'county',
             })
 

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -58,7 +58,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind': 'disputed_reference_line',
                 'kind:us': 'region',
                 # in the absence of a admin_level:XX, the disputed_by tag dictates the kind
-                'kind:xx': 'unrecognized_region',
+                'kind:xx': 'unrecognized',
                 # verifies the admin_level:SA overrides the disputed_by
                 'kind:sa': 'region',
                 'dispute_id': 'B91',
@@ -70,7 +70,7 @@ class DisputedBoundariesTest(FixtureTest):
             'kind:vn': None
         })
 
-    def test_disputed_by_to_unrecognized_disputed_reference_line(self):
+    def test_disputed_by_to_unrecognized(self):
         z, x, y = (16, 53533, 28559)
 
         self.generate_fixtures(
@@ -89,14 +89,14 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 13574166,
-                'kind:ru': 'unrecognized_country',
-                'kind:pk': 'unrecognized_country',
-                'kind:il': 'unrecognized_country',
-                'kind:ps': 'unrecognized_country',
-                'kind:sa': 'unrecognized_country',
-                'kind:eg': 'unrecognized_country',
-                'kind:id': 'unrecognized_country',
-                'kind:bd': 'unrecognized_country',
+                'kind:ru': 'unrecognized',
+                'kind:pk': 'unrecognized',
+                'kind:il': 'unrecognized',
+                'kind:ps': 'unrecognized',
+                'kind:sa': 'unrecognized',
+                'kind:eg': 'unrecognized',
+                'kind:id': 'unrecognized',
+                'kind:bd': 'unrecognized',
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
                 'dispute_id': 'B16_1746705859;1746705871',
@@ -130,9 +130,9 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind': 'disputed_claim',
                 'kind:cn': 'country',
                 'kind:tw': 'country',
-                'kind:in': 'unrecognized_country',
-                'kind:pk': 'unrecognized_country',
-                'kind:tr': 'unrecognized_country',
+                'kind:in': 'unrecognized',
+                'kind:pk': 'unrecognized',
+                'kind:tr': 'unrecognized',
                 'kind:ru': 'country',
                 'dispute_id': 'B02_1746705405'
             })
@@ -161,9 +161,9 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 202058477,
                 'kind': 'disputed_claim',
-                'kind:in': 'unrecognized_country',
-                'kind:pk': 'unrecognized_country',
-                'kind:tr': 'unrecognized_country',
+                'kind:in': 'unrecognized',
+                'kind:pk': 'unrecognized',
+                'kind:tr': 'unrecognized',
                 'dispute_id': 'B02_1746705405'
             })
 
@@ -188,7 +188,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 202058477,
-                'kind:in': 'unrecognized_country',
+                'kind:in': 'unrecognized',
                 'kind:cn': 'country',
                 'kind:tw': 'country',
                 'kind:ru': 'country',

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -185,7 +185,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 202058477,
-                'kind': 'unrecognized_country',
+                'kind': 'disputed_claim',
                 'kind:cn': 'country',
                 'kind:tw': 'country',
                 'kind:in': 'unrecognized_country',
@@ -217,7 +217,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 202058477,
-                'kind': 'unrecognized_country',
+                'kind': 'disputed_claim',
                 'kind:in': 'unrecognized_country',
                 'kind:pk': 'unrecognized_country',
                 'kind:tr': 'unrecognized_country',

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -189,20 +189,20 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:in': 'unrecognized_disputed_reference_line',
                 'kind:pk': 'unrecognized_disputed_reference_line',
                 'kind:tr': 'unrecognized_disputed_reference_line',
+                'kind:ru': 'country',
             })
-
-    # TODO add a testcase for recognized_by
 
     def test_boundary_dispute_disputed_by_claimed_by(self):
         z, x, y = (16, 53533, 28559)
 
         self.generate_fixtures(
-            # https://www.openstreetmap.org/relation/13574166
+            # https://www.openstreetmap.org/relation/202058477
             dsl.way(202058477, dsl.tile_diagonal(z, x, y), {
                 'admin_level': '2',
                 'boundary': 'disputed',
                 'claimed_by': 'IN',
                 'disputed_by': 'CN;RU;TW',
+                'recognized_by': 'XX;YY',
                 'name': 'Extent of Indian Claim at Bara Hotii Valleys',
                 'ne:brk_a3': 'B02',
                 'ne_id': '1746708469',
@@ -212,11 +212,13 @@ class DisputedBoundariesTest(FixtureTest):
 
         self.assert_has_feature(
             z, x, y, 'boundaries', {
-                'id': 13574166,
+                'id': 202058477,
                 'disputed': True,
                 'kind:in': 'country',
                 'kind:cn': 'unrecognized_disputed_reference_line',
                 'kind:ru': 'unrecognized_disputed_reference_line',
                 'kind:tw': 'unrecognized_disputed_reference_line',
-                'kind': 'disputed_reference_line'
+                'kind': 'disputed_reference_line',
+                'kind:xx': 'country',
+                'kind:yy': 'country'
             })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -84,7 +84,6 @@ class DisputedBoundariesTest(FixtureTest):
                 'id': 909074085,
                 'kind': 'disputed_reference_line',
                 'kind:xx': 'country',
-                'disputed': True,
                 'kind:yy': 'country',
             })
 
@@ -109,7 +108,6 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind': 'disputed_reference_line',
                 'kind:xx': 'country',
                 'kind:yy': 'country',
-                'disputed': True,
             })
 
     def test_admin_level_3_other_place(self):
@@ -150,7 +148,6 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 13574166,
-                'disputed': True,
                 'kind:ru': 'unrecognized_disputed_reference_line',
                 'kind:pk': 'unrecognized_disputed_reference_line',
                 'kind:il': 'unrecognized_disputed_reference_line',
@@ -248,7 +245,6 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 202058477,
-                'disputed': True,
                 'kind:in': 'unrecognized_disputed_reference_line',
                 'kind:cn': 'country',
                 'kind:tw': 'country',
@@ -277,7 +273,6 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 202058477,
-                'disputed': True,
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
             })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -61,6 +61,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:xx': 'unrecognized_region',
                 # verifies the admin_level:SA overrides the disputed_by
                 'kind:sa': 'region',
+                'dispute_id': 'B91',
             })
 
         # make sure kind:vn didn't make it in because its admin_level doesn't map to anything
@@ -98,6 +99,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:bd': 'unrecognized_country',
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
+                'dispute_id': 'B16_1746705859;1746705871',
             })
 
     def test_boundary_claim_disputed_by_claimed_by(self):
@@ -132,6 +134,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:pk': 'unrecognized_country',
                 'kind:tr': 'unrecognized_country',
                 'kind:ru': 'country',
+                'dispute_id': 'B02_1746705405'
             })
 
     def test_boundary_claim_disputed_by_only(self):
@@ -161,6 +164,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:in': 'unrecognized_country',
                 'kind:pk': 'unrecognized_country',
                 'kind:tr': 'unrecognized_country',
+                'dispute_id': 'B02_1746705405'
             })
 
     def test_boundary_dispute_disputed_by_claimed_by(self):
@@ -192,6 +196,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:tr': 'country',
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
+                'dispute_id': 'B07_1746705319'
             })
 
     def test_boundary_dispute_no_disputed_by_claimed_by(self):
@@ -214,6 +219,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'id': 202058477,
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
+                'dispute_id': 'B02_1746708469',
             })
 
     def test_places_disputed_by(self):

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -82,6 +82,7 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 909074085,
                 'kind': 'disputed_reference_line',
+                'kind_detail': '2',
                 'kind:xx': 'country',
                 'disputed': True,
             })
@@ -104,6 +105,7 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 123456,
                 'kind': 'disputed_reference_line',
+                'kind_detail': '2',
                 'kind:yy': 'country',
                 'disputed': True,
             })
@@ -155,7 +157,8 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:eg': 'unrecognized_disputed_reference_line',
                 'kind:id': 'unrecognized_disputed_reference_line',
                 'kind:bd': 'unrecognized_disputed_reference_line',
-                'kind': 'disputed_reference_line'
+                'kind': 'disputed_reference_line',
+                'kind_detail': '2',
             })
 
     def test_boundary_claim_disputed_by_claimed_by(self):
@@ -219,6 +222,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:ru': 'unrecognized_disputed_reference_line',
                 'kind:tw': 'unrecognized_disputed_reference_line',
                 'kind': 'disputed_reference_line',
+                'kind_detail': '2',
                 'kind:xx': 'country',
                 'kind:yy': 'country'
             })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -275,3 +275,57 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
             })
+
+    def test_places_disputed_by(self):
+        import dsl
+
+        z, x, y = (10, 11, 12)
+
+        import dsl
+
+        z, x, y = (10, 725, 402)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/316441092
+            dsl.point(316441092, (75.0000023, 35.9999972), {
+                'description': u'Formed in 1970 from the amalgamation of the Gilgit Agency, the Baltistan District of the Ladakh Wazarat, and the states of Hunza and Nagar.',
+                'gns:dsg': u'ADMD',
+                'gns:uni': u'-3846588',
+                'is_in:country': u'Pakistan',
+                'name': u'گلگت بلتستان',
+                'name:ar': u'غلغت-بلتستان',
+                'name:bft': u'གིལྒིཏ་བལྟིསྟན',
+                'name:en': u'Gilgit-Baltistan',
+                'name:fr': u'Gilgit-Baltistan',
+                'name:hi': u'गिलगित-बल्तिस्तान',
+                'name:hu': u'Északi területek',
+                'name:ja': u'ギルギット・バルティスタン',
+                'name:ko': u'길기트발티스탄',
+                'name:pl': u'Gilgit-Baltistan',
+                'name:ru': u'Гилгит-Балтистан',
+                'name:uk': u'Гілгіт-Балтистан',
+                'name:ur': u'گلگت - بلتستان',
+                'name:vi': u'Gilgit-Baltistan',
+                'old_name': u'Northern Areas;Federally Administered Northern Areas;FANA',
+                'old_name:de': u'Nordgebiete',
+                'old_name:ru': u'Северная территория',
+                'old_name:ur': u'شمالی علاقہ جات, Shumālī Ilāqe Jāt',
+                'old_name:vi': u'Các khu vực phía Bắc',
+                'place': u'state',
+                'population': u'1800000',
+                'ref': u'NA',
+                'source': u'openstreetmap.org',
+                'state_code': u'NA',
+                'wikidata': u'Q200697',
+                'wikipedia': u'en:Gilgit-Baltistan',
+                'disputed_by': 'IN,XX',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 316441092,
+                'kind': 'region',
+                'kind:in': 'unrecognized',
+                'kind:xx': 'unrecognized'
+            })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -82,7 +82,6 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 909074085,
                 'kind': 'disputed_reference_line',
-                'kind_detail': '2',
                 'kind:xx': 'country',
                 'disputed': True,
             })
@@ -105,7 +104,6 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 123456,
                 'kind': 'disputed_reference_line',
-                'kind_detail': '2',
                 'kind:yy': 'country',
                 'disputed': True,
             })
@@ -254,4 +252,27 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind_detail': '2',
                 'kind:xx': 'country',
                 'kind:yy': 'country'
+            })
+
+    def test_boundary_dispute_no_disputed_by_claimed_by(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/202058477
+            dsl.way(202058477, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '2',
+                'boundary': 'disputed',
+                'name': 'Extent of Indian Claim at Bara Hotii Valleys',
+                'ne:brk_a3': 'B02',
+                'ne_id': '1746708469',
+                'type': 'linestring',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 202058477,
+                'disputed': True,
+                'kind': 'disputed_reference_line',
+                'kind_detail': '2',
             })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -75,7 +75,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'place': 'state',
                 'source': 'openstreetmap.org',
                 'admin_level:XX': '2',
-                'recognized_by:': 'YY'
+                'recognized_by': 'YY'
             }),
         )
 

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -147,13 +147,13 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 13574166,
                 'disputed': True,
-                'kind:ru': 'disputed_reference_line',
-                'kind:pk': 'disputed_reference_line',
-                'kind:il': 'disputed_reference_line',
-                'kind:ps': 'disputed_reference_line',
-                'kind:sa': 'disputed_reference_line',
-                'kind:eg': 'disputed_reference_line',
-                'kind:id': 'disputed_reference_line',
-                'kind:bd': 'disputed_reference_line',
-                'kind': 'unrecognized_disputed_reference_line'
+                'kind:ru': 'unrecognized_disputed_reference_line',
+                'kind:pk': 'unrecognized_disputed_reference_line',
+                'kind:il': 'unrecognized_disputed_reference_line',
+                'kind:ps': 'unrecognized_disputed_reference_line',
+                'kind:sa': 'unrecognized_disputed_reference_line',
+                'kind:eg': 'unrecognized_disputed_reference_line',
+                'kind:id': 'unrecognized_disputed_reference_line',
+                'kind:bd': 'unrecognized_disputed_reference_line',
+                'kind': 'disputed_reference_line'
             })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -157,3 +157,66 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:bd': 'unrecognized_disputed_reference_line',
                 'kind': 'disputed_reference_line'
             })
+
+    def test_boundary_claim_disputed_by_claimed_by(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/13574166
+            dsl.way(202058477, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '2',
+                'boundary': 'claim',
+                'claimed_by': 'CN;TW',
+                'disputed_by': 'IN;PK;TR',
+                'name': 'Extent of Chinese Claim - ﻿Bara Hoti area',
+                'name:de': 'Ausdehnung des chinesischen Anspruchs',
+                'name:en': 'Extent of Chinese Claim - ﻿Bara Hoti area',
+                'name:zh': '中国声称边境线',
+                'name:zh_pinyin': 'Zhōngguó shēngchēng biānjìng xiàn',
+                'ne:brk_a3': 'B02',
+                'ne_id': '1746705405',
+                'recognized_by': 'RU',
+                'type': 'linestring',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 202058477,
+                'kind': 'unrecognized_country',
+                'kind:cn': 'country',
+                'kind:tw': 'country',
+                'kind:in': 'unrecognized_disputed_reference_line',
+                'kind:pk': 'unrecognized_disputed_reference_line',
+                'kind:tr': 'unrecognized_disputed_reference_line',
+            })
+
+    # TODO add a testcase for recognized_by
+
+    def test_boundary_dispute_disputed_by_claimed_by(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/13574166
+            dsl.way(202058477, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '2',
+                'boundary': 'disputed',
+                'claimed_by': 'IN',
+                'disputed_by': 'CN;RU;TW',
+                'name': 'Extent of Indian Claim at Bara Hotii Valleys',
+                'ne:brk_a3': 'B02',
+                'ne_id': '1746708469',
+                'type': 'linestring',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 13574166,
+                'disputed': True,
+                'kind:in': 'country',
+                'kind:cn': 'unrecognized_disputed_reference_line',
+                'kind:ru': 'unrecognized_disputed_reference_line',
+                'kind:tw': 'unrecognized_disputed_reference_line',
+                'kind': 'disputed_reference_line'
+            })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -84,12 +84,9 @@ class DisputedBoundariesTest(FixtureTest):
             }),
         )
 
-        self.assert_has_feature(
+        self.assert_no_matching_feature(
             z, x, y, 'boundaries', {
                 'id': 909074085,
-                'kind': 'disputed_reference_line',
-                'kind:xx': 'country',
-                'kind:yy': 'country',
             })
 
     def test_admin_level_3_country(self):
@@ -107,12 +104,9 @@ class DisputedBoundariesTest(FixtureTest):
             }),
         )
 
-        self.assert_has_feature(
+        self.assert_no_matching_feature(
             z, x, y, 'boundaries', {
                 'id': 123456,
-                'kind': 'disputed_reference_line',
-                'kind:xx': 'country',
-                'kind:yy': 'country',
             })
 
     def test_admin_level_3_other_place(self):

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -126,3 +126,34 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 345678,
             })
+
+    def test_disputed_by_to_unrecognized_disputed_reference_line(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/13574166
+            dsl.way(13574166, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '2',
+                'boundary': 'disputed',
+                'disputed_by': 'RU;PK;IL;PS;SA;EG;ID;BD',
+                'name': '1949 Israeli-Syrian DMZ',
+                'ne:brk_a3': 'B16',
+                'ne_id': '1746705859;1746705871',
+                'type': 'linestring',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 13574166,
+                'disputed': True,
+                'kind:ru': 'disputed_reference_line',
+                'kind:pk': 'disputed_reference_line',
+                'kind:il': 'disputed_reference_line',
+                'kind:ps': 'disputed_reference_line',
+                'kind:sa': 'disputed_reference_line',
+                'kind:eg': 'disputed_reference_line',
+                'kind:id': 'disputed_reference_line',
+                'kind:bd': 'disputed_reference_line',
+                'kind': 'unrecognized_disputed_reference_line'
+            })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -188,9 +188,9 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind': 'unrecognized_country',
                 'kind:cn': 'country',
                 'kind:tw': 'country',
-                'kind:in': 'unrecognized_disputed_reference_line',
-                'kind:pk': 'unrecognized_disputed_reference_line',
-                'kind:tr': 'unrecognized_disputed_reference_line',
+                'kind:in': 'unrecognized_country',
+                'kind:pk': 'unrecognized_country',
+                'kind:tr': 'unrecognized_country',
                 'kind:ru': 'country',
             })
 
@@ -218,9 +218,9 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 202058477,
                 'kind': 'unrecognized_country',
-                'kind:in': 'unrecognized_disputed_reference_line',
-                'kind:pk': 'unrecognized_disputed_reference_line',
-                'kind:tr': 'unrecognized_disputed_reference_line',
+                'kind:in': 'unrecognized_country',
+                'kind:pk': 'unrecognized_country',
+                'kind:tr': 'unrecognized_country',
             })
 
     def test_boundary_dispute_disputed_by_claimed_by(self):

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -230,12 +230,13 @@ class DisputedBoundariesTest(FixtureTest):
             dsl.way(202058477, dsl.tile_diagonal(z, x, y), {
                 'admin_level': '2',
                 'boundary': 'disputed',
-                'claimed_by': 'IN',
-                'disputed_by': 'CN;RU;TW',
-                'recognized_by': 'XX;YY',
-                'name': 'Extent of Indian Claim at Bara Hotii Valleys',
-                'ne:brk_a3': 'B02',
-                'ne_id': '1746708469',
+                'claimed_by': 'CN;TW',
+                'disputed_by': 'IN',
+                'name': 'Extent', 'of': 'Chinese', 'Claim': 'at', 'Aksai': 'Chin',
+                'name:ur': 'اکسائی', 'چن': 'میں', 'چینی': 'دعوے', 'کی': 'حد',
+                'ne:brk_a3': 'B07',
+                'ne_id': '1746705319',
+                'recognized_by': 'RU;PK;TR',
                 'type': 'linestring',
             }),
         )
@@ -244,14 +245,14 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 202058477,
                 'disputed': True,
-                'kind:in': 'country',
-                'kind:cn': 'unrecognized_disputed_reference_line',
-                'kind:ru': 'unrecognized_disputed_reference_line',
-                'kind:tw': 'unrecognized_disputed_reference_line',
+                'kind:in': 'unrecognized_disputed_reference_line',
+                'kind:cn': 'country',
+                'kind:tw': 'country',
+                'kind:ru': 'country',
+                'kind:pk': 'country',
+                'kind:tr': 'country',
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
-                'kind:xx': 'country',
-                'kind:yy': 'country'
             })
 
     def test_boundary_dispute_no_disputed_by_claimed_by(self):

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -195,6 +195,35 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:ru': 'country',
             })
 
+    def test_boundary_claim_disputed_by_only(self):
+        z, x, y = (16, 53533, 28559)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/relation/13574166
+            dsl.way(202058477, dsl.tile_diagonal(z, x, y), {
+                'admin_level': '2',
+                'boundary': 'claim',
+                'disputed_by': 'IN;PK;TR',
+                'name': 'Extent of Chinese Claim - ﻿Bara Hoti area',
+                'name:de': 'Ausdehnung des chinesischen Anspruchs',
+                'name:en': 'Extent of Chinese Claim - ﻿Bara Hoti area',
+                'name:zh': '中国声称边境线',
+                'name:zh_pinyin': 'Zhōngguó shēngchēng biānjìng xiàn',
+                'ne:brk_a3': 'B02',
+                'ne_id': '1746705405',
+                'type': 'linestring',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'boundaries', {
+                'id': 202058477,
+                'kind': 'unrecognized_country',
+                'kind:in': 'unrecognized_disputed_reference_line',
+                'kind:pk': 'unrecognized_disputed_reference_line',
+                'kind:tr': 'unrecognized_disputed_reference_line',
+            })
+
     def test_boundary_dispute_disputed_by_claimed_by(self):
         z, x, y = (16, 53533, 28559)
 

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -329,3 +329,49 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:in': 'unrecognized',
                 'kind:xx': 'unrecognized'
             })
+
+    def test_places_with_viewpoints(self):
+        import dsl
+
+        z, x, y = (10, 856, 441)
+
+        self.generate_fixtures(
+            # https://www.openstreetmap.org/node/432425099
+            dsl.point(432425099, (120.9820179, 23.9739374), {
+                'name': u'臺灣',
+                'name:en': u'Taiwan',
+                'place': u'country',
+                'place:CN': 'state',
+                # the rest of these place:xx are made up
+                'place:US': 'country',
+                'place:PK': 'region',
+                'place:IN': 'county',
+                'place:RU': 'district',
+                'place:JP': 'locality',
+                'place:IT': 'town',
+                'place:TR': 'not_there',
+                'place:XX': 'country',
+                'source': u'openstreetmap.org',
+                'source:sqkm': u'CIA World Factbook',
+            }),
+        )
+
+        self.assert_has_feature(
+            z, x, y, 'places', {
+                'id': 432425099,
+                'kind': 'country',
+                'kind:cn': 'region',
+                'kind:us': 'country',
+                'kind:pk': 'region',
+                'kind:in': 'county',
+                'kind:ru': 'county',
+                'kind:jp': 'locality',
+                'kind:it': 'locality'
+            })
+
+        self.assert_no_matching_feature(
+            z, x, y, 'places', {
+                'id': 432425099,
+                'kind:tr': None,  # invalid place type not converted to a kind
+                'kind:xx': None,  # invalid viewpoint not exported
+            })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -42,8 +42,9 @@ class DisputedBoundariesTest(FixtureTest):
                 'admin_level:UA': '4',
                 'admin_level:US': '4',
                 'admin_level:VN': '2.5',
-                'boundary': 'claim',
+                'boundary': 'disputed',
                 'name': 'Viewpoints on Disputed Administrative Boundaries',
+                'disputed_by': 'SA,XX',
                 'ne:brk_a3': 'B91',
                 'type': 'linestring',
                 'source': 'openstreetmap.org',
@@ -54,8 +55,12 @@ class DisputedBoundariesTest(FixtureTest):
             z, x, y, 'boundaries', {
                 'id': 726514231,
                 'kind:ps': 'locality',
-                'kind': 'region',
+                'kind': 'disputed_reference_line',
                 'kind:us': 'region',
+                # in the absence of a admin_level:XX, the disputed_by tag dictates the kind
+                'kind:xx': 'unrecognized_region',
+                # verifies the admin_level:SA overrides the disputed_by
+                'kind:sa': 'region',
             })
 
         # make sure kind:vn didn't make it in because its admin_level doesn't map to anything

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -148,14 +148,14 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 13574166,
-                'kind:ru': 'unrecognized_disputed_reference_line',
-                'kind:pk': 'unrecognized_disputed_reference_line',
-                'kind:il': 'unrecognized_disputed_reference_line',
-                'kind:ps': 'unrecognized_disputed_reference_line',
-                'kind:sa': 'unrecognized_disputed_reference_line',
-                'kind:eg': 'unrecognized_disputed_reference_line',
-                'kind:id': 'unrecognized_disputed_reference_line',
-                'kind:bd': 'unrecognized_disputed_reference_line',
+                'kind:ru': 'unrecognized_country',
+                'kind:pk': 'unrecognized_country',
+                'kind:il': 'unrecognized_country',
+                'kind:ps': 'unrecognized_country',
+                'kind:sa': 'unrecognized_country',
+                'kind:eg': 'unrecognized_country',
+                'kind:id': 'unrecognized_country',
+                'kind:bd': 'unrecognized_country',
                 'kind': 'disputed_reference_line',
                 'kind_detail': '2',
             })
@@ -245,7 +245,7 @@ class DisputedBoundariesTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'id': 202058477,
-                'kind:in': 'unrecognized_disputed_reference_line',
+                'kind:in': 'unrecognized_country',
                 'kind:cn': 'country',
                 'kind:tw': 'country',
                 'kind:ru': 'country',

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -69,65 +69,6 @@ class DisputedBoundariesTest(FixtureTest):
             'kind:vn': None
         })
 
-    def test_admin_level_3_state(self):
-        z, x, y = (16, 53533, 28559)
-
-        self.generate_fixtures(
-            # https://www.openstreetmap.org/way/909074085
-            dsl.way(909074085, dsl.tile_diagonal(z, x, y), {
-                'admin_level': '3',
-                'boundary': 'administrative',
-                'place': 'state',
-                'source': 'openstreetmap.org',
-                'admin_level:XX': '2',
-                'recognized_by': 'YY'
-            }),
-        )
-
-        self.assert_no_matching_feature(
-            z, x, y, 'boundaries', {
-                'id': 909074085,
-            })
-
-    def test_admin_level_3_country(self):
-        z, x, y = (16, 53533, 28559)
-
-        self.generate_fixtures(
-            # this one is made up - just place = country
-            dsl.way(123456, dsl.tile_diagonal(z, x, y), {
-                'admin_level': '3',
-                'boundary': 'administrative',
-                'place': 'country',
-                'source': 'openstreetmap.org',
-                'admin_level:XX': '2',
-                'recognized_by': 'YY',
-            }),
-        )
-
-        self.assert_no_matching_feature(
-            z, x, y, 'boundaries', {
-                'id': 123456,
-            })
-
-    def test_admin_level_3_other_place(self):
-        z, x, y = (16, 53533, 28559)
-
-        self.generate_fixtures(
-            # also made up - we should ignore other place values
-            dsl.way(345678, dsl.tile_diagonal(z, x, y), {
-                'admin_level': '3',
-                'boundary': 'administrative',
-                'place': 'Neither state nor country',
-                'source': 'openstreetmap.org',
-                'admin_level:ZZ': '2'
-            }),
-        )
-
-        self.assert_no_matching_feature(
-            z, x, y, 'boundaries', {
-                'id': 345678,
-            })
-
     def test_disputed_by_to_unrecognized_disputed_reference_line(self):
         z, x, y = (16, 53533, 28559)
 
@@ -232,8 +173,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'boundary': 'disputed',
                 'claimed_by': 'CN;TW',
                 'disputed_by': 'IN',
-                'name': 'Extent', 'of': 'Chinese', 'Claim': 'at', 'Aksai': 'Chin',
-                'name:ur': 'اکسائی', 'چن': 'میں', 'چینی': 'دعوے', 'کی': 'حد',
+                'name': 'Extent of Chinese Claim at Aksai Chin',
                 'ne:brk_a3': 'B07',
                 'ne_id': '1746705319',
                 'recognized_by': 'RU;PK;TR',

--- a/osm2pgsql.lua
+++ b/osm2pgsql.lua
@@ -499,6 +499,10 @@ function osm2pgsql.process_way(object)
         output_hstore.recognized_by = nil
     end
 
+    if object.tags.boundary == 'disputed' then
+        output_hstore.boundary = 'administrative'
+    end
+
 -- Adds tags to redefine Taiwan admin levels. Applies to both relation and ways
     for k, v in pairs(twadmin) do
         if k == object.id then

--- a/osm2pgsql.lua
+++ b/osm2pgsql.lua
@@ -492,6 +492,13 @@ function osm2pgsql.process_way(object)
     local z_order, roads = get_z_order(object.tags)
     output.z_order = z_order
 
+-- Stripped disputed tags off of ways
+    if object.tags.claimed_by or object.tags.disputed_by or object.tags.recognized_by then
+        output_hstore.claimed_by = nil
+        output_hstore.disputed_by = nil
+        output_hstore.recognized_by = nil
+    end
+
 -- Adds tags to redefine Taiwan admin levels. Applies to both relation and ways
     for k, v in pairs(twadmin) do
         if k == object.id then

--- a/osm2pgsql.lua
+++ b/osm2pgsql.lua
@@ -564,6 +564,9 @@ function osm2pgsql.process_way(object)
             if v.recognized_by_by then
                 output_hstore.recognized_by = v.recognized_by
             end
+            if v.boundary == 'administrative' then
+                output_hstore.boundary = 'disputed'
+            end
         end
     end
 

--- a/osm2pgsql.lua
+++ b/osm2pgsql.lua
@@ -495,6 +495,7 @@ function osm2pgsql.process_way(object)
 -- Adds tags to redefine Taiwan admin levels. Applies to both relation and ways
     for k, v in pairs(twadmin) do
         if k == object.id then
+            output_hstore.admin_level = '4'
             output_hstore['admin_level:AR'] = '4'
             output_hstore['admin_level:BD'] = '4'
             output_hstore['admin_level:BR'] = '4'
@@ -627,6 +628,7 @@ function osm2pgsql.process_relation(object)
                     twadmin[member.ref] = object.id
                 end
             end
+            output_hstore.admin_level = '4'
             output_hstore['admin_level:AR'] = '4'
             output_hstore['admin_level:BD'] = '4'
             output_hstore['admin_level:BR'] = '4'
@@ -685,7 +687,36 @@ function osm2pgsql.process_relation(object)
     end
 
     if type == 'boundary' and (object.tags['ISO3166-1'] == 'MO' or object.tags['ISO3166-1'] == 'HK') then
+        output_hstore['admin_level:AR'] = '2'
+        output_hstore['admin_level:BD'] = '2'
+        output_hstore['admin_level:BR'] = '2'
         output_hstore['admin_level:CN'] = '4'
+        output_hstore['admin_level:DE'] = '2'
+        output_hstore['admin_level:EG'] = '2'
+        output_hstore['admin_level:ES'] = '2'
+        output_hstore['admin_level:FR'] = '2'
+        output_hstore['admin_level:GB'] = '2'
+        output_hstore['admin_level:GR'] = '2'
+        output_hstore['admin_level:ID'] = '2'
+        output_hstore['admin_level:IL'] = '2'
+        output_hstore['admin_level:IN'] = '2'
+        output_hstore['admin_level:IT'] = '2'
+        output_hstore['admin_level:JP'] = '2'
+        output_hstore['admin_level:KO'] = '2'
+        output_hstore['admin_level:MA'] = '2'
+        output_hstore['admin_level:NL'] = '2'
+        output_hstore['admin_level:NP'] = '2'
+        output_hstore['admin_level:PK'] = '2'
+        output_hstore['admin_level:PL'] = '2'
+        output_hstore['admin_level:PS'] = '2'
+        output_hstore['admin_level:PT'] = '2'
+        output_hstore['admin_level:SA'] = '2'
+        output_hstore['admin_level:SE'] = '2'
+        output_hstore['admin_level:TR'] = '2'
+        output_hstore['admin_level:TW'] = '2'
+        output_hstore['admin_level:UA'] = '2'
+        output_hstore['admin_level:US'] = '2'
+        output_hstore['admin_level:VN'] = '2'
     end
 
     if enable_legacy_route_processing and (hstore or hstore_all) and type == 'route' then

--- a/osm2pgsql.lua
+++ b/osm2pgsql.lua
@@ -422,28 +422,28 @@ function osm2pgsql.process_node(object)
     end
 
 -- Add POV tags to certain place nodes to change label rendering
--- Arunachal Pradesh
-    if type == 'place' and object.tags.wikidata == 'Q1162' then
+-- Hide Arunachal Pradesh region label for China POV
+    if object.tags.place and object.tags.wikidata == 'Q1162' then
         output_hstore['disputed_by'] = 'CN'
     end
--- Gilgit-Baltistan
-    if type == 'place' and object.tags.wikidata == 'Q200697' then
+-- Hide Gilgit-Baltistan region label for India POV
+    if object.tags.place and object.tags.wikidata == 'Q200697' then
         output_hstore['disputed_by'] = 'IN'
     end
--- Azad Kashmir
-    if type == 'place' and object.tags.wikidata == 'Q200130' then
+-- Hide Azad Kashmir region label for India POV
+    if object.tags.place and object.tags.wikidata == 'Q200130' then
         output_hstore['disputed_by'] = 'IN'
     end
--- Ladakh
-    if type == 'place' and object.tags.wikidata == 'Q200667' then
+-- Hide Ladakh region label for Pakistan POV
+    if object.tags.place and object.tags.wikidata == 'Q200667' then
         output_hstore['disputed_by'] = 'PK'
     end
--- Taiwan country label
-    if type == 'place' and object.tags.wikidata == 'Q865' then
+-- Recast Taiwan country label as region label for China POV
+    if object.tags.place and object.tags.wikidata == 'Q865' then
         output_hstore['place:CN'] = 'region'
     end
--- Taiwan city labels
-    if type == 'place' and (object.tags.wikidata == 'Q133865' or object.tags.wikidata == 'Q166977' or
+-- Recast Taiwan region to county labels for China POV
+    if object.tags.place and (object.tags.wikidata == 'Q133865' or object.tags.wikidata == 'Q166977' or
     object.tags.wikidata == 'Q249995' or object.tags.wikidata == 'Q74054' or object.tags.wikidata == 'Q249994' or
     object.tags.wikidata == 'Q249868' or object.tags.wikidata == 'Q181557' or object.tags.wikidata == 'Q249996' or
     object.tags.wikidata == 'Q249870' or object.tags.wikidata == 'Q249872' or object.tags.wikidata == 'Q63706' or
@@ -451,11 +451,17 @@ function osm2pgsql.process_node(object)
     object.tags.wikidata == 'Q194989' or object.tags.wikidata == 'Q245023' or object.tags.wikidata == 'Q140631' or
     object.tags.wikidata == 'Q1867' or object.tags.wikidata == 'Q249904' or object.tags.wikidata == 'Q115256' or
     object.tags.wikidata == 'Q237258' or object.tags.wikidata == 'Q153221') then
-        output_hstore['place:CN'] = 'city'
+        output_hstore['place:CN'] = 'county'
     end
-
--- Kosovo country and district labels
-    if type == 'place' and (object.tags.wikidata == 'Q1246' or object.tags.wikidata == 'Q474651' or
+-- Recast Taiwan country label as region label for China POV
+    if object.tags.place and object.tags.wikidata == 'Q1246' then
+        output_hstore['place:CN'] = 'region'
+        output_hstore['place:RU'] = 'region'
+        output_hstore['place:IN'] = 'region'
+        output_hstore['place:GR'] = 'region'
+    end
+-- Hide Kosovo country and region labels for several POVs including China and Russia
+    if object.tags.place and (object.tags.wikidata == 'Q474651' or
     object.tags.wikidata == 'Q939112' or object.tags.wikidata == 'Q59074' or object.tags.wikidata == 'Q1008042' or
     object.tags.wikidata == 'Q739808' or object.tags.wikidata == 'Q991332' or object.tags.wikidata == 'Q248378' or
     object.tags.wikidata == 'Q963121' or object.tags.wikidata == 'Q786124' or object.tags.wikidata == 'Q124725' or
@@ -623,7 +629,6 @@ function osm2pgsql.process_relation(object)
                 end
                 disputed[member.ref] = object.tags
             end
-            output_hstore = nil
         end
     end
 

--- a/osm2pgsql.lua
+++ b/osm2pgsql.lua
@@ -553,7 +553,7 @@ function osm2pgsql.process_way(object)
             if v.claimed_by then
                 output_hstore.claimed_by = v.claimed_by
             end
-            if v.recognized_by_by then
+            if v.recognized_by then
                 output_hstore.recognized_by = v.recognized_by
             end
         end

--- a/queries.yaml
+++ b/queries.yaml
@@ -191,6 +191,7 @@ layers:
       - vectordatasource.transform.population_rank
       - vectordatasource.transform.capital_alternate_viewpoint
       - vectordatasource.transform.unpack_places_disputes
+      - vectordatasource.transform.apply_places_with_viewpoints
       - vectordatasource.transform.calculate_default_place_min_zoom
       - vectordatasource.transform.add_id_to_properties
       - vectordatasource.transform.detect_osm_relation

--- a/queries.yaml
+++ b/queries.yaml
@@ -293,8 +293,6 @@ layers:
     transform:
       - vectordatasource.transform.tags_create_dict
       - vectordatasource.transform.tags_name_i18n
-      - vectordatasource.transform.admin_level_alternate_viewpoint
-      - vectordatasource.transform.tags_remove
       - vectordatasource.transform.admin_level_as_int
       - vectordatasource.transform.add_id_to_properties
       - vectordatasource.transform.detect_osm_relation
@@ -302,6 +300,8 @@ layers:
       - vectordatasource.transform.truncate_min_zoom_to_1dp
       - vectordatasource.transform.remap_viewpoint_kinds
       - vectordatasource.transform.unpack_viewpoint_claims
+      - vectordatasource.transform.admin_level_alternate_viewpoint
+      - vectordatasource.transform.tags_remove
     area-inclusion-threshold: 1
   transit:
     geometry_types: [LineString, MultiLineString, Polygon, MultiPolygon]

--- a/queries.yaml
+++ b/queries.yaml
@@ -728,6 +728,7 @@ post_process:
         - disputed_by
         - "disputed_by:left"
         - "disputed_by:right"
+        - recognized_by
 
   # drop id/id:left/id:right on boundaries up to zoom 13 inclusive.
   # the left/right IDs tend to be unique as a pair, and so prevent merging.

--- a/queries.yaml
+++ b/queries.yaml
@@ -190,6 +190,7 @@ layers:
       - vectordatasource.transform.place_population_int
       - vectordatasource.transform.population_rank
       - vectordatasource.transform.capital_alternate_viewpoint
+      - vectordatasource.transform.unpack_places_disputes
       - vectordatasource.transform.calculate_default_place_min_zoom
       - vectordatasource.transform.add_id_to_properties
       - vectordatasource.transform.detect_osm_relation

--- a/queries.yaml
+++ b/queries.yaml
@@ -305,6 +305,7 @@ layers:
       # note: the next line needs to come after anything else that touches the kind:XX values.
       # admin_level:XX is intended to be an override for all the other general logic for disputes
       - vectordatasource.transform.admin_level_alternate_viewpoint
+      - vectordatasource.transform.create_dispute_ids
       - vectordatasource.transform.tags_remove
     area-inclusion-threshold: 1
   transit:

--- a/queries.yaml
+++ b/queries.yaml
@@ -302,6 +302,8 @@ layers:
       - vectordatasource.transform.truncate_min_zoom_to_1dp
       - vectordatasource.transform.remap_viewpoint_kinds
       - vectordatasource.transform.unpack_viewpoint_claims
+      # note: the next line needs to come after anything else that touches the kind:XX values.
+      # admin_level:XX is intended to be an override for all the other general logic for disputes
       - vectordatasource.transform.admin_level_alternate_viewpoint
       - vectordatasource.transform.tags_remove
     area-inclusion-threshold: 1
@@ -731,6 +733,10 @@ post_process:
         - "disputed_by:left"
         - "disputed_by:right"
         - recognized_by
+        - "recognized_by:left"
+        - "recognized_by:right"
+        - tz_admin_level
+
 
   # drop id/id:left/id:right on boundaries up to zoom 13 inclusive.
   # the left/right IDs tend to be unique as a pair, and so prevent merging.

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9314,31 +9314,25 @@ def unpack_viewpoint_claims(shape, props, fid, zoom):
     see it in their viewpoint as a country/region/county.
     """
 
-    prefix = 'unrecognized_'
-    kind = props.get('kind')
-    claimed_by = props.get('claimed_by')
-    recognized_by = props.get('recognized_by')
-    disputed_by = props.get('disputed_by')
+    claimed_by = props.get('claimed_by', '')
+    recognized_by = props.get('recognized_by', '')
+    disputed_by = props.get('disputed_by', '')
 
-    if kind and kind.startswith(prefix) and claimed_by:
+    admin_level = str(props.get('tz_admin_level', ''))
 
-        claimed_kind = kind[len(prefix):]
+    if admin_level:
+        base_kind = _ADMIN_LEVEL_TO_KIND.get(admin_level)
 
-        for country in _list_of_countries(claimed_by):
-            props['kind:' + country] = claimed_kind
+        for viewpoint in _list_of_countries(claimed_by):
+            props['kind:' + viewpoint] = base_kind
 
-        if recognized_by:
-            for viewpoint in _list_of_countries(recognized_by):
-                props['kind:' + viewpoint] = claimed_kind
+        for viewpoint in _list_of_countries(recognized_by):
+            props['kind:' + viewpoint] = base_kind
 
-    if kind and kind.startswith(prefix) and disputed_by:
+        for viewpoint in _list_of_countries(disputed_by):
+            props['kind:' + viewpoint] = 'unrecognized_' + base_kind
 
-        # TODO what do I need to do with geometry here?
-        if disputed_by:
-            for viewpoint in _list_of_countries(disputed_by):
-                props['kind:' + viewpoint] = 'unrecognized_disputed_reference_line'
-
-    return (shape, props, fid)
+    return shape, props, fid
 
 
 class _DisputeMasks(object):

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9709,3 +9709,20 @@ def apply_places_with_viewpoints(shape, props, fid, zoom):
         props.pop(prop)
 
     return shape, props, fid
+
+
+def create_dispute_ids(shape, props, fid, zoom):
+    """
+    concatenate <breakaway_code>_<ne_id> and store in dispute_id.  Just use what's there
+    stores no dispute_id if both input fields are missing
+    """
+
+    # retrieve and remove these items from props.  This is the only func that will use them
+    items = [props.pop('tz_breakaway_code', None), props.pop('tz_ne_id', None)]
+    items = [item for item in items if item is not None]
+
+    dispute_id = '_'.join(items)
+    if dispute_id:
+        props['dispute_id'] = dispute_id
+
+    return shape, props, fid

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9303,7 +9303,7 @@ def _list_of_countries(value):
 
 def unpack_viewpoint_claims(shape, props, fid, zoom):
     """
-    Unpack OSM "claimed_by" list into viewpoint kinds.
+    Unpack OSM "claimed_by" and "disputed_by" lists into viewpoint kinds.
 
     For example; "claimed_by=AA;BB;CC" should become "kind:aa=country,
     kind:bb=country, kind:cc=country" (or region, etc... as appropriate for
@@ -9330,6 +9330,8 @@ def unpack_viewpoint_claims(shape, props, fid, zoom):
         if recognized_by:
             for viewpoint in _list_of_countries(recognized_by):
                 props['kind:' + viewpoint] = claimed_kind
+
+    if kind and kind.startswith(prefix) and disputed_by:
 
         # TODO what do I need to do with geometry here?
         if disputed_by:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9331,6 +9331,7 @@ def unpack_viewpoint_claims(shape, props, fid, zoom):
             for viewpoint in _list_of_countries(recognized_by):
                 props['kind:' + viewpoint] = claimed_kind
 
+        # TODO what do I need to do with geometry here?
         if disputed_by:
             for viewpoint in _list_of_countries(disputed_by):
                 props['kind:' + viewpoint] = 'unrecognized_disputed_reference_line'
@@ -9484,6 +9485,7 @@ def apply_disputed_boundary_viewpoints(ctx):
 
         # this covers the disputed_reference_line case.
         # unpack all the viewpoints from disputed_by, and make them all unrecognized
+        # TODO what do I need to do with geometry here?
         elif kind == 'disputed_reference_line':
             disputed_by = props.get('disputed_by')
             if disputed_by:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9321,7 +9321,9 @@ def unpack_viewpoint_claims(shape, props, fid, zoom):
     admin_level = str(props.get('tz_admin_level', ''))
 
     if admin_level:
-        base_kind = _ADMIN_LEVEL_TO_KIND.get(admin_level)
+        base_kind = _ADMIN_LEVEL_TO_KIND.get(admin_level, '')
+        if not base_kind:
+            base_kind = 'debug'
 
         for viewpoint in _list_of_countries(claimed_by):
             props['kind:' + viewpoint] = base_kind

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9643,12 +9643,18 @@ _ADMIN_LEVEL_TO_KIND = {'2': 'country',
                         '8': 'locality'}
 
 _PLACE_TO_KIND = {'country': 'country',
-                  'state': 'region',
                   'region': 'region',
+                  'state': 'region',
+                  'province': 'region',
                   'county': 'county',
                   'district': 'county',
-                  'locality': 'locality',
+                  'city': 'locality',
                   'town': 'locality',
+                  'village': 'locality',
+                  'locality': 'locality',
+                  'hamlet': 'locality',
+                  'isolated_dwelling': 'locality',
+                  'farm': 'locality',
                   }
 
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9646,7 +9646,7 @@ def admin_level_alternate_viewpoint(shape, props, fid, zoom):
     turns e.g. admin_level:XX=4 into kind:xx=region
     """
     admin_viewpoint_prefix = 'admin_level:'
-    tags = props['tags']
+    tags = props.get('tags', {})
 
     for k in tags.keys():
         if k.startswith(admin_viewpoint_prefix):

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9381,14 +9381,6 @@ class _DisputeMasks(object):
 
         updated_features = []
 
-        # figure out what we want the boundary kind to be, if it's intersected
-        # with the dispute mask.
-        kind = props['kind']
-        if kind.startswith('unrecognized_'):
-            unrecognized = kind
-        else:
-            unrecognized = 'unrecognized_' + kind
-
         for mask_shape, disputants in self.masks:
             # we don't want to override a kind:xx if it has already been set
             # (e.g: by a claim), so we filter out disputant viewpoints where
@@ -9412,7 +9404,9 @@ class _DisputeMasks(object):
                 if not cut_shape.is_empty:
                     new_props = props.copy()
                     for disputant in non_claim_disputants:
-                        new_props['kind:' + disputant] = unrecognized
+                        new_props['kind:' + disputant] = 'unrecognized_disputed_reference_line'
+
+                    new_props['kind'] = 'disputed_reference_line'
                     updated_features.append((cut_shape, new_props, None))
 
         if not shape.is_empty:

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9474,18 +9474,18 @@ def apply_disputed_boundary_viewpoints(ctx):
         # too, as this allows for multi-level fallback from one viewpoint
         # possibly through several others before reaching the default.
         elif kind.startswith('unrecognized_'):
-            disputed_kind = kind[len('unrecognized_'):]
-            if disputed_kind in _BOUNDARY_KINDS:
+            if kind[len('unrecognized_'):] in _BOUNDARY_KINDS:
                 boundaries.append((shape, props, fid))
-            else:
-                # this covers the unrecognized_disputed_reference_line case
-                # unpack all the viewpoints from disputed_by
-                disputed_by = props['disputed_by']
-                if disputed_by:
-                    for country in _list_of_countries(disputed_by):
-                        props['kind:' + country] = disputed_kind
 
-                new_features.append((shape, props, fid))
+        # this covers the disputed_reference_line case.
+        # unpack all the viewpoints from disputed_by, and make them all unrecognized
+        elif kind == 'disputed_reference_line':
+            disputed_by = props.get('disputed_by')
+            if disputed_by:
+                for country in _list_of_countries(disputed_by):
+                    props['kind:' + country] = 'unrecognized_disputed_reference_line'
+
+            new_features.append((shape, props, fid))
 
         else:
             # pass through this feature - we just ignore it.

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9482,30 +9482,6 @@ def apply_disputed_boundary_viewpoints(ctx):
             if kind[len('unrecognized_'):] in _BOUNDARY_KINDS:
                 boundaries.append((shape, props, fid))
 
-        # this covers the disputed_reference_line case.
-        # unpack all the viewpoints from disputed_by, and make them all unrecognized
-        # TODO what do I need to do with geometry here?
-        elif kind == 'disputed_reference_line':
-            disputed_by = props.get('disputed_by')
-            if disputed_by:
-                for country in _list_of_countries(disputed_by):
-                    props['kind:' + country] = 'unrecognized_disputed_reference_line'
-
-            kind_from_admin_level = _ADMIN_LEVEL_TO_KIND.get(str(props.get('tz_admin_level')))
-            if kind_from_admin_level:
-                props.pop('tz_admin_level')
-                claimed_by = props.get('claimed_by')
-                if claimed_by:
-                    for country in _list_of_countries(claimed_by):
-                        props['kind:' + country] = kind_from_admin_level
-
-                recognized_by = props.get('recognized_by')
-                if recognized_by:
-                    for country in _list_of_countries(recognized_by):
-                        props['kind:' + country] = kind_from_admin_level
-
-            new_features.append((shape, props, fid))
-
         else:
             # pass through this feature - we just ignore it.
             new_features.append((shape, props, fid))

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9318,6 +9318,7 @@ def unpack_viewpoint_claims(shape, props, fid, zoom):
     kind = props.get('kind')
     claimed_by = props.get('claimed_by')
     recognized_by = props.get('recognized_by')
+    disputed_by = props.get('disputed_by')
 
     if kind and kind.startswith(prefix) and claimed_by:
 
@@ -9329,6 +9330,10 @@ def unpack_viewpoint_claims(shape, props, fid, zoom):
         if recognized_by:
             for viewpoint in _list_of_countries(recognized_by):
                 props['kind:' + viewpoint] = claimed_kind
+
+        if disputed_by:
+            for viewpoint in _list_of_countries(disputed_by):
+                props['kind:' + viewpoint] = 'unrecognized_disputed_reference_line'
 
     return (shape, props, fid)
 
@@ -9484,6 +9489,18 @@ def apply_disputed_boundary_viewpoints(ctx):
             if disputed_by:
                 for country in _list_of_countries(disputed_by):
                     props['kind:' + country] = 'unrecognized_disputed_reference_line'
+
+            kind_from_admin_level = _ADMIN_LEVEL_TO_KIND.get(str(props.get('tz_admin_level')))
+            if kind_from_admin_level:
+                claimed_by = props.get('claimed_by')
+                if claimed_by:
+                    for country in _list_of_countries(claimed_by):
+                        props['kind:' + country] = kind_from_admin_level
+
+                recognized_by = props.get('recognized_by')
+                if recognized_by:
+                    for country in _list_of_countries(recognized_by):
+                        props['kind:' + country] = kind_from_admin_level
 
             new_features.append((shape, props, fid))
 

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9658,3 +9658,16 @@ def admin_level_alternate_viewpoint(shape, props, fid, zoom):
                 props['kind:' + viewpoint] = _ADMIN_LEVEL_TO_KIND.get(admin_level, None)
 
     return shape, props, fid
+
+
+def unpack_places_disputes(shape, props, fid, zoom):
+    """
+    turns disputed places into 'unrecognized' for that viewpoint
+    """
+    disputed_by = props.pop('disputed_by', '')
+    disputants = _list_of_countries(disputed_by)
+
+    for disputant in disputants:
+        props['kind:' + disputant] = 'unrecognized'
+
+    return shape, props, fid

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9494,6 +9494,7 @@ def apply_disputed_boundary_viewpoints(ctx):
 
             kind_from_admin_level = _ADMIN_LEVEL_TO_KIND.get(str(props.get('tz_admin_level')))
             if kind_from_admin_level:
+                props.pop('tz_admin_level')
                 claimed_by = props.get('claimed_by')
                 if claimed_by:
                     for country in _list_of_countries(claimed_by):

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9332,7 +9332,7 @@ def unpack_viewpoint_claims(shape, props, fid, zoom):
             props['kind:' + viewpoint] = base_kind
 
         for viewpoint in _list_of_countries(disputed_by):
-            props['kind:' + viewpoint] = 'unrecognized_' + base_kind
+            props['kind:' + viewpoint] = 'unrecognized'
 
     return shape, props, fid
 
@@ -9403,7 +9403,7 @@ class _DisputeMasks(object):
                 if not cut_shape.is_empty:
                     new_props = props.copy()
                     for disputant in non_claim_disputants:
-                        new_props['kind:' + disputant] = 'unrecognized_disputed_reference_line'
+                        new_props['kind:' + disputant] = 'unrecognized'
 
                     for recognizant in recognizants:
                         new_props['kind:' + recognizant] = 'country'

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9636,11 +9636,20 @@ def capital_alternate_viewpoint(shape, props, fid, zoom):
 
 # Map admin level to the kind it should become. Admin_level 3 isn't a widely recognized country,
 # but the only uses of 3 we care about are when it is a country from some viewpoint
+# Similarly 5 is typically used for disputed regions.
 _ADMIN_LEVEL_TO_KIND = {'2': 'country',
-                        '3': 'country',
                         '4': 'region',
                         '6': 'county',
                         '8': 'locality'}
+
+_PLACE_TO_KIND = {'country': 'country',
+                  'state': 'region',
+                  'region': 'region',
+                  'county': 'county',
+                  'district': 'county',
+                  'locality': 'locality',
+                  'town': 'locality',
+                  }
 
 
 def admin_level_alternate_viewpoint(shape, props, fid, zoom):
@@ -9671,5 +9680,26 @@ def unpack_places_disputes(shape, props, fid, zoom):
 
     for disputant in disputants:
         props['kind:' + disputant] = 'unrecognized'
+
+    return shape, props, fid
+
+
+def apply_places_with_viewpoints(shape, props, fid, zoom):
+    """
+    turns a valid place:XX into a corresponding kind:xx
+    """
+    prefix = 'place:'
+
+    for prop, value in list(props.items()):
+        if not prop.startswith(prefix):
+            continue
+
+        viewpoint = prop[len(prefix):].strip().lower()
+        kind = _PLACE_TO_KIND.get(value.strip().lower(), '')
+        if not kind:
+            continue
+
+        props['kind:' + viewpoint] = kind
+        props.pop(prop)
 
     return shape, props, fid

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -105,6 +105,7 @@ global:
     claimed_by: { col: claimed_by }
     recognized_by: { col: recognized_by }
     disputed_by: { col: disputed_by }
+    tz_admin_level: {col: admin_level }
     dispute_id: {col: 'ne:brk_a3'}
 
 filters:
@@ -210,7 +211,6 @@ filters:
     output:
       <<: [ *output_properties, *dispute_properties ]
       kind: disputed_reference_line
-      tz_admin_level: {col: admin_level }
     table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
   # becomes kind:xx=unrecognized_disputed_reference_line
@@ -220,7 +220,6 @@ filters:
       <<: [ *output_properties, *dispute_properties ]
       kind: disputed_reference_line
       kind_detail: {col: admin_level }
-      tz_admin_level: {col: admin_level }
     table: osm
   - filter:
       all:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -171,21 +171,6 @@ filters:
       <<: *output_properties
       kind: county
     table: osm
-  # this filter covers admin_level 3 boundaries for countries and states,
-  # turning them into disputed_reference_lines.
-  - filter:
-      all:
-        - geom_type: line
-        - admin_level: '3'
-        - any:
-            # place is added in the osm2pgsql import LUA script
-            - place: 'state'
-            - place: 'country'
-    min_zoom: 8
-    output:
-      <<: [ *output_properties, *dispute_properties ]
-      kind: disputed_reference_line
-    table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
   # becomes kind:xx=unrecognized_disputed_reference_line
   - filter: {admin_level: ['2','4','6'], boundary: disputed, geom_type: line}

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -141,20 +141,7 @@ filters:
   - filter:
       all:
         - geom_type: line
-        - admin_level: '2'
-        - boundary: claim
-        - any:
-            - claimed_by: true
-            - disputed_by: true
-    min_zoom: 8
-    output:
-      <<: [*output_properties, *dispute_properties]
-      kind: unrecognized_country
-    table: osm
-  - filter:
-      all:
-        - geom_type: line
-        - admin_level: '4'
+        - admin_level: ['2', '4', '6']
         - boundary: claim
         - any:
             - claimed_by: true
@@ -162,20 +149,7 @@ filters:
     min_zoom: 8
     output:
       <<: [ *output_properties, *dispute_properties ]
-      kind: unrecognized_region
-    table: osm
-  - filter:
-      all:
-        - geom_type: line
-        - admin_level: '6'
-        - boundary: claim
-        - any:
-            - claimed_by: true
-            - disputed_by: true
-    min_zoom: 8
-    output:
-      <<: [ *output_properties, *dispute_properties ]
-      kind: unrecognized_county
+      kind: disputed_claim
     table: osm
   # these filters look for claims that don't have a claimed_by
   # but have different point of view tags for admin_level:XX

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -138,6 +138,7 @@ filters:
       kind: unrecognized_country
       claimed_by: {col: claimed_by}
       recognized_by: {col: recognized_by}
+      disputed_by: {col: disputed_by}
     table: osm
   - filter: {admin_level: '4', boundary: claim, claimed_by: true, geom_type: line}
     min_zoom: 8
@@ -146,6 +147,7 @@ filters:
       kind: unrecognized_region
       claimed_by: {col: claimed_by}
       recognized_by: {col: recognized_by}
+      disputed_by: {col: disputed_by}
     table: osm
   - filter: {admin_level: '6', boundary: claim, claimed_by: true, geom_type: line}
     min_zoom: 8
@@ -154,6 +156,7 @@ filters:
       kind: unrecognized_county
       claimed_by: {col: claimed_by}
       recognized_by: {col: recognized_by}
+      disputed_by: {col: disputed_by}
     table: osm
   # these filters look for claims that don't have a claimed_by
   # but have different point of view tags for admin_level:XX
@@ -199,6 +202,8 @@ filters:
       kind: disputed_reference_line
       disputed: True
       disputed_by: {col: disputed_by}
+      claimed_by: { col: claimed_by }
+      recognized_by: { col: recognized_by }
     table: osm
   - filter: {admin_level: '4', boundary: disputed, disputed_by: true, geom_type: line}
     min_zoom: 8
@@ -207,6 +212,8 @@ filters:
       kind: disputed_reference_line
       disputed: True
       disputed_by: {col: disputed_by}
+      claimed_by: { col: claimed_by }
+      recognized_by: { col: recognized_by }
     table: osm
   - filter: {admin_level: '6', boundary: disputed, disputed_by: true, geom_type: line}
     min_zoom: 8
@@ -215,6 +222,8 @@ filters:
       kind: disputed_reference_line
       disputed: True
       disputed_by: {col: disputed_by}
+      claimed_by: { col: claimed_by }
+      recognized_by: { col: recognized_by }
     table: osm
   - filter:
       all:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -101,12 +101,16 @@ global:
           - geom_type: line
           - mz_boundary_from_polygon: true
 
+  - &dispute_id_components
+    tz_breakaway_code: { col: 'ne:brk_a3' }
+    tz_ne_id: { col: 'ne_id' }
+
   - &dispute_properties
     claimed_by: { col: claimed_by }
     recognized_by: { col: recognized_by }
     disputed_by: { col: disputed_by }
     tz_admin_level: {col: admin_level }
-    dispute_id: {col: 'ne:brk_a3'}
+    <<: *dispute_id_components
 
 filters:
 
@@ -264,10 +268,10 @@ filters:
         - 'Map unit boundary'
     min_zoom: { col: min_zoom }
     output:
-      <<: [*output_properties, *ne_localized_kind_properties]
+      <<: [*output_properties, *ne_localized_kind_properties, *dispute_id_components]
       kind: *ne_country_boundaries_kind
       kind_detail: '2'
-      dispute_id: { col: 'ne:brk_a3' }
+
     table: ne
 
   # ne for disputed kind:xx POV we want to always include
@@ -282,10 +286,9 @@ filters:
         - 'Unrecognized'
     min_zoom: 1
     output:
-      <<: [*output_properties, *ne_localized_kind_properties]
+      <<: [*output_properties, *ne_localized_kind_properties, *dispute_id_components]
       kind: *ne_country_boundaries_kind
       kind_detail: '2'
-      dispute_id: { col: 'ne:brk_a3' }
     table: ne
 
   - filter:
@@ -317,10 +320,9 @@ filters:
     min_zoom: *ne_region_boundaries_min_zoom
     extra_columns: [scalerank]
     output:
-      <<: [*output_properties, *ne_localized_kind_properties]
+      <<: [*output_properties, *ne_localized_kind_properties, *dispute_id_components]
       kind: unrecognized_macroregion
       kind_detail: '4'
-      dispute_id: { col: 'ne:brk_a3' }
     table: ne
   - filter:
       featurecla:
@@ -330,8 +332,7 @@ filters:
     min_zoom: *ne_region_boundaries_min_zoom
     extra_columns: [scalerank]
     output:
-      <<: [*output_properties, *ne_localized_kind_properties]
+      <<: [*output_properties, *ne_localized_kind_properties, *dispute_id_components]
       kind: unrecognized_region
       kind_detail: '4'
-      dispute_id: { col: 'ne:brk_a3' }
     table: ne

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -101,6 +101,12 @@ global:
           - geom_type: line
           - mz_boundary_from_polygon: true
 
+  - &dispute_properties
+    claimed_by: { col: claimed_by }
+    recognized_by: { col: recognized_by }
+    disputed_by: { col: disputed_by }
+    dispute_id: {col: 'ne:brk_a3'}
+
 filters:
 
   # kind pre-generated for buffered_land
@@ -141,11 +147,8 @@ filters:
             - disputed_by: true
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [*output_properties, *dispute_properties]
       kind: unrecognized_country
-      claimed_by: {col: claimed_by}
-      recognized_by: {col: recognized_by}
-      disputed_by: {col: disputed_by}
     table: osm
   - filter:
       all:
@@ -157,11 +160,8 @@ filters:
             - disputed_by: true
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [ *output_properties, *dispute_properties ]
       kind: unrecognized_region
-      claimed_by: {col: claimed_by}
-      recognized_by: {col: recognized_by}
-      disputed_by: {col: disputed_by}
     table: osm
   - filter:
       all:
@@ -173,11 +173,8 @@ filters:
             - disputed_by: true
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [ *output_properties, *dispute_properties ]
       kind: unrecognized_county
-      claimed_by: {col: claimed_by}
-      recognized_by: {col: recognized_by}
-      disputed_by: {col: disputed_by}
     table: osm
   # these filters look for claims that don't have a claimed_by
   # but have different point of view tags for admin_level:XX
@@ -200,7 +197,7 @@ filters:
       kind: county
     table: osm
   # this filter covers admin_level 3 boundaries for countries and states,
-  # turning them into disputed_reference_lines
+  # turning them into disputed_reference_lines.
   - filter:
       all:
         - geom_type: line
@@ -210,9 +207,8 @@ filters:
             - place: 'country'
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [ *output_properties, *dispute_properties ]
       kind: disputed_reference_line
-      recognized_by: { col: recognized_by }
       tz_admin_level: {col: admin_level }
     table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
@@ -220,12 +216,9 @@ filters:
   - filter: {admin_level: ['2','4','6'], boundary: disputed, geom_type: line}
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [ *output_properties, *dispute_properties ]
       kind: disputed_reference_line
       kind_detail: {col: admin_level }
-      disputed_by: {col: disputed_by }
-      claimed_by: { col: claimed_by }
-      recognized_by: { col: recognized_by }
       tz_admin_level: {col: admin_level }
     table: osm
   - filter:
@@ -237,11 +230,8 @@ filters:
             - disputed: 'yes'
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [ *output_properties, *dispute_properties ]
       kind: mz_internal_dispute_mask
-      disputed_by: {col: disputed_by}
-      claimed_by: { col: claimed_by }
-      recognized_by: { col: recognized_by }
     table: osm
 
   # osm
@@ -315,6 +305,7 @@ filters:
       <<: [*output_properties, *ne_localized_kind_properties]
       kind: *ne_country_boundaries_kind
       kind_detail: '2'
+      dispute_id: { col: 'ne:brk_a3' }
     table: ne
 
   # ne for disputed kind:xx POV we want to always include
@@ -332,6 +323,7 @@ filters:
       <<: [*output_properties, *ne_localized_kind_properties]
       kind: *ne_country_boundaries_kind
       kind_detail: '2'
+      dispute_id: { col: 'ne:brk_a3' }
     table: ne
 
   - filter:
@@ -366,6 +358,7 @@ filters:
       <<: [*output_properties, *ne_localized_kind_properties]
       kind: unrecognized_macroregion
       kind_detail: '4'
+      dispute_id: { col: 'ne:brk_a3' }
     table: ne
   - filter:
       featurecla:
@@ -378,4 +371,5 @@ filters:
       <<: [*output_properties, *ne_localized_kind_properties]
       kind: unrecognized_region
       kind_detail: '4'
+      dispute_id: { col: 'ne:brk_a3' }
     table: ne

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -146,6 +146,7 @@ filters:
         - any:
             - claimed_by: true
             - disputed_by: true
+            - recognized_by: true
     min_zoom: 8
     output:
       <<: [ *output_properties, *dispute_properties ]
@@ -172,7 +173,9 @@ filters:
       kind: county
     table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
-  # becomes kind:xx=unrecognized_disputed_reference_line
+  # project to kind:xx=unrecognized_disputed_reference_line.  The lua preprocessing
+  # project admin_level 3 and 5 cases to appropriate tags for us, so we don't need
+  # to handle them here
   - filter: {admin_level: ['2','4','6'], boundary: disputed, geom_type: line}
     min_zoom: 8
     output:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -203,6 +203,7 @@ filters:
         - geom_type: line
         - admin_level: '3'
         - any:
+            # place is added in the osm2pgsql import LUA script
             - place: 'state'
             - place: 'country'
     min_zoom: 8

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -177,7 +177,7 @@ filters:
       kind: county
     table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
-  # project to kind:xx=unrecognized_disputed_reference_line.  The lua preprocessing
+  # project to kind:xx=unrecognized.  The lua preprocessing
   # project admin_level 3 and 5 cases to appropriate tags for us, so we don't need
   # to handle them here
   - filter: {admin_level: ['2','4','6'], boundary: disputed, geom_type: line}

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -242,6 +242,8 @@ filters:
       <<: *output_properties
       kind: mz_internal_dispute_mask
       disputed_by: {col: disputed_by}
+      claimed_by: { col: claimed_by }
+      recognized_by: { col: recognized_by }
       disputed: True
     table: osm
 

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -212,7 +212,6 @@ filters:
     output:
       <<: *output_properties
       kind: disputed_reference_line
-      disputed: True
       recognized_by: { col: recognized_by }
       tz_admin_level: {col: admin_level }
     table: osm
@@ -224,7 +223,6 @@ filters:
       <<: *output_properties
       kind: disputed_reference_line
       kind_detail: {col: admin_level }
-      disputed: True
       disputed_by: {col: disputed_by }
       claimed_by: { col: claimed_by }
       recognized_by: { col: recognized_by }
@@ -244,7 +242,6 @@ filters:
       disputed_by: {col: disputed_by}
       claimed_by: { col: claimed_by }
       recognized_by: { col: recognized_by }
-      disputed: True
     table: osm
 
   # osm

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -152,23 +152,23 @@ filters:
       kind: disputed_claim
     table: osm
   # these filters look for claims that don't have a claimed_by
-  # but have different point of view tags for admin_level:XX
+  # they should have different point of view tags for admin_level:XX
   - filter: {admin_level: '2', boundary: claim, geom_type: line}
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [*output_properties, *dispute_properties]
       kind: country
     table: osm
   - filter: {admin_level: '4', boundary: claim, geom_type: line}
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [*output_properties, *dispute_properties]
       kind: region
     table: osm
   - filter: {admin_level: '6', boundary: claim, geom_type: line}
     min_zoom: 8
     output:
-      <<: *output_properties
+      <<: [*output_properties, *dispute_properties]
       kind: county
     table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -190,6 +190,30 @@ filters:
       kind: disputed_reference_line
       disputed: True
     table: osm
+  - filter: {admin_level: '2', boundary: disputed, disputed_by: true, geom_type: line}
+    min_zoom: 8
+    output:
+      <<: *output_properties
+      kind: unrecognized_disputed_reference_line
+      disputed: True
+      disputed_by: {col: disputed_by}
+    table: osm
+  - filter: {admin_level: '4', boundary: disputed, disputed_by: true, geom_type: line}
+    min_zoom: 8
+    output:
+      <<: *output_properties
+      kind: unrecognized_disputed_reference_line
+      disputed: True
+      disputed_by: {col: disputed_by}
+    table: osm
+  - filter: {admin_level: '6', boundary: disputed, disputed_by: true, geom_type: line}
+    min_zoom: 8
+    output:
+      <<: *output_properties
+      kind: unrecognized_disputed_reference_line
+      disputed: True
+      disputed_by: {col: disputed_by}
+    table: osm
   - filter:
       all:
         - geom_type: line

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -193,8 +193,8 @@ filters:
       kind: disputed_reference_line
       disputed: True
     table: osm
-  # These are kind=unrecognized_disputed_reference_lines that, for viewpoint XX in disputed_by,
-  # becomes kind:xx=disputed_reference_line
+  # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
+  # becomes kind:xx=unrecognized_disputed_reference_line
   - filter: {admin_level: ['2','4','6'], boundary: disputed, disputed_by: true, geom_type: line}
     min_zoom: 8
     output:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -195,35 +195,16 @@ filters:
     table: osm
   # These are kind=unrecognized_disputed_reference_lines that, for viewpoint XX in disputed_by,
   # becomes kind:xx=disputed_reference_line
-  - filter: {admin_level: '2', boundary: disputed, disputed_by: true, geom_type: line}
+  - filter: {admin_level: ['2','4','6'], boundary: disputed, disputed_by: true, geom_type: line}
     min_zoom: 8
     output:
       <<: *output_properties
       kind: disputed_reference_line
       disputed: True
-      disputed_by: {col: disputed_by}
+      disputed_by: {col: disputed_by }
       claimed_by: { col: claimed_by }
       recognized_by: { col: recognized_by }
-    table: osm
-  - filter: {admin_level: '4', boundary: disputed, disputed_by: true, geom_type: line}
-    min_zoom: 8
-    output:
-      <<: *output_properties
-      kind: disputed_reference_line
-      disputed: True
-      disputed_by: {col: disputed_by}
-      claimed_by: { col: claimed_by }
-      recognized_by: { col: recognized_by }
-    table: osm
-  - filter: {admin_level: '6', boundary: disputed, disputed_by: true, geom_type: line}
-    min_zoom: 8
-    output:
-      <<: *output_properties
-      kind: disputed_reference_line
-      disputed: True
-      disputed_by: {col: disputed_by}
-      claimed_by: { col: claimed_by }
-      recognized_by: { col: recognized_by }
+      tz_admin_level: {col: admin_level }
     table: osm
   - filter:
       all:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -190,8 +190,8 @@ filters:
       kind: disputed_reference_line
       disputed: True
     table: osm
-  # These are kind=unrecognized_disputed_reference_lines that, for viewpoints in disputed_by,
-  # become kind=disputed_reference_line
+  # These are kind=unrecognized_disputed_reference_lines that, for viewpoint XX in disputed_by,
+  # becomes kind:xx=disputed_reference_line
   - filter: {admin_level: '2', boundary: disputed, disputed_by: true, geom_type: line}
     min_zoom: 8
     output:

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -131,7 +131,14 @@ filters:
   #    `unrecognized_*` (where XX is the viewpoint / country code and * is the
   #    kind of boundary it is).
   #
-  - filter: {admin_level: '2', boundary: claim, claimed_by: true, geom_type: line}
+  - filter:
+      all:
+        - geom_type: line
+        - admin_level: '2'
+        - boundary: claim
+        - any:
+            - claimed_by: true
+            - disputed_by: true
     min_zoom: 8
     output:
       <<: *output_properties
@@ -140,7 +147,14 @@ filters:
       recognized_by: {col: recognized_by}
       disputed_by: {col: disputed_by}
     table: osm
-  - filter: {admin_level: '4', boundary: claim, claimed_by: true, geom_type: line}
+  - filter:
+      all:
+        - geom_type: line
+        - admin_level: '4'
+        - boundary: claim
+        - any:
+            - claimed_by: true
+            - disputed_by: true
     min_zoom: 8
     output:
       <<: *output_properties
@@ -149,7 +163,14 @@ filters:
       recognized_by: {col: recognized_by}
       disputed_by: {col: disputed_by}
     table: osm
-  - filter: {admin_level: '6', boundary: claim, claimed_by: true, geom_type: line}
+  - filter:
+      all:
+        - geom_type: line
+        - admin_level: '6'
+        - boundary: claim
+        - any:
+            - claimed_by: true
+            - disputed_by: true
     min_zoom: 8
     output:
       <<: *output_properties

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -191,6 +191,7 @@ filters:
     output:
       <<: *output_properties
       kind: disputed_reference_line
+      kind_detail: '2'
       disputed: True
     table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
@@ -200,6 +201,7 @@ filters:
     output:
       <<: *output_properties
       kind: disputed_reference_line
+      kind_detail: '2'
       disputed: True
       disputed_by: {col: disputed_by }
       claimed_by: { col: claimed_by }

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -194,7 +194,7 @@ filters:
     min_zoom: 8
     output:
       <<: *output_properties
-      kind: unrecognized_disputed_reference_line
+      kind: disputed_reference_line
       disputed: True
       disputed_by: {col: disputed_by}
     table: osm
@@ -202,7 +202,7 @@ filters:
     min_zoom: 8
     output:
       <<: *output_properties
-      kind: unrecognized_disputed_reference_line
+      kind: disputed_reference_line
       disputed: True
       disputed_by: {col: disputed_by}
     table: osm
@@ -210,7 +210,7 @@ filters:
     min_zoom: 8
     output:
       <<: *output_properties
-      kind: unrecognized_disputed_reference_line
+      kind: disputed_reference_line
       disputed: True
       disputed_by: {col: disputed_by}
     table: osm

--- a/yaml/boundaries.yaml
+++ b/yaml/boundaries.yaml
@@ -212,17 +212,16 @@ filters:
     output:
       <<: *output_properties
       kind: disputed_reference_line
-      kind_detail: '2'
       disputed: True
     table: osm
   # These are kind=disputed_reference_lines that, for viewpoint XX in disputed_by,
   # becomes kind:xx=unrecognized_disputed_reference_line
-  - filter: {admin_level: ['2','4','6'], boundary: disputed, disputed_by: true, geom_type: line}
+  - filter: {admin_level: ['2','4','6'], boundary: disputed, geom_type: line}
     min_zoom: 8
     output:
       <<: *output_properties
       kind: disputed_reference_line
-      kind_detail: '2'
+      kind_detail: {col: admin_level }
       disputed: True
       disputed_by: {col: disputed_by }
       claimed_by: { col: claimed_by }

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -35,6 +35,37 @@ global:
         args: [ { col: is_landuse_aoi } ]
     wikidata_id: {col: wikidata}
     disputed_by: {col: disputed_by }
+    'place:ISO': { col: 'place:ISO' }
+    'place:AR': { col: 'place:AR' }
+    'place:BD': { col: 'place:BD' }
+    'place:BR': { col: 'place:BR' }
+    'place:CN': { col: 'place:CN' }
+    'place:DE': { col: 'place:DE' }
+    'place:EG': { col: 'place:EG' }
+    'place:ES': { col: 'place:ES' }
+    'place:FR': { col: 'place:FR' }
+    'place:GB': { col: 'place:GB' }
+    'place:GR': { col: 'place:GR' }
+    'place:ID': { col: 'place:ID' }
+    'place:IL': { col: 'place:IL' }
+    'place:IN': { col: 'place:IN' }
+    'place:IT': { col: 'place:IT' }
+    'place:JP': { col: 'place:JP' }
+    'place:KO': { col: 'place:KO' }
+    'place:MA': { col: 'place:MA' }
+    'place:NL': { col: 'place:NL' }
+    'place:NP': { col: 'place:NP' }
+    'place:PK': { col: 'place:PK' }
+    'place:PL': { col: 'place:PL' }
+    'place:PS': { col: 'place:PS' }
+    'place:PT': { col: 'place:PT' }
+    'place:RU': { col: 'place:RU' }
+    'place:SA': { col: 'place:SA' }
+    'place:SE': { col: 'place:SE' }
+    'place:TR': { col: 'place:TR' }
+    'place:TW': { col: 'place:TW' }
+    'place:US': { col: 'place:US' }
+    'place:VN': { col: 'place:VN' }
 
   - &ne_places_min_zoom
     lookup:

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -34,6 +34,7 @@ global:
         func: util.true_or_none
         args: [ { col: is_landuse_aoi } ]
     wikidata_id: {col: wikidata}
+    disputed_by: {col: disputed_by }
 
   - &ne_places_min_zoom
     lookup:


### PR DESCRIPTION
import changes
*new lua script for osm2pgsql import.

boundaries changes
* OSM admin_level with a viewpoint overrides default kind behaviors
* exporting dispute_id from newly exported NE fields
* boundary: disputed -> kind: disputed_reference_line
* boundary: claim -> disputed_claim
* any OSM claim or dispute with a disputed_by, recognized_by, or claimed_by will now get kinds with viewpoints.  
* Simplified yaml logic to fewer cases.

places changes
* OSM places can now have a disputed_by field that projects to a kind:xx=unrecognized
* OSM place tags can now have viewpoints (e.g. place -> region, place:CN -> country for Taiwan)
