### PR TITLE
Fix NE country names

### DIFF
--- a/data/apply-ne_country_label_recasting.sql
+++ b/data/apply-ne_country_label_recasting.sql
@@ -124,15 +124,15 @@ update ne_10m_admin_0_countries_iso set name_pt = 'São Bartolomeu' where ne_id 
 update ne_10m_admin_0_countries_iso set name_zht = '聖巴多祿繆島' where ne_id = 1159320633;
 
 --Update Saint Helena, Ascension and Tristan da Cunha name
-update ne_10m_admin_0_countries_iso set name_ar = 'سانت هيلينا، أسينسيون وتريستان دا كونها' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_de = 'St. Helena, Ascension und Tristan da Cunha' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_en = 'Saint Helena, Ascension and Tristan da Cunha' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_es = 'Santa Elena, Ascensión y Tristán de Acuña' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_fr = 'Sainte-Hélène, Ascension et Tristan da Cunha' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_pt = 'Santa Helena, Ascensão e Tristão da Cunha' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_ru = 'Острова Святой Елены, Вознесения и Тристан-да-Кунья' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_zh= '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320769;
-update ne_10m_admin_0_countries_iso set name_zht = '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_ar = 'سانت هيلينا، أسينسيون وتريستان دا كونها' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_de = 'St. Helena, Ascension und Tristan da Cunha' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_en = 'Saint Helena, Ascension and Tristan da Cunha' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_es = 'Santa Elena, Ascensión y Tristán de Acuña' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_fr = 'Sainte-Hélène, Ascension et Tristan da Cunha' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_pt = 'Santa Helena, Ascensão e Tristão da Cunha' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_ru = 'Острова Святой Елены, Вознесения и Тристан-да-Кунья' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_zh= '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320733;
+update ne_10m_admin_0_countries_iso set name_zht = '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320733;
 
 --Update Saint Kitts and Nevis
 update ne_10m_admin_0_countries_iso set name_zht = '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320983;

--- a/data/apply-ne_country_label_recasting.sql
+++ b/data/apply-ne_country_label_recasting.sql
@@ -51,12 +51,16 @@ update ne_10m_admin_0_countries_iso set name_ru = 'Багамы' where ne_id = 1
 
 --Update Central Africa Republic name
 update ne_10m_admin_0_countries_iso set name_fr = 'Centrafrique' where ne_id = 1159320463;
+update ne_10m_admin_0_countries_iso set name_zh = '中非' where ne_id = 1159320463;
+update ne_10m_admin_0_countries_iso set name_zht = '中非' where ne_id = 1159320463;
 
 --Update China name
 update ne_10m_admin_0_countries_iso set name_de = 'China' where ne_id = 1159320471;
 update ne_10m_admin_0_countries_iso set name_en = 'China' where ne_id = 1159320471;
 update ne_10m_admin_0_countries_iso set name_fr = 'Chine' where ne_id = 1159320471;
 update ne_10m_admin_0_countries_iso set name_ko = '중국' where ne_id = 1159320471;
+update ne_10m_admin_0_countries_iso set name_zh = '中国' where ne_id = 1159320471;
+update ne_10m_admin_0_countries_iso set name_zht = '中国' where ne_id = 1159320471;
 
 --Update Cocos (Keeling) Island
 update ne_10m_admin_0_countries_iso set name_ar = 'جزر كوكوس (كيلينغ)' where ne_id = 1159320367;
@@ -71,6 +75,7 @@ update ne_10m_admin_0_countries_iso set name_de = 'Zypern' where ne_id = 1159320
 --Update Czechia name
 update ne_10m_admin_0_countries_iso set name_en = 'Czechia' where ne_id = 1159320535;
 update ne_10m_admin_0_countries_iso set name_es = 'Chequia' where ne_id = 1159320535;
+update ne_10m_admin_0_countries_iso set name_zht = '捷克' where ne_id = 1159320535;
 
 --Update Dominica name
 update ne_10m_admin_0_countries_iso set name_ko = '도미니카' where ne_id = 1159320543;
@@ -99,6 +104,7 @@ update ne_10m_admin_0_countries_tlc set name_ru = 'Косово' where ne_id = 1
 
 --Update Mali name
 update ne_10m_admin_0_countries_iso set name_ja = 'マリ' where ne_id = 1159321063;
+update ne_10m_admin_0_countries_iso set name_zht = '馬利' where ne_id = 1159321063;
 
 --Update Moldova name
 update ne_10m_admin_0_countries_iso set name_de = 'Moldawien' where ne_id = 1159321045;
@@ -106,11 +112,16 @@ update ne_10m_admin_0_countries_iso set name_de = 'Moldawien' where ne_id = 1159
 --Update Myanmar name
 update ne_10m_admin_0_countries_iso set name_es = 'Myanmar' where ne_id = 1159321067;
 
+--Update North Korea name
+update ne_10m_admin_0_countries_iso set name_zh = '朝鲜' where ne_id = 1159321181;
+update ne_10m_admin_0_countries_iso set name_zht = '北韓' where ne_id = 1159321181;
+
 --Update Oman name
 update ne_10m_admin_0_countries_iso set name_ar = 'عمان' where ne_id = 1159321151;
 
 --Update Saint Barthélemy name
 update ne_10m_admin_0_countries_iso set name_pt = 'São Bartolomeu' where ne_id = 1159320633;
+update ne_10m_admin_0_countries_iso set name_zht = '聖巴多祿繆島' where ne_id = 1159320633;
 
 --Update Saint Helena, Ascension and Tristan da Cunha name
 update ne_10m_admin_0_countries_iso set name_ar = 'سانت هيلينا، أسينسيون وتريستان دا كونها' where ne_id = 1159320769;
@@ -120,8 +131,17 @@ update ne_10m_admin_0_countries_iso set name_es = 'Santa Elena, Ascensión y Tri
 update ne_10m_admin_0_countries_iso set name_fr = 'Sainte-Hélène, Ascension et Tristan da Cunha' where ne_id = 1159320769;
 update ne_10m_admin_0_countries_iso set name_pt = 'Santa Helena, Ascensão e Tristão da Cunha' where ne_id = 1159320769;
 update ne_10m_admin_0_countries_iso set name_ru = 'Острова Святой Елены, Вознесения и Тристан-да-Кунья' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_zh= '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_zht = '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320769;
+
+--Update Saint Kitts and Nevis
+update ne_10m_admin_0_countries_iso set name_zht = '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320983;
 
 --Update South Africa name
+update ne_10m_admin_0_countries_iso set name_zh = '南アフリカ' where ne_id = 1159320985;
+update ne_10m_admin_0_countries_iso set name_zht = '남아프리카' where ne_id = 1159320985;
+
+--Update South Korea name
 update ne_10m_admin_0_countries_iso set name_ja = '南アフリカ' where ne_id = 1159321431;
 update ne_10m_admin_0_countries_iso set name_ko = '남아프리카' where ne_id = 1159321431;
 
@@ -130,6 +150,11 @@ update ne_10m_admin_0_countries_iso set name_de = 'Taiwan' where ne_id = 1159321
 update ne_10m_admin_0_countries_iso set name_es = 'Taiwán' where ne_id = 1159321335;
 update ne_10m_admin_0_countries_iso set name_ja = '台湾' where ne_id = 1159321335;
 update ne_10m_admin_0_countries_iso set name_ko = '타이완' where ne_id = 1159321335;
+update ne_10m_admin_0_countries_iso set name_zh = '台湾' where ne_id = 1159321335;
+update ne_10m_admin_0_countries_iso set name_zht = '臺灣' where ne_id = 1159321335;
+
+--Update Turks and Caicos Island
+update ne_10m_admin_0_countries_iso set name_zht = '特克斯和凱科斯群島' where ne_id = 1159320737;
 
 --Update United States name
 update ne_10m_admin_0_countries_iso set name_en = 'United States' where ne_id = 1159321369;

--- a/data/apply-ne_country_label_recasting.sql
+++ b/data/apply-ne_country_label_recasting.sql
@@ -97,8 +97,8 @@ update ne_10m_admin_0_countries_iso set name_ar = 'أيرلندا' where ne_id =
 update ne_10m_admin_0_countries_iso set name_pt = 'Irlanda' where ne_id = 1159320877;
 
 --Update Kosovo name
-update ne_10m_admin_0_countries_iso set name_ja = 'コソボ' where ne_id = 1159321007;
-update ne_10m_admin_0_countries_iso set name_ru = 'Косово' where ne_id = 1159321007;
+update ne_10m_admin_0_countries_tlc set name_ja = 'コソボ' where ne_id = 1159321007;
+update ne_10m_admin_0_countries_tlc set name_ru = 'Косово' where ne_id = 1159321007;
 
 --Update Mali name
 update ne_10m_admin_0_countries_iso set name_ja = 'マリ' where ne_id = 1159321063;

--- a/data/apply-ne_country_label_recasting.sql
+++ b/data/apply-ne_country_label_recasting.sql
@@ -46,9 +46,6 @@ update ne_10m_admin_0_countries_iso set wikidataid = 'Q192184' where ne_id = 115
 
 -- Fixes to country labels for some languages to shorten or match local expectations
 
---Update Australia name
-update ne_10m_admin_0_countries_iso set name_zht = '澳大利亚' where ne_id = 1159320355;
-
 --Update Bahamas name
 update ne_10m_admin_0_countries_iso set name_ru = 'Багамы' where ne_id = 1159320415;
 

--- a/data/apply-ne_country_label_recasting.sql
+++ b/data/apply-ne_country_label_recasting.sql
@@ -42,3 +42,85 @@ update ne_10m_admin_0_countries_tlc set featurecla = 'Admin-0 dependency' where 
 
 -- Fix Saint Helena wikidata id for this build. Remove once NE is updated
 update ne_10m_admin_0_countries_iso set wikidataid = 'Q192184' where ne_id = 1159320733;
+
+
+-- Fixes to country labels for some languages to shorten or match local expectations
+
+--Update China name
+update ne_10m_admin_0_countries_iso set name_de = 'China' where ne_id = 1159320471;
+update ne_10m_admin_0_countries_iso set name_en = 'China' where ne_id = 1159320471;
+update ne_10m_admin_0_countries_iso set name_fr = 'Chine' where ne_id = 1159320471;
+update ne_10m_admin_0_countries_iso set name_ko = '중국' where ne_id = 1159320471;
+
+--Update Cyprus name
+update ne_10m_admin_0_countries_iso set name_de = 'Zypern' where ne_id = 1159320533;
+
+--Update Czechia name
+update ne_10m_admin_0_countries_iso set name_en = 'Czechia' where ne_id = 1159320535;
+update ne_10m_admin_0_countries_iso set name_es = 'Chequia' where ne_id = 1159320535;
+
+--Update Dominica name
+update ne_10m_admin_0_countries_iso set name_ko = '도미니카' where ne_id = 1159320543;
+
+--Update Falklands Islands name
+update ne_10m_admin_0_countries_iso set name_en = 'Falkland Islands (Islas Malvinas)' where ne_id = 1159320711;
+update ne_10m_admin_0_countries_iso set name_fr = 'Îles Malouines (Îles Falkland)' where ne_id = 1159320711;
+update ne_10m_admin_0_countries_iso set name_ja = 'フォークランド諸島 (マルビナス諸島)' where ne_id = 1159320711;
+update ne_10m_admin_0_countries_iso set name_ko = '포클랜드 제도 (말비나스 군도)' where ne_id = 1159320711;
+
+--Update Israel name
+update ne_10m_admin_0_countries_iso set name_ar = 'فلسطين' where ne_id = 1159320895;
+update ne_10m_admin_0_countries_iso set name_id = 'Palestina' where ne_id = 1159320895;
+update ne_10m_admin_0_countries_iso set name_ur = 'فلسطین' where ne_id = 1159320895;
+
+--Update Haiti name
+update ne_10m_admin_0_countries_iso set name_ru = 'Гаити' where ne_id = 1159320839;
+
+--Update Ireland name
+update ne_10m_admin_0_countries_iso set name_ar = 'أيرلندا' where ne_id = 1159320877;
+update ne_10m_admin_0_countries_iso set name_pt = 'Irlanda' where ne_id = 1159320877;
+
+--Update Kosovo name
+update ne_10m_admin_0_countries_iso set name_ja = 'コソボ' where ne_id = 1159321007;
+
+--Update Mali name
+update ne_10m_admin_0_countries_iso set name_ja = 'マリ' where ne_id = 1159321063;
+
+--Update Moldova name
+update ne_10m_admin_0_countries_iso set name_de = 'Moldawien' where ne_id = 1159321045;
+
+--Update Myanmar name
+update ne_10m_admin_0_countries_iso set name_es = 'Myanmar' where ne_id = 1159321067;
+
+--Update North Korea name
+update ne_10m_admin_0_countries_iso set name_ = 'Корейская Народно-Демократическая Республика' where ne_id = 1159321181;
+
+--Update Oman name
+update ne_10m_admin_0_countries_iso set name_ar = 'عمان' where ne_id = 1159321151;
+
+--Update Saint Barthélemy name
+update ne_10m_admin_0_countries_iso set name_pt = 'São Bartolomeu' where ne_id = 1159320633;
+
+--Update Saint Helena, Ascension and Tristan da Cunha name
+update ne_10m_admin_0_countries_iso set name_ar = 'سانت هيلينا، أسينسيون وتريستان دا كونها' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_de = 'St. Helena, Ascension und Tristan da Cunha' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_en = 'Saint Helena, Ascension and Tristan da Cunha' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_es = 'Santa Elena, Ascensión y Tristán de Acuña' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_fr = 'Sainte-Hélène, Ascension et Tristan da Cunha' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_pt = 'Santa Helena, Ascensão e Tristão da Cunha' where ne_id = 1159320769;
+update ne_10m_admin_0_countries_iso set name_ru = 'Острова Святой Елены, Вознесения и Тристан-да-Кунья' where ne_id = 1159320769;
+
+--Update South Africa name
+update ne_10m_admin_0_countries_iso set name_ja = '南アフリカ' where ne_id = 1159321431;
+update ne_10m_admin_0_countries_iso set name_ko = '남아프리카' where ne_id = 1159321431;
+update ne_10m_admin_0_countries_iso set name_ru = 'Южно-Африканская Республика' where ne_id = 1159321431;
+
+--Update Taiwan name
+update ne_10m_admin_0_countries_iso set name_de = 'Taiwan' where ne_id = 1159321335;
+update ne_10m_admin_0_countries_iso set name_es = 'Taiwán' where ne_id = 1159321335;
+update ne_10m_admin_0_countries_iso set name_ja = '台湾' where ne_id = 1159321335;
+update ne_10m_admin_0_countries_iso set name_ko = '타이완' where ne_id = 1159321335;
+
+--Update United States name
+update ne_10m_admin_0_countries_iso set name_en = 'United States' where ne_id = 1159321369;
+update ne_10m_admin_0_countries_iso set name_ = 'Соединённые Штаты Америки' where ne_id = 1159321369;

--- a/data/apply-ne_country_label_recasting.sql
+++ b/data/apply-ne_country_label_recasting.sql
@@ -46,11 +46,27 @@ update ne_10m_admin_0_countries_iso set wikidataid = 'Q192184' where ne_id = 115
 
 -- Fixes to country labels for some languages to shorten or match local expectations
 
+--Update Australia name
+update ne_10m_admin_0_countries_iso set name_zht = '澳大利亚' where ne_id = 1159320355;
+
+--Update Bahamas name
+update ne_10m_admin_0_countries_iso set name_ru = 'Багамы' where ne_id = 1159320415;
+
+--Update Central Africa Republic name
+update ne_10m_admin_0_countries_iso set name_fr = 'Centrafrique' where ne_id = 1159320463;
+
 --Update China name
 update ne_10m_admin_0_countries_iso set name_de = 'China' where ne_id = 1159320471;
 update ne_10m_admin_0_countries_iso set name_en = 'China' where ne_id = 1159320471;
 update ne_10m_admin_0_countries_iso set name_fr = 'Chine' where ne_id = 1159320471;
 update ne_10m_admin_0_countries_iso set name_ko = '중국' where ne_id = 1159320471;
+
+--Update Cocos (Keeling) Island
+update ne_10m_admin_0_countries_iso set name_ar = 'جزر كوكوس (كيلينغ)' where ne_id = 1159320367;
+update ne_10m_admin_0_countries_iso set name_en = 'Cocos (Keeling) Islands' where ne_id = 1159320367;
+update ne_10m_admin_0_countries_iso set name_es = 'Islas Cocos (Keeling)' where ne_id = 1159320367;
+update ne_10m_admin_0_countries_iso set name_ja = 'ココス[キーリング]諸島' where ne_id = 1159320367;
+update ne_10m_admin_0_countries_iso set name_ru = 'Кокосовые (Килинг) острова' where ne_id = 1159320367;
 
 --Update Cyprus name
 update ne_10m_admin_0_countries_iso set name_de = 'Zypern' where ne_id = 1159320533;
@@ -82,6 +98,7 @@ update ne_10m_admin_0_countries_iso set name_pt = 'Irlanda' where ne_id = 115932
 
 --Update Kosovo name
 update ne_10m_admin_0_countries_iso set name_ja = 'コソボ' where ne_id = 1159321007;
+update ne_10m_admin_0_countries_iso set name_ru = 'Косово' where ne_id = 1159321007;
 
 --Update Mali name
 update ne_10m_admin_0_countries_iso set name_ja = 'マリ' where ne_id = 1159321063;
@@ -91,9 +108,6 @@ update ne_10m_admin_0_countries_iso set name_de = 'Moldawien' where ne_id = 1159
 
 --Update Myanmar name
 update ne_10m_admin_0_countries_iso set name_es = 'Myanmar' where ne_id = 1159321067;
-
---Update North Korea name
-update ne_10m_admin_0_countries_iso set name_ = 'Корейская Народно-Демократическая Республика' where ne_id = 1159321181;
 
 --Update Oman name
 update ne_10m_admin_0_countries_iso set name_ar = 'عمان' where ne_id = 1159321151;
@@ -113,7 +127,6 @@ update ne_10m_admin_0_countries_iso set name_ru = 'Острова Святой �
 --Update South Africa name
 update ne_10m_admin_0_countries_iso set name_ja = '南アフリカ' where ne_id = 1159321431;
 update ne_10m_admin_0_countries_iso set name_ko = '남아프리카' where ne_id = 1159321431;
-update ne_10m_admin_0_countries_iso set name_ru = 'Южно-Африканская Республика' where ne_id = 1159321431;
 
 --Update Taiwan name
 update ne_10m_admin_0_countries_iso set name_de = 'Taiwan' where ne_id = 1159321335;
@@ -123,4 +136,3 @@ update ne_10m_admin_0_countries_iso set name_ko = '타이완' where ne_id = 1159
 
 --Update United States name
 update ne_10m_admin_0_countries_iso set name_en = 'United States' where ne_id = 1159321369;
-update ne_10m_admin_0_countries_iso set name_ = 'Соединённые Штаты Америки' where ne_id = 1159321369;

--- a/data/apply-ne_country_label_recasting.sql
+++ b/data/apply-ne_country_label_recasting.sql
@@ -135,15 +135,15 @@ update ne_10m_admin_0_countries_iso set name_zh= '圣赫勒拿、阿森松和特
 update ne_10m_admin_0_countries_iso set name_zht = '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320733;
 
 --Update Saint Kitts and Nevis
-update ne_10m_admin_0_countries_iso set name_zht = '圣赫勒拿、阿森松和特里斯坦-达库尼亚' where ne_id = 1159320983;
+update ne_10m_admin_0_countries_iso set name_zht = '圣基茨和尼维斯' where ne_id = 1159320983;
 
 --Update South Africa name
-update ne_10m_admin_0_countries_iso set name_zh = '南アフリカ' where ne_id = 1159320985;
-update ne_10m_admin_0_countries_iso set name_zht = '남아프리카' where ne_id = 1159320985;
-
---Update South Korea name
 update ne_10m_admin_0_countries_iso set name_ja = '南アフリカ' where ne_id = 1159321431;
 update ne_10m_admin_0_countries_iso set name_ko = '남아프리카' where ne_id = 1159321431;
+
+--Update South Korea name
+update ne_10m_admin_0_countries_iso set name_zh = '韩国' where ne_id = 1159320985;
+update ne_10m_admin_0_countries_iso set name_zht = '南韓' where ne_id = 1159320985;
 
 --Update Taiwan name
 update ne_10m_admin_0_countries_iso set name_de = 'Taiwan' where ne_id = 1159321335;

--- a/data/functions.sql
+++ b/data/functions.sql
@@ -1302,8 +1302,8 @@ BEGIN
             'ne_name_uk', i.name_uk,
             'ne_name_ur', i.name_ur,
             'ne_name_vi', i.name_vi,
-            'ne_name_zh', i.name_zh,
-            'ne_name_zht', i.name_zht
+            'ne_name_zh-Hans', i.name_zh,
+            'ne_name_zh-Hant', i.name_zht
             ]) INTO ne_name_tags
         FROM ne_10m_admin_0_countries_iso i
         WHERE i.wikidataid = wikidata_id;
@@ -1335,8 +1335,8 @@ BEGIN
                 'ne_name_uk', t.name_uk,
                 'ne_name_ur', t.name_ur,
                 'ne_name_vi', t.name_vi,
-                'ne_name_zh', t.name_zh,
-                'ne_name_zht', t.name_zht
+                'ne_name_zh-Hans', t.name_zh,
+                'ne_name_zh-Hant', t.name_zht
                 ]) INTO ne_name_tags
             FROM ne_10m_admin_0_countries_tlc t
             WHERE t.wikidataid = wikidata_id
@@ -1370,8 +1370,8 @@ BEGIN
                 'ne_name_uk', sp.name_uk,
                 'ne_name_ur', sp.name_ur,
                 'ne_name_vi', sp.name_vi,
-                'ne_name_zh', sp.name_zh,
-                'ne_name_zht', sp.name_zht
+                'ne_name_zh-Hans', sp.name_zh,
+                'ne_name_zh-Hant', sp.name_zht
                 ]) INTO ne_name_tags
             FROM ne_10m_admin_1_states_provinces sp
             WHERE sp.wikidataid = wikidata_id;
@@ -1403,8 +1403,8 @@ BEGIN
                 'ne_name_uk', pp.name_uk,
                 'ne_name_ur', pp.name_ur,
                 'ne_name_vi', pp.name_vi,
-                'ne_name_zh', pp.name_zh,
-                'ne_name_zht', pp.name_zht
+                'ne_name_zh-Hans', pp.name_zh,
+                'ne_name_zh-Hant', pp.name_zht
                 ]) INTO ne_name_tags
             FROM ne_10m_populated_places pp
             WHERE pp.wikidataid = wikidata_id;

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -98,7 +98,7 @@ class CountryBoundaryTest(FixtureTest):
         # should get a section recognised only by XX
         self.assert_has_feature(
             z, x, y, 'boundaries', {
-                'kind': 'unrecognized_country',
+                'kind': 'disputed_claim',
                 'kind:xx': 'country',
                 'name': 'XX Claim',
 
@@ -157,7 +157,7 @@ class CountryBoundaryTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 # generally unrecognised
-                'kind': 'unrecognized_country',
+                'kind': 'disputed_claim',
                 # but BB & CC both claim this as a border
                 'kind:bb': 'country',
                 'kind:cc': 'country',

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -98,7 +98,7 @@ class CountryBoundaryTest(FixtureTest):
         # should get a section recognised only by XX
         self.assert_has_feature(
             z, x, y, 'boundaries', {
-                'kind': 'disputed_claim',
+                'kind': 'unrecognized',
                 'kind:xx': 'country',
                 'name': 'XX Claim',
 
@@ -111,14 +111,14 @@ class CountryBoundaryTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 'kind': 'country',
-                'kind:xx': 'unrecognized_country',
+                'kind:xx': 'unrecognized',
                 'name': 'XX - YY',
             })
 
     def test_claim(self):
         # test that a claim by countries BB & CC (and recognised by DD) is
         # only kind:country for those countries. everyone else's view is
-        # kind: unrecognized_country.
+        # kind: unrecognized.
         #
         # TODO: recognized_by not working yet.
         import dsl
@@ -157,7 +157,7 @@ class CountryBoundaryTest(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'boundaries', {
                 # generally unrecognised
-                'kind': 'disputed_claim',
+                'kind': 'unrecognized',
                 # but BB & CC both claim this as a border
                 'kind:bb': 'country',
                 'kind:cc': 'country',
@@ -165,7 +165,7 @@ class CountryBoundaryTest(FixtureTest):
                 # added to the output even though it duplicates the kind. this
                 # is to help with multi-level fallback. see
                 # https://github.com/tilezen/vector-datasource/pull/1895#discussion_r283912502
-                'kind:aa': 'unrecognized_country',
+                'kind:aa': 'unrecognized',
                 # DD recognizes BB's claim, so should see this as a country.
                 'kind:dd': 'country',
             })

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -297,6 +297,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'place:IT': 'town',
                 'place:TR': 'not_there',
                 'place:XX': 'country',
+                '__ne_min_zoom': 4,
                 'source': u'openstreetmap.org',
                 'source:sqkm': u'CIA World Factbook',
             }),

--- a/integration-test/2068-place-unrecognized.py
+++ b/integration-test/2068-place-unrecognized.py
@@ -18,5 +18,5 @@ class TestPlaceUnrecognized(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'places', {
                 'kind': 'unrecognized',
-                'min_zoom': 6,
+                'min_zoom': 8,
             })

--- a/integration-test/2081-tlc-pov.py
+++ b/integration-test/2081-tlc-pov.py
@@ -90,6 +90,7 @@ class TestTLCPOV(FixtureTest):
                 'place:TLC': 'district',
                 'source': 'openstreetmap.org',
                 'source:sqkm': 'CIA World Factbook',
+                '__ne_min_zoom': 4,
             }),
         )
 

--- a/integration-test/2088-use-NE-name.py
+++ b/integration-test/2088-use-NE-name.py
@@ -12,16 +12,22 @@ class TestNEName(FixtureTest):
                 u'place': u'country',
                 u'name': u'Schweiz/Suisse/Svizzera/Svizra',
                 u'name:en': u'Switzerland',
+                u'name:zh-Hans': u'瑞士',
+                u'name:zh-Hant': u'瑞士',
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30',
-                u'ne_name_en': u'Test'
+                u'ne_name_en': u'Test',
+                u'ne_name_zh-Hans': u'瑞士联邦',
+                u'ne_name_zh-Hant': u'瑞士聯邦'
             }),
         )
 
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 10200326532,
-                'name:en': u'Test'
+                'name:en': u'Test',
+                'name:zh-Hans': u'瑞士联邦',
+                'name:zh-Hant': u'瑞士聯邦'
             })
 
     def test_use_ne_name_hamlet(self):
@@ -32,16 +38,22 @@ class TestNEName(FixtureTest):
                 u'place': u'hamlet',
                 u'name': u'Schweiz/Suisse/Svizzera/Svizra',
                 u'name:en': u'Switzerland',
+                u'name:zh-Hans': u'瑞士',
+                u'name:zh-Hant': u'瑞士',
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30',
-                u'ne_name_en': u'Test'
+                u'ne_name_en': u'Test',
+                u'ne_name_zh-Hans': u'瑞士联邦',
+                u'ne_name_zh-Hant': u'瑞士聯邦'
             }),
         )
 
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 10200326532,
-                'name:en': u'Test'
+                'name:en': u'Test',
+                'name:zh-Hans': u'瑞士联邦',
+                'name:zh-Hant': u'瑞士聯邦'
             })
 
     def test_no_ne_name(self):
@@ -52,15 +64,19 @@ class TestNEName(FixtureTest):
                 u'place': u'country',
                 u'name': u'Schweiz/Suisse/Svizzera/Svizra',
                 u'name:en': u'Switzerland',
+                u'name:zh-Hans': u'瑞士',
+                u'name:zh-Hant': u'瑞士',
                 u'source': u'openstreetmap.org',
-                u'wikidata': u'Q30',
+                u'wikidata': u'Q30'
             }),
         )
 
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 10200326532,
-                'name:en': u'Switzerland'
+                'name:en': u'Switzerland',
+                'name:zh-Hans': u'瑞士',
+                'name:zh-Hant': u'瑞士'
             })
 
     def test_null_name(self):

--- a/integration-test/2088-use-NE-name.py
+++ b/integration-test/2088-use-NE-name.py
@@ -12,13 +12,13 @@ class TestNEName(FixtureTest):
                 u'place': u'country',
                 u'name': u'Schweiz/Suisse/Svizzera/Svizra',
                 u'name:en': u'Switzerland',
-                u'name:zh-Hans': u'瑞士',
-                u'name:zh-Hant': u'瑞士',
+                u'name:zh-Hans': u'\u745e\u58eb',
+                u'name:zh-Hant': u'\u745e\u58eb',
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30',
                 u'ne_name_en': u'Test',
-                u'ne_name_zh-Hans': u'瑞士联邦',
-                u'ne_name_zh-Hant': u'瑞士聯邦'
+                u'ne_name_zh-Hans': u'\u745e\u58eb\u8054\u90a6',
+                u'ne_name_zh-Hant': u'\u745e\u58eb\u806f\u90a6'
             }),
         )
 
@@ -26,8 +26,8 @@ class TestNEName(FixtureTest):
             z, x, y, 'places', {
                 'id': 10200326532,
                 'name:en': u'Test',
-                'name:zh-Hans': u'瑞士联邦',
-                'name:zh-Hant': u'瑞士聯邦'
+                'name:zh-Hans': u'\u745e\u58eb\u8054\u90a6',
+                'name:zh-Hant': u'\u745e\u58eb\u806f\u90a6'
             })
 
     def test_use_ne_name_hamlet(self):
@@ -38,13 +38,13 @@ class TestNEName(FixtureTest):
                 u'place': u'hamlet',
                 u'name': u'Schweiz/Suisse/Svizzera/Svizra',
                 u'name:en': u'Switzerland',
-                u'name:zh-Hans': u'瑞士',
-                u'name:zh-Hant': u'瑞士',
+                u'name:zh-Hans': u'\u745e\u58eb',
+                u'name:zh-Hant': u'\u745e\u58eb',
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30',
                 u'ne_name_en': u'Test',
-                u'ne_name_zh-Hans': u'瑞士联邦',
-                u'ne_name_zh-Hant': u'瑞士聯邦'
+                u'ne_name_zh-Hans': u'\u745e\u58eb\u8054\u90a6',
+                u'ne_name_zh-Hant': u'\u745e\u58eb\u806f\u90a6'
             }),
         )
 
@@ -52,8 +52,8 @@ class TestNEName(FixtureTest):
             z, x, y, 'places', {
                 'id': 10200326532,
                 'name:en': u'Test',
-                'name:zh-Hans': u'瑞士联邦',
-                'name:zh-Hant': u'瑞士聯邦'
+                'name:zh-Hans': u'\u745e\u58eb\u8054\u90a6',
+                'name:zh-Hant': u'\u745e\u58eb\u806f\u90a6'
             })
 
     def test_no_ne_name(self):
@@ -64,8 +64,8 @@ class TestNEName(FixtureTest):
                 u'place': u'country',
                 u'name': u'Schweiz/Suisse/Svizzera/Svizra',
                 u'name:en': u'Switzerland',
-                u'name:zh-Hans': u'瑞士',
-                u'name:zh-Hant': u'瑞士',
+                u'name:zh-Hans': u'\u745e\u58eb',
+                u'name:zh-Hant': u'\u745e\u58eb',
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30'
             }),
@@ -75,8 +75,8 @@ class TestNEName(FixtureTest):
             z, x, y, 'places', {
                 'id': 10200326532,
                 'name:en': u'Switzerland',
-                'name:zh-Hans': u'瑞士',
-                'name:zh-Hant': u'瑞士'
+                'name:zh-Hans': u'\u745e\u58eb',
+                'name:zh-Hant': u'\u745e\u58eb'
             })
 
     def test_null_name(self):

--- a/integration-test/2088-use-NE-name.py
+++ b/integration-test/2088-use-NE-name.py
@@ -16,6 +16,7 @@ class TestNEName(FixtureTest):
                 u'name:zh-Hant': u'\u745e\u58eb',
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30',
+                u'__ne_min_zoom': 4,
                 u'ne_name_en': u'Test',
                 u'ne_name_zh-Hans': u'\u745e\u58eb\u8054\u90a6',
                 u'ne_name_zh-Hant': u'\u745e\u58eb\u806f\u90a6'
@@ -25,6 +26,7 @@ class TestNEName(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 10200326532,
+                'kind': 'country',
                 'name:en': u'Test',
                 'name:zh-Hans': u'\u745e\u58eb\u8054\u90a6',
                 'name:zh-Hant': u'\u745e\u58eb\u806f\u90a6'
@@ -51,6 +53,7 @@ class TestNEName(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 10200326532,
+                'kind': 'locality',
                 'name:en': u'Test',
                 'name:zh-Hans': u'\u745e\u58eb\u8054\u90a6',
                 'name:zh-Hant': u'\u745e\u58eb\u806f\u90a6'
@@ -66,6 +69,7 @@ class TestNEName(FixtureTest):
                 u'name:en': u'Switzerland',
                 u'name:zh-Hans': u'\u745e\u58eb',
                 u'name:zh-Hant': u'\u745e\u58eb',
+                u'__ne_min_zoom': 4,
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30'
             }),
@@ -74,6 +78,7 @@ class TestNEName(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 10200326532,
+                'kind': 'country',
                 'name:en': u'Switzerland',
                 'name:zh-Hans': u'\u745e\u58eb',
                 'name:zh-Hant': u'\u745e\u58eb'
@@ -89,6 +94,7 @@ class TestNEName(FixtureTest):
                 u'name:en': u'Switzerland',
                 u'source': u'openstreetmap.org',
                 u'wikidata': u'Q30',
+                u'__ne_min_zoom': 4,
                 u'ne_name_en': u''
             }),
         )
@@ -96,5 +102,6 @@ class TestNEName(FixtureTest):
         self.assert_has_feature(
             z, x, y, 'places', {
                 'id': 10200326532,
+                'kind': 'country',
                 'name:en': u'Switzerland'
             })

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -153,6 +153,7 @@ class CountryTest(FixtureTest):
                 'name': 'Foo Country',
                 'population': '1000000000',
                 'source': 'openstreetmap.org',
+                '__ne_min_zoom': 4,
             }),
         )
 

--- a/osm2pgsql.lua
+++ b/osm2pgsql.lua
@@ -462,12 +462,6 @@ function osm2pgsql.process_node(object)
         output_hstore['place'] = 'country'
         output_hstore['disputed_by'] = 'FR;ID;IN;MA;NL;Pl;PS;SA;TR'
     end
--- Redefine Israel country label for SA;PK;ID
-    if object.tags.place and object.tags.wikidata == 'Q801' then
-        output_hstore["name:id"] = 'Palestina'
-        output_hstore["name:ur"] = 'فلسطین'
-        output_hstore["name:ar"] = 'فلسطين'
-    end
 -- Recast Taiwan country label as region label for China POV
     if object.tags.place and object.tags.wikidata == 'Q865' then
         output_hstore['place:CN'] = 'region'
@@ -646,20 +640,6 @@ function osm2pgsql.process_node(object)
 -- French Guiana
     if object.tags.place == 'state' and object.tags['ISO3166-1'] == 'GF' then
         output_hstore['place'] = 'country'
-    end
-
--- Update names of some countries for better rendering. We will update the data and deprecate this eventually.
--- Rename Falkland Islands
-    if object.tags.place == 'country' and object.tags['ISO3166-1'] == 'FK' then
-        output_hstore['name:en'] = 'Falkland Islands (Islas Malvinas)'
-    end
--- Rename Saint Martin
-    if object.tags.place == 'state' and object.tags['ISO3166-1'] == 'MF' then
-        output_hstore['name:en'] = 'Saint Martin'
-    end
--- Rename Sint Maarten
-    if object.tags.place == 'country' and object.tags['ISO3166-1'] == 'SX' then
-        output_hstore['name:en'] = 'Sint Maarten'
     end
 
     output.tags = output_hstore

--- a/scripts/disputed_relation_overpass_query.txt
+++ b/scripts/disputed_relation_overpass_query.txt
@@ -84,12 +84,12 @@ rel(13563121); // Extent of Claim at South Ossetia
 rel(13573737); // Extent of Chilean Claim at Southern Glaciers Field
 rel(13573738); // Extent of Argentinian Claim at Southern Glaciers Field
 rel(13573952); // Extent of Claim at Abkhazia
-rel(13573966); // Extent of Claim at Donbass
+// timeline(rel,13573966);foreach(retro(u(t["created"]))(rel(13573966);(._;>;); out meta;);); // Extent of Claim at Donbass
 rel(13573969); // Extent of Belize Claim
 rel(13573970); // Extent of Guatemalan Claim
 rel(13573985); // Extent of Kosovo Claim
 rel(13574165); // Extent of Israeli Claim at Golan Heights
-rel(13574166); // 1949 Israeli–Syrian DMZ
+timeline(rel,13574166);foreach(retro(u(t["created"]))(rel(13574166);(._;>;); out meta;);); // 1949 Israeli–Syrian DMZ
 rel(13574167); // Extent of Syrian Claims at Golan Heights
 rel(13790690); // Approximate Extent of Siachen Glacier Dispute
 rel(13812677); // Line of Control at Demchok

--- a/vectordatasource/transform.py
+++ b/vectordatasource/transform.py
@@ -9755,6 +9755,7 @@ def override_with_ne_names(shape, props, fid, zoom):
             language = k[len(name_prefix):]
             ne_name = props.pop(k)
 
-            props['name:' + language] = ne_name
+            if len(ne_name) > 0:
+                props['name:' + language] = ne_name
 
     return shape, props, fid

--- a/yaml/places.yaml
+++ b/yaml/places.yaml
@@ -152,8 +152,8 @@ global:
     __ne_name_uk: {col: ne_name_uk}
     __ne_name_ur: {col: ne_name_ur}
     __ne_name_vi: {col: ne_name_vi}
-    __ne_name_zh: {col: ne_name_zh}
-    __ne_name_zht: {col: ne_name_zht}
+    __ne_name_zh-Hans: {col: ne_name_zh-Hans}
+    __ne_name_zh-Hant: {col: ne_name_zh-Hant}
 
 filters:
   - filter:


### PR DESCRIPTION
Some country names in Natural Earth are undesirable so this changes them back to their OSM names which are generally shorter. Most of these changes can be deprecated once NE is updated.

There was also an issue with the overwriting of chinese names with NE as the column name was incorrect that has been fixed and added to the test.

This also addresses some broken country related tests that needed fixing