### PR TITLE
Set Taiwan view for nine dash line to unrecognized

### DIFF
--- a/data/apply-ne_disputed_border_suppression.sql
+++ b/data/apply-ne_disputed_border_suppression.sql
@@ -290,5 +290,8 @@ where brk_a3 in ('B30');
 
 
 -- Remove Taiwanese view for nine dash line
+update ne_10m_admin_0_boundary_lines_maritime_indicator_chn set
+            fclass_tw = 'Unrecognized';
+
 update ne_50m_admin_0_boundary_lines_maritime_indicator_chn set
             fclass_tw = 'Unrecognized';

--- a/data/apply-ne_disputed_border_suppression.sql
+++ b/data/apply-ne_disputed_border_suppression.sql
@@ -287,3 +287,8 @@ where brk_a3 in ('B30');
 update ne_50m_admin_0_boundary_lines_disputed_areas set
             fclass_tw = 'country'
 where brk_a3 in ('B30');
+
+
+-- Remove Taiwanese view for nine dash line
+update ne_50m_admin_0_boundary_lines_maritime_indicator_chn set
+            fclass_tw = 'Unrecognized';


### PR DESCRIPTION
A bit of sql to update the `ne_50m_admin_0_boundary_lines_maritime_indicator_chn` and `ne_10m_admin_0_boundary_lines_maritime_indicator_chn` tables with `fclass_tw` as `unrecognized`