### PR TITLE
Fix broken unit test

### DIFF
--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -886,6 +886,10 @@ class BuildingsUnifyTest(unittest.TestCase):
             if props['kind'] == 'building_part':
                 root_id = props.get('root_id')
                 self.assertEquals(root_id, 2)
+            elif props['kind'] == 'building':
+                root_id = props.get('root_id')
+                id = props.get('id')
+                self.assertEquals(root_id, id)
             else:
                 assert 'root_id' not in props
 


### PR DESCRIPTION
We added a `root_id` for buildings that is equal to the `id`, but I didn't notice an assertion in a unit test that `root_id` doesn't exist.  Since it was just checking to make sure we only add the `root_id` to `building_part`s, and we now add it to buildings too, just checking in buildings as well is fine.

<img width="605" alt="image" src="https://user-images.githubusercontent.com/879175/181805988-54a84add-70b3-44b8-82b9-0edf50c92499.png">
