### PR TITLE
disable reimports on the ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ jobs:
           name: Check Code Style using pre-commit
           command: |
             . ~/env/bin/activate
-            pre-commit run --show-diff-on-failure --all-files
+# we enabled pre-commit.ci for the repo so no need to run it on Circle here again
+#            pre-commit run --show-diff-on-failure --all-files
       - run:
           name: Setup.py develop
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,7 @@ jobs:
           name: Check Code Style using pre-commit
           command: |
             . ~/env/bin/activate
-# we enabled pre-commit.ci for the repo so no need to run it on Circle here again
-#           pre-commit run --show-diff-on-failure --all-files
+            pre-commit run --show-diff-on-failure --all-files
       - run:
           name: Setup.py develop
           command: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+    skip: [reorder-python-imports]
 default_language_version:
     python: python2.7
 repos:

--- a/data/bootstrap.py
+++ b/data/bootstrap.py
@@ -1,9 +1,8 @@
 import urllib
 
+import yaml
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
-
-import yaml
 
 with open('assets.yaml') as fh:
     asset_cfg = yaml.load(fh)

--- a/data/bootstrap.py
+++ b/data/bootstrap.py
@@ -1,8 +1,9 @@
 import urllib
 
-import yaml
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
+
+import yaml
 
 with open('assets.yaml') as fh:
     asset_cfg = yaml.load(fh)

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -39,7 +39,6 @@ from tilequeue.tile import coord_to_bounds
 from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import reproject_lnglat_to_mercator
 from tilequeue.tile import reproject_mercator_to_lnglat
-from yaml import load as load_yaml
 
 from vectordatasource.meta import find_yaml_path
 from vectordatasource.meta.python import make_function_name_min_zoom
@@ -47,6 +46,7 @@ from vectordatasource.meta.python import make_function_name_props
 from vectordatasource.meta.python import output_kind
 from vectordatasource.meta.python import output_min_zoom
 from vectordatasource.meta.python import parse_layers
+from yaml import load as load_yaml
 
 
 # the Overpass server is used to download data about OSM elements. the

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -39,6 +39,7 @@ from tilequeue.tile import coord_to_bounds
 from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import reproject_lnglat_to_mercator
 from tilequeue.tile import reproject_mercator_to_lnglat
+from yaml import load as load_yaml
 
 from vectordatasource.meta import find_yaml_path
 from vectordatasource.meta.python import make_function_name_min_zoom
@@ -46,7 +47,6 @@ from vectordatasource.meta.python import make_function_name_props
 from vectordatasource.meta.python import output_kind
 from vectordatasource.meta.python import output_min_zoom
 from vectordatasource.meta.python import parse_layers
-from yaml import load as load_yaml
 
 
 # the Overpass server is used to download data about OSM elements. the

--- a/scripts/csv_colours.py
+++ b/scripts/csv_colours.py
@@ -3,6 +3,7 @@ import sys
 from optparse import OptionParser
 
 import yaml
+
 from vectordatasource.colour import parse_colour
 from vectordatasource.transform import Palette
 

--- a/scripts/csv_colours.py
+++ b/scripts/csv_colours.py
@@ -45,7 +45,6 @@ for file_name in args:
     with open(file_name, 'rb') as csvfile:
         reader = csv.DictReader(csvfile)
         writer = None
-
         for row in reader:
             if writer is None:
                 keys = list(row.keys()) + [output_colour_key]

--- a/scripts/csv_colours.py
+++ b/scripts/csv_colours.py
@@ -3,7 +3,6 @@ import sys
 from optparse import OptionParser
 
 import yaml
-
 from vectordatasource.colour import parse_colour
 from vectordatasource.transform import Palette
 

--- a/scripts/csv_colours.py
+++ b/scripts/csv_colours.py
@@ -45,6 +45,7 @@ for file_name in args:
     with open(file_name, 'rb') as csvfile:
         reader = csv.DictReader(csvfile)
         writer = None
+
         for row in reader:
             if writer is None:
                 keys = list(row.keys()) + [output_colour_key]

--- a/vectordatasource/meta/python.py
+++ b/vectordatasource/meta/python.py
@@ -5,8 +5,8 @@ from collections import namedtuple
 from numbers import Number
 
 import astformatter
-
 import yaml
+
 from vectordatasource import util
 from vectordatasource.meta import function
 

--- a/vectordatasource/meta/python.py
+++ b/vectordatasource/meta/python.py
@@ -5,8 +5,8 @@ from collections import namedtuple
 from numbers import Number
 
 import astformatter
-import yaml
 
+import yaml
 from vectordatasource import util
 from vectordatasource.meta import function
 


### PR DESCRIPTION
We are using a very old version of reimport that still supports python2, but his version on the CI sometimes generate inconsistent results on reimports. So we just disable the reimports on the CI.

