### PR TITLE
add additional intermittent tags to water yaml

### DIFF
--- a/yaml/water.yaml
+++ b/yaml/water.yaml
@@ -20,6 +20,9 @@ globals:
           - when:
               intermittent: 'yes'
             then: true
+          - when:
+              { basin: [infiltration, detention] }
+            then: true
   - &water_polygon_min_zoom
     lookup:
       key: { col: way_area }


### PR DESCRIPTION
This adds intermittent=true to some basin tags that indicate intermittent water bodies but won't necessarily have the intermittent=yes tag from OSM. 