### PR TITLE
Disable broken integ tests

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -101,4 +101,4 @@ Additionally, optional arguments can be provided to `load_fixtures`:
 NOTE: z/x/y coordinates [are describing location and zoom level](https://mapzen.com/documentation/vector-tiles/use-service/#specify-z-x-and-y-tile-coordinates).
 
 ## Skipped Tests
-There are some broken tests that are decorated with `@unittest.skip(SKIP_UNIT_TEST_REASON)` are currently skipped. Once these tests are fixed, we can remove the decorators.
+There are some broken tests that are decorated with `@unittest.skip(BROKEN)` are currently skipped. Once these tests are fixed, we can remove the decorators.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -101,4 +101,4 @@ Additionally, optional arguments can be provided to `load_fixtures`:
 NOTE: z/x/y coordinates [are describing location and zoom level](https://mapzen.com/documentation/vector-tiles/use-service/#specify-z-x-and-y-tile-coordinates).
 
 ## Skipped Tests
-There are some broken tests that are decorated with `@unittest.skip(BROKEN)` are currently skipped. Once these tests are fixed, we can remove the decorators.
+There are some broken tests that we skip with the `@unittest.skip(BROKEN)` decorator. Once these tests are fixed, we can remove the decorators.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -101,4 +101,4 @@ Additionally, optional arguments can be provided to `load_fixtures`:
 NOTE: z/x/y coordinates [are describing location and zoom level](https://mapzen.com/documentation/vector-tiles/use-service/#specify-z-x-and-y-tile-coordinates).
 
 ## Skipped Tests
-There are some tests that are decorated with `@unittest.skip` that are currently skipped. Once these tests are fixed, we can remove the decorators.
+There are some tests that are decorated with `@unittest.skip(SKIP_UNIT_TEST_MESSAGE)` that are currently skipped. Once these tests are fixed, we can remove the decorators.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -101,4 +101,4 @@ Additionally, optional arguments can be provided to `load_fixtures`:
 NOTE: z/x/y coordinates [are describing location and zoom level](https://mapzen.com/documentation/vector-tiles/use-service/#specify-z-x-and-y-tile-coordinates).
 
 ## Skipped Tests
-There are some tests that are decorated with `@unittest.skip(SKIP_UNIT_TEST_MESSAGE)` that are currently skipped. Once these tests are fixed, we can remove the decorators.
+There are some broken tests that are decorated with `@unittest.skip(SKIP_UNIT_TEST_REASON)` are currently skipped. Once these tests are fixed, we can remove the decorators.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -99,3 +99,6 @@ Additionally, optional arguments can be provided to `load_fixtures`:
 * `simplify=...` generalises the geometry to the tolerance given as the argument. This is also useful for reducing the size of fixtures and the complexity of the processing when the test does not need the geometry to be accurate.
 
 NOTE: z/x/y coordinates [are describing location and zoom level](https://mapzen.com/documentation/vector-tiles/use-service/#specify-z-x-and-y-tile-coordinates).
+
+## Skipped Tests
+There are some tests that are decorated with `@unittest.skip` that are currently skipped. Once these tests are fixed, we can remove the decorators.

--- a/integration-test/1082-common.py
+++ b/integration-test/1082-common.py
@@ -2,11 +2,11 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class CommonTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_blithedale_summit_landuse(self):
         import dsl
 

--- a/integration-test/1082-common.py
+++ b/integration-test/1082-common.py
@@ -1,12 +1,12 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class CommonTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_blithedale_summit_landuse(self):
         import dsl
 

--- a/integration-test/1082-common.py
+++ b/integration-test/1082-common.py
@@ -1,9 +1,12 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class CommonTest(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_blithedale_summit_landuse(self):
         import dsl
 

--- a/integration-test/1170-very-early-paths-and-bike-routes.py
+++ b/integration-test/1170-very-early-paths-and-bike-routes.py
@@ -1,9 +1,13 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class VeryEarlyPathsAndBikeRoutes(FixtureTest):
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_path_with_international_route(self):
         # highway=path, with route inter-national
         # GR5-Grand Traverse de Jura between France and Switzerland
@@ -36,6 +40,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             9, 265, 179, 'roads',
             {'kind': 'path', 'walking_network': 'iwn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_path_with_national_route(self):
         # highway=path, with route national (Pacific Crest Trail) at zoom 9
         #         self.load_fixtures([
@@ -86,6 +91,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             11, 343, 792, 'roads',
             {'kind': 'path', 'walking_network': 'rwn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_unclassified_with_local_route(self):
         # highway=unclassified, with route local (Grant Avenue) at zoom 12
         # part of The Barbary Coast Trail in San Francisco
@@ -98,6 +104,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             12, 655, 1582, 'roads',
             {'kind': 'minor_road', 'walking_network': 'lwn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_secondary_with_international_route(self):
         # Strøby Bygade secondary road part of international cycle network
         # https://www.openstreetmap.org/relation/28441
@@ -120,6 +127,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'secondary',
              'is_bicycle_related': True, 'bicycle_network': 'icn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_teriary_with_national_route(self):
         # Sundbylillevej tertiary road part of national cycle network
         self.load_fixtures([
@@ -132,6 +140,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'tertiary',
              'is_bicycle_related': True, 'bicycle_network': 'ncn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_cycleway_with_international_route(self):
         # Way: North Sea Cycle Route - part Netherlands (1977662)
         # A really long highway=cycleway
@@ -203,6 +212,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'path', 'is_bicycle_related': True,
              'bicycle_network': 'icn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_ferry_with_international_route(self):
         # Ferry between Denmark and Germany, icn
         self.load_fixtures([
@@ -215,6 +225,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'ferry', 'is_bicycle_related': True,
              'bicycle_network': 'icn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_minor_road_with_national_route(self):
         # Søndervangsvej minor road in Denmark as national cycle route
         self.load_fixtures([
@@ -247,6 +258,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'path', 'is_bicycle_related': True,
              'bicycle_network': type(None)})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_residential_with_regional_route(self):
         # Hyltebjerg Allé residential road with rcn in Copenhagen
         self.load_fixtures([

--- a/integration-test/1170-very-early-paths-and-bike-routes.py
+++ b/integration-test/1170-very-early-paths-and-bike-routes.py
@@ -2,12 +2,12 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class VeryEarlyPathsAndBikeRoutes(FixtureTest):
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_path_with_international_route(self):
         # highway=path, with route inter-national
         # GR5-Grand Traverse de Jura between France and Switzerland
@@ -40,7 +40,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             9, 265, 179, 'roads',
             {'kind': 'path', 'walking_network': 'iwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_path_with_national_route(self):
         # highway=path, with route national (Pacific Crest Trail) at zoom 9
         #         self.load_fixtures([
@@ -91,7 +91,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             11, 343, 792, 'roads',
             {'kind': 'path', 'walking_network': 'rwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_unclassified_with_local_route(self):
         # highway=unclassified, with route local (Grant Avenue) at zoom 12
         # part of The Barbary Coast Trail in San Francisco
@@ -104,7 +104,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             12, 655, 1582, 'roads',
             {'kind': 'minor_road', 'walking_network': 'lwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_secondary_with_international_route(self):
         # Strøby Bygade secondary road part of international cycle network
         # https://www.openstreetmap.org/relation/28441
@@ -127,7 +127,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'secondary',
              'is_bicycle_related': True, 'bicycle_network': 'icn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_teriary_with_national_route(self):
         # Sundbylillevej tertiary road part of national cycle network
         self.load_fixtures([
@@ -140,7 +140,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'tertiary',
              'is_bicycle_related': True, 'bicycle_network': 'ncn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_cycleway_with_international_route(self):
         # Way: North Sea Cycle Route - part Netherlands (1977662)
         # A really long highway=cycleway
@@ -212,7 +212,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'path', 'is_bicycle_related': True,
              'bicycle_network': 'icn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_ferry_with_international_route(self):
         # Ferry between Denmark and Germany, icn
         self.load_fixtures([
@@ -225,7 +225,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'ferry', 'is_bicycle_related': True,
              'bicycle_network': 'icn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_minor_road_with_national_route(self):
         # Søndervangsvej minor road in Denmark as national cycle route
         self.load_fixtures([
@@ -258,7 +258,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'path', 'is_bicycle_related': True,
              'bicycle_network': type(None)})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_residential_with_regional_route(self):
         # Hyltebjerg Allé residential road with rcn in Copenhagen
         self.load_fixtures([

--- a/integration-test/1170-very-early-paths-and-bike-routes.py
+++ b/integration-test/1170-very-early-paths-and-bike-routes.py
@@ -1,13 +1,13 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class VeryEarlyPathsAndBikeRoutes(FixtureTest):
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_path_with_international_route(self):
         # highway=path, with route inter-national
         # GR5-Grand Traverse de Jura between France and Switzerland
@@ -40,7 +40,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             9, 265, 179, 'roads',
             {'kind': 'path', 'walking_network': 'iwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_path_with_national_route(self):
         # highway=path, with route national (Pacific Crest Trail) at zoom 9
         #         self.load_fixtures([
@@ -91,7 +91,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             11, 343, 792, 'roads',
             {'kind': 'path', 'walking_network': 'rwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_unclassified_with_local_route(self):
         # highway=unclassified, with route local (Grant Avenue) at zoom 12
         # part of The Barbary Coast Trail in San Francisco
@@ -104,7 +104,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             12, 655, 1582, 'roads',
             {'kind': 'minor_road', 'walking_network': 'lwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_secondary_with_international_route(self):
         # Strøby Bygade secondary road part of international cycle network
         # https://www.openstreetmap.org/relation/28441
@@ -127,7 +127,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'secondary',
              'is_bicycle_related': True, 'bicycle_network': 'icn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_teriary_with_national_route(self):
         # Sundbylillevej tertiary road part of national cycle network
         self.load_fixtures([
@@ -140,7 +140,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'tertiary',
              'is_bicycle_related': True, 'bicycle_network': 'ncn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_cycleway_with_international_route(self):
         # Way: North Sea Cycle Route - part Netherlands (1977662)
         # A really long highway=cycleway
@@ -212,7 +212,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'path', 'is_bicycle_related': True,
              'bicycle_network': 'icn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_ferry_with_international_route(self):
         # Ferry between Denmark and Germany, icn
         self.load_fixtures([
@@ -225,7 +225,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'ferry', 'is_bicycle_related': True,
              'bicycle_network': 'icn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_minor_road_with_national_route(self):
         # Søndervangsvej minor road in Denmark as national cycle route
         self.load_fixtures([
@@ -258,7 +258,7 @@ class VeryEarlyPathsAndBikeRoutes(FixtureTest):
             {'kind': 'path', 'is_bicycle_related': True,
              'bicycle_network': type(None)})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_residential_with_regional_route(self):
         # Hyltebjerg Allé residential road with rcn in Copenhagen
         self.load_fixtures([

--- a/integration-test/1178-earlier-piers.py
+++ b/integration-test/1178-earlier-piers.py
@@ -1,10 +1,14 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class EarlierPiers(FixtureTest):
 
     def test_very_large_pier(self):

--- a/integration-test/1178-earlier-piers.py
+++ b/integration-test/1178-earlier-piers.py
@@ -5,10 +5,10 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class EarlierPiers(FixtureTest):
 
     def test_very_large_pier(self):

--- a/integration-test/1178-earlier-piers.py
+++ b/integration-test/1178-earlier-piers.py
@@ -4,11 +4,11 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class EarlierPiers(FixtureTest):
 
     def test_very_large_pier(self):

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -1,9 +1,12 @@
+import unittest
+
 import dsl
-from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class BusRouteRefs(FixtureTest):
     def test_one_bus_route(self):
         # Sloat Blvd, part of:

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -3,10 +3,10 @@ import unittest
 import dsl
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class BusRouteRefs(FixtureTest):
     def test_one_bus_route(self):
         # Sloat Blvd, part of:

--- a/integration-test/1194-bus-route-refs.py
+++ b/integration-test/1194-bus-route-refs.py
@@ -2,11 +2,11 @@ import unittest
 
 import dsl
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class BusRouteRefs(FixtureTest):
     def test_one_bus_route(self):
         # Sloat Blvd, part of:

--- a/integration-test/1250-early-unclassified-roads.py
+++ b/integration-test/1250-early-unclassified-roads.py
@@ -4,11 +4,11 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class EarlyUnclassifiedRoads(FixtureTest):
 
     def test_early_unclassified_road1_utah(self):

--- a/integration-test/1250-early-unclassified-roads.py
+++ b/integration-test/1250-early-unclassified-roads.py
@@ -5,10 +5,10 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class EarlyUnclassifiedRoads(FixtureTest):
 
     def test_early_unclassified_road1_utah(self):

--- a/integration-test/1250-early-unclassified-roads.py
+++ b/integration-test/1250-early-unclassified-roads.py
@@ -1,10 +1,14 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class EarlyUnclassifiedRoads(FixtureTest):
 
     def test_early_unclassified_road1_utah(self):

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -1,8 +1,12 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class RoadsSurface(FixtureTest):
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_cobblestones(self):
         # Add surface properties to roads layer (at max zooms)
         # Prince St with cobblestones in Alexandria, VA
@@ -30,6 +34,7 @@ class RoadsSurface(FixtureTest):
             7, 71, 43, 'roads',
             {'kind_detail': 'motorway', 'surface': 'asphalt'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_concrete_lanes(self):
         # track with cycling route in Schartau, Germany
         # http://www.openstreetmap.org/way/58691615

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -2,11 +2,11 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class RoadsSurface(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_cobblestones(self):
         # Add surface properties to roads layer (at max zooms)
         # Prince St with cobblestones in Alexandria, VA
@@ -34,7 +34,7 @@ class RoadsSurface(FixtureTest):
             7, 71, 43, 'roads',
             {'kind_detail': 'motorway', 'surface': 'asphalt'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_concrete_lanes(self):
         # track with cycling route in Schartau, Germany
         # http://www.openstreetmap.org/way/58691615

--- a/integration-test/1252-roads-surface.py
+++ b/integration-test/1252-roads-surface.py
@@ -1,12 +1,12 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class RoadsSurface(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_cobblestones(self):
         # Add surface properties to roads layer (at max zooms)
         # Prince St with cobblestones in Alexandria, VA
@@ -34,7 +34,7 @@ class RoadsSurface(FixtureTest):
             7, 71, 43, 'roads',
             {'kind_detail': 'motorway', 'surface': 'asphalt'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_concrete_lanes(self):
         # track with cycling route in Schartau, Germany
         # http://www.openstreetmap.org/way/58691615

--- a/integration-test/1259-add-grassland-polygons.py
+++ b/integration-test/1259-add-grassland-polygons.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class GrasslandTest(FixtureTest):
@@ -104,6 +107,7 @@ class GrasslandTest(FixtureTest):
                 'kind': 'bare_rock',
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_desert(self):
         import dsl
 

--- a/integration-test/1259-add-grassland-polygons.py
+++ b/integration-test/1259-add-grassland-polygons.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class GrasslandTest(FixtureTest):
@@ -107,7 +107,7 @@ class GrasslandTest(FixtureTest):
                 'kind': 'bare_rock',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_desert(self):
         import dsl
 

--- a/integration-test/1259-add-grassland-polygons.py
+++ b/integration-test/1259-add-grassland-polygons.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class GrasslandTest(FixtureTest):
@@ -107,7 +107,7 @@ class GrasslandTest(FixtureTest):
                 'kind': 'bare_rock',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_desert(self):
         import dsl
 

--- a/integration-test/1273-roads-access.py
+++ b/integration-test/1273-roads-access.py
@@ -1,12 +1,15 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class RoadsAccess(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_restricted_access(self):
         # Add surface properties to roads layer (at max zooms)
         # restricted access road in military base, Kraków, Poland

--- a/integration-test/1273-roads-access.py
+++ b/integration-test/1273-roads-access.py
@@ -5,11 +5,11 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class RoadsAccess(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_restricted_access(self):
         # Add surface properties to roads layer (at max zooms)
         # restricted access road in military base, Kraków, Poland

--- a/integration-test/1273-roads-access.py
+++ b/integration-test/1273-roads-access.py
@@ -4,12 +4,12 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class RoadsAccess(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_restricted_access(self):
         # Add surface properties to roads layer (at max zooms)
         # restricted access road in military base, Kraków, Poland

--- a/integration-test/1298-missing-road.py
+++ b/integration-test/1298-missing-road.py
@@ -1,10 +1,10 @@
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class MissingRoad(FixtureTest):
     def test_route_611(self):
         # Relation: route 611 (975266)

--- a/integration-test/1298-missing-road.py
+++ b/integration-test/1298-missing-road.py
@@ -1,10 +1,10 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class MissingRoad(FixtureTest):
     def test_route_611(self):
         # Relation: route 611 (975266)

--- a/integration-test/1298-missing-road.py
+++ b/integration-test/1298-missing-road.py
@@ -1,6 +1,10 @@
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class MissingRoad(FixtureTest):
     def test_route_611(self):
         # Relation: route 611 (975266)

--- a/integration-test/1331-drop-road-properties.py
+++ b/integration-test/1331-drop-road-properties.py
@@ -1,11 +1,11 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class DropRoadPropertiesTest(FixtureTest):
 
     def test_rcn(self):

--- a/integration-test/1331-drop-road-properties.py
+++ b/integration-test/1331-drop-road-properties.py
@@ -2,10 +2,10 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class DropRoadPropertiesTest(FixtureTest):
 
     def test_rcn(self):

--- a/integration-test/1331-drop-road-properties.py
+++ b/integration-test/1331-drop-road-properties.py
@@ -1,7 +1,11 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class DropRoadPropertiesTest(FixtureTest):
 
     def test_rcn(self):

--- a/integration-test/1353-ne-min-zoom-roads.py
+++ b/integration-test/1353-ne-min-zoom-roads.py
@@ -5,7 +5,7 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class NeMinZoomRoads(FixtureTest):
@@ -16,7 +16,7 @@ class NeMinZoomRoads(FixtureTest):
         self.generate_fixtures(dsl.way(1, wkt_loads('LINESTRING (-74.34536905773159 40.52738074072361, -74.43219878225844 40.44228761068732, -74.505135750861 40.28252091755795, -74.60585823131211 40.19221800405002)'), {u'labelrank': 0, u'length_km': 41, u'scalerank': 3, u'prefix': u'', u'continent': u'North America', u'namealtt': u'', u'localalt': u'', u'question': 0, u'sov_a3': u'USA', u'label': u'', u'note': u'',
                                u'source': u'naturalearthdata.com', u'ne_part': u'ne_1d4_original', u'toll': 1, u'expressway': 1, u'local': u'', u'edited': u'New in version 2.0.0', u'label2': u'', u'orig_fid': 0, u'namealt': u'', u'uident': 76105, u'featurecla': u'Road', u'rwdb_rd_id': 0, u'name': u'95', u'level': u'Interstate', u'type': u'Major Highway', u'routeraw': u'', u'ignore': 0, u'add': 0, u'localtype': u'', u'min_zoom': 3.0}))
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_roads_present_at_zoom_5(self):
         # the road should be present at zoom 5
         self.assert_has_feature(

--- a/integration-test/1353-ne-min-zoom-roads.py
+++ b/integration-test/1353-ne-min-zoom-roads.py
@@ -1,8 +1,11 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class NeMinZoomRoads(FixtureTest):
@@ -13,6 +16,7 @@ class NeMinZoomRoads(FixtureTest):
         self.generate_fixtures(dsl.way(1, wkt_loads('LINESTRING (-74.34536905773159 40.52738074072361, -74.43219878225844 40.44228761068732, -74.505135750861 40.28252091755795, -74.60585823131211 40.19221800405002)'), {u'labelrank': 0, u'length_km': 41, u'scalerank': 3, u'prefix': u'', u'continent': u'North America', u'namealtt': u'', u'localalt': u'', u'question': 0, u'sov_a3': u'USA', u'label': u'', u'note': u'',
                                u'source': u'naturalearthdata.com', u'ne_part': u'ne_1d4_original', u'toll': 1, u'expressway': 1, u'local': u'', u'edited': u'New in version 2.0.0', u'label2': u'', u'orig_fid': 0, u'namealt': u'', u'uident': 76105, u'featurecla': u'Road', u'rwdb_rd_id': 0, u'name': u'95', u'level': u'Interstate', u'type': u'Major Highway', u'routeraw': u'', u'ignore': 0, u'add': 0, u'localtype': u'', u'min_zoom': 3.0}))
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_roads_present_at_zoom_5(self):
         # the road should be present at zoom 5
         self.assert_has_feature(

--- a/integration-test/1353-ne-min-zoom-roads.py
+++ b/integration-test/1353-ne-min-zoom-roads.py
@@ -4,8 +4,8 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class NeMinZoomRoads(FixtureTest):
@@ -16,7 +16,7 @@ class NeMinZoomRoads(FixtureTest):
         self.generate_fixtures(dsl.way(1, wkt_loads('LINESTRING (-74.34536905773159 40.52738074072361, -74.43219878225844 40.44228761068732, -74.505135750861 40.28252091755795, -74.60585823131211 40.19221800405002)'), {u'labelrank': 0, u'length_km': 41, u'scalerank': 3, u'prefix': u'', u'continent': u'North America', u'namealtt': u'', u'localalt': u'', u'question': 0, u'sov_a3': u'USA', u'label': u'', u'note': u'',
                                u'source': u'naturalearthdata.com', u'ne_part': u'ne_1d4_original', u'toll': 1, u'expressway': 1, u'local': u'', u'edited': u'New in version 2.0.0', u'label2': u'', u'orig_fid': 0, u'namealt': u'', u'uident': 76105, u'featurecla': u'Road', u'rwdb_rd_id': 0, u'name': u'95', u'level': u'Interstate', u'type': u'Major Highway', u'routeraw': u'', u'ignore': 0, u'add': 0, u'localtype': u'', u'min_zoom': 3.0}))
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_roads_present_at_zoom_5(self):
         # the road should be present at zoom 5
         self.assert_has_feature(

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class KindsForMakiIconSupportTest(FixtureTest):
@@ -918,7 +918,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'name': u'cliff top',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_danger_area_otmoor(self):
         import dsl
 

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class KindsForMakiIconSupportTest(FixtureTest):
@@ -915,6 +918,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'name': u'cliff top',
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_danger_area_otmoor(self):
         import dsl
 

--- a/integration-test/1423-kinds-for-maki-icon-library-support.py
+++ b/integration-test/1423-kinds-for-maki-icon-library-support.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class KindsForMakiIconSupportTest(FixtureTest):
@@ -918,7 +918,7 @@ class KindsForMakiIconSupportTest(FixtureTest):
                 'name': u'cliff top',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_danger_area_otmoor(self):
         import dsl
 

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -1,11 +1,11 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class LowEmissionZoneTest(FixtureTest):
 
     def test_low_emission_zone_way(self):

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -2,10 +2,10 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class LowEmissionZoneTest(FixtureTest):
 
     def test_low_emission_zone_way(self):

--- a/integration-test/1553-hgv-properties.py
+++ b/integration-test/1553-hgv-properties.py
@@ -1,7 +1,11 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class LowEmissionZoneTest(FixtureTest):
 
     def test_low_emission_zone_way(self):

--- a/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
+++ b/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
@@ -2,13 +2,13 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 # To decrease file size let's drop all_networks and all_shield_texts
 # from low and mid-zooms when there's often not room to display this
 # information.
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class DropAllNetworksShieldsAtLowZooms(FixtureTest):
 
     def _drop_at_zoom(self, z, osm=None, kind=None):

--- a/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
+++ b/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
@@ -1,10 +1,14 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 # To decrease file size let's drop all_networks and all_shield_texts
 # from low and mid-zooms when there's often not room to display this
 # information.
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class DropAllNetworksShieldsAtLowZooms(FixtureTest):
 
     def _drop_at_zoom(self, z, osm=None, kind=None):

--- a/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
+++ b/integration-test/1642-drop-all-networks-shields-at-low-zooms.py
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 # To decrease file size let's drop all_networks and all_shield_texts
 # from low and mid-zooms when there's often not room to display this
 # information.
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class DropAllNetworksShieldsAtLowZooms(FixtureTest):
 
     def _drop_at_zoom(self, z, osm=None, kind=None):

--- a/integration-test/1715-slimming-down-boundaries.py
+++ b/integration-test/1715-slimming-down-boundaries.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class BoundaryIdTest(FixtureTest):
@@ -58,7 +58,7 @@ class BoundaryIdTest(FixtureTest):
             ),
         )
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_have_ids_at_z13(self):
         z, x, y = (13, 100, 100)
         self._setup(z, x, y, 1, 2)

--- a/integration-test/1715-slimming-down-boundaries.py
+++ b/integration-test/1715-slimming-down-boundaries.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class BoundaryIdTest(FixtureTest):
@@ -55,6 +58,7 @@ class BoundaryIdTest(FixtureTest):
             ),
         )
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_have_ids_at_z13(self):
         z, x, y = (13, 100, 100)
         self._setup(z, x, y, 1, 2)

--- a/integration-test/1715-slimming-down-boundaries.py
+++ b/integration-test/1715-slimming-down-boundaries.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class BoundaryIdTest(FixtureTest):
@@ -58,7 +58,7 @@ class BoundaryIdTest(FixtureTest):
             ),
         )
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_have_ids_at_z13(self):
         z, x, y = (13, 100, 100)
         self._setup(z, x, y, 1, 2)

--- a/integration-test/1716-reduce-surface-tag-precision.py
+++ b/integration-test/1716-reduce-surface-tag-precision.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class ResidentialTest(FixtureTest):
@@ -13,15 +13,15 @@ class ResidentialTest(FixtureTest):
     def test_z15(self):
         self._check(zoom=15, expect_surface='fine_gravel')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_z14(self):
         self._check(zoom=14, expect_surface='unpaved')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_z13(self):
         self._check(zoom=13, expect_surface='unpaved')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_z12(self):
         self._check(zoom=12, expect_surface='unpaved')
 
@@ -67,19 +67,19 @@ class HighwayTest(FixtureTest):
     def test_z12(self):
         self._check(zoom=12, expect_surface='asphalt')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_z11(self):
         self._check(zoom=11, expect_surface='asphalt')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_z10(self):
         self._check(zoom=10, expect_surface='paved')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_z09(self):
         self._check(zoom=9, expect_surface='paved')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_z08(self):
         self._check(zoom=8, expect_surface='paved')
 

--- a/integration-test/1716-reduce-surface-tag-precision.py
+++ b/integration-test/1716-reduce-surface-tag-precision.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class ResidentialTest(FixtureTest):
@@ -13,15 +13,15 @@ class ResidentialTest(FixtureTest):
     def test_z15(self):
         self._check(zoom=15, expect_surface='fine_gravel')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_z14(self):
         self._check(zoom=14, expect_surface='unpaved')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_z13(self):
         self._check(zoom=13, expect_surface='unpaved')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_z12(self):
         self._check(zoom=12, expect_surface='unpaved')
 
@@ -67,19 +67,19 @@ class HighwayTest(FixtureTest):
     def test_z12(self):
         self._check(zoom=12, expect_surface='asphalt')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_z11(self):
         self._check(zoom=11, expect_surface='asphalt')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_z10(self):
         self._check(zoom=10, expect_surface='paved')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_z09(self):
         self._check(zoom=9, expect_surface='paved')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_z08(self):
         self._check(zoom=8, expect_surface='paved')
 

--- a/integration-test/1716-reduce-surface-tag-precision.py
+++ b/integration-test/1716-reduce-surface-tag-precision.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class ResidentialTest(FixtureTest):
@@ -10,12 +13,15 @@ class ResidentialTest(FixtureTest):
     def test_z15(self):
         self._check(zoom=15, expect_surface='fine_gravel')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_z14(self):
         self._check(zoom=14, expect_surface='unpaved')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_z13(self):
         self._check(zoom=13, expect_surface='unpaved')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_z12(self):
         self._check(zoom=12, expect_surface='unpaved')
 
@@ -61,15 +67,19 @@ class HighwayTest(FixtureTest):
     def test_z12(self):
         self._check(zoom=12, expect_surface='asphalt')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_z11(self):
         self._check(zoom=11, expect_surface='asphalt')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_z10(self):
         self._check(zoom=10, expect_surface='paved')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_z09(self):
         self._check(zoom=9, expect_surface='paved')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_z08(self):
         self._check(zoom=8, expect_surface='paved')
 

--- a/integration-test/1728-henry-coe-state-park.py
+++ b/integration-test/1728-henry-coe-state-park.py
@@ -1,9 +1,13 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class ParkTest(FixtureTest):
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_henry_coe_state_park(self):
         import dsl
 
@@ -33,6 +37,7 @@ class ParkTest(FixtureTest):
                 'kind': 'park',
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_lake_district_national_park(self):
         import dsl
 

--- a/integration-test/1728-henry-coe-state-park.py
+++ b/integration-test/1728-henry-coe-state-park.py
@@ -1,13 +1,13 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class ParkTest(FixtureTest):
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_henry_coe_state_park(self):
         import dsl
 
@@ -37,7 +37,7 @@ class ParkTest(FixtureTest):
                 'kind': 'park',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_lake_district_national_park(self):
         import dsl
 

--- a/integration-test/1728-henry-coe-state-park.py
+++ b/integration-test/1728-henry-coe-state-park.py
@@ -2,12 +2,12 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class ParkTest(FixtureTest):
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_henry_coe_state_park(self):
         import dsl
 
@@ -37,7 +37,7 @@ class ParkTest(FixtureTest):
                 'kind': 'park',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_lake_district_national_park(self):
         import dsl
 

--- a/integration-test/1738-drop-name-from-locality-boundary-z11.py
+++ b/integration-test/1738-drop-name-from-locality-boundary-z11.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 # https://www.openstreetmap.org/relation/3694102
 SAN_ANSELMO = {
@@ -93,7 +93,7 @@ class LocalityTest(FixtureTest):
                 'official_name:left': type(None),
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_name_not_stripped_at_z13(self):
         z, x, y = (13, 1307, 3160)
         self._setup(z, x, y, SAN_ANSELMO, SAN_RAFAEL)

--- a/integration-test/1738-drop-name-from-locality-boundary-z11.py
+++ b/integration-test/1738-drop-name-from-locality-boundary-z11.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 # https://www.openstreetmap.org/relation/3694102
 SAN_ANSELMO = {
@@ -93,7 +93,7 @@ class LocalityTest(FixtureTest):
                 'official_name:left': type(None),
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_name_not_stripped_at_z13(self):
         z, x, y = (13, 1307, 3160)
         self._setup(z, x, y, SAN_ANSELMO, SAN_RAFAEL)

--- a/integration-test/1738-drop-name-from-locality-boundary-z11.py
+++ b/integration-test/1738-drop-name-from-locality-boundary-z11.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 # https://www.openstreetmap.org/relation/3694102
 SAN_ANSELMO = {
@@ -90,6 +93,7 @@ class LocalityTest(FixtureTest):
                 'official_name:left': type(None),
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_name_not_stripped_at_z13(self):
         z, x, y = (13, 1307, 3160)
         self._setup(z, x, y, SAN_ANSELMO, SAN_RAFAEL)

--- a/integration-test/1769-fix-tier3-zoom-12-area-threshold.py
+++ b/integration-test/1769-fix-tier3-zoom-12-area-threshold.py
@@ -1,11 +1,11 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class LanduseTest(FixtureTest):
     def test_tier1_national_park(self):
         import dsl

--- a/integration-test/1769-fix-tier3-zoom-12-area-threshold.py
+++ b/integration-test/1769-fix-tier3-zoom-12-area-threshold.py
@@ -1,9 +1,12 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class LanduseTest(FixtureTest):
-
     def test_tier1_national_park(self):
         import dsl
 

--- a/integration-test/1769-fix-tier3-zoom-12-area-threshold.py
+++ b/integration-test/1769-fix-tier3-zoom-12-area-threshold.py
@@ -2,10 +2,10 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class LanduseTest(FixtureTest):
     def test_tier1_national_park(self):
         import dsl

--- a/integration-test/1794-demote-early-landcover.py
+++ b/integration-test/1794-demote-early-landcover.py
@@ -1,12 +1,12 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class DemoteEarlyLandcover(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_forest(self):
         import dsl
 

--- a/integration-test/1794-demote-early-landcover.py
+++ b/integration-test/1794-demote-early-landcover.py
@@ -2,11 +2,11 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class DemoteEarlyLandcover(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_forest(self):
         import dsl
 

--- a/integration-test/1794-demote-early-landcover.py
+++ b/integration-test/1794-demote-early-landcover.py
@@ -1,9 +1,12 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class DemoteEarlyLandcover(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_forest(self):
         import dsl
 

--- a/integration-test/1800-limit-marshes.py
+++ b/integration-test/1800-limit-marshes.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class MarshTest(FixtureTest):
@@ -42,7 +42,7 @@ class MarshTest(FixtureTest):
                 'name': str,
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_oro_loma_marsh(self):
         import dsl
 

--- a/integration-test/1800-limit-marshes.py
+++ b/integration-test/1800-limit-marshes.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class MarshTest(FixtureTest):
@@ -42,7 +42,7 @@ class MarshTest(FixtureTest):
                 'name': str,
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_oro_loma_marsh(self):
         import dsl
 

--- a/integration-test/1800-limit-marshes.py
+++ b/integration-test/1800-limit-marshes.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class MarshTest(FixtureTest):
@@ -39,6 +42,7 @@ class MarshTest(FixtureTest):
                 'name': str,
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_oro_loma_marsh(self):
         import dsl
 

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -1,9 +1,12 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class CountryBoundaryTest(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundary(self):
         import dsl
 
@@ -115,6 +118,7 @@ class CountryBoundaryTest(FixtureTest):
                 'name': 'XX - YY',
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_claim(self):
         # test that a claim by countries BB & CC (and recognised by DD) is
         # only kind:country for those countries. everyone else's view is

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -2,11 +2,11 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class CountryBoundaryTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundary(self):
         import dsl
 
@@ -118,7 +118,7 @@ class CountryBoundaryTest(FixtureTest):
                 'name': 'XX - YY',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_claim(self):
         # test that a claim by countries BB & CC (and recognised by DD) is
         # only kind:country for those countries. everyone else's view is

--- a/integration-test/1810-alternate-viewpoints.py
+++ b/integration-test/1810-alternate-viewpoints.py
@@ -1,12 +1,12 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class CountryBoundaryTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundary(self):
         import dsl
 
@@ -118,7 +118,7 @@ class CountryBoundaryTest(FixtureTest):
                 'name': 'XX - YY',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_claim(self):
         # test that a claim by countries BB & CC (and recognised by DD) is
         # only kind:country for those countries. everyone else's view is

--- a/integration-test/1873-backfill-aerodrome-polygons.py
+++ b/integration-test/1873-backfill-aerodrome-polygons.py
@@ -1,10 +1,11 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
+@unittest.skip(BROKEN)
 class AerodromeTest(FixtureTest):
     def test_sfo(self):
         # SFO should be "international": both the polygon _and_ the POI.

--- a/integration-test/1873-backfill-aerodrome-polygons.py
+++ b/integration-test/1873-backfill-aerodrome-polygons.py
@@ -11,7 +11,6 @@ class AerodromeTest(FixtureTest):
         import dsl
 
         z, x, y = (13, 1311, 3170)
-
         self.generate_fixtures(
             # https://www.openstreetmap.org/way/545819287
             dsl.way(545819287, dsl.tile_box(z, x, y), {

--- a/integration-test/1873-backfill-aerodrome-polygons.py
+++ b/integration-test/1873-backfill-aerodrome-polygons.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class AerodromeTest(FixtureTest):

--- a/integration-test/1873-backfill-aerodrome-polygons.py
+++ b/integration-test/1873-backfill-aerodrome-polygons.py
@@ -1,9 +1,11 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class AerodromeTest(FixtureTest):
-
     def test_sfo(self):
         # SFO should be "international": both the polygon _and_ the POI.
         import dsl

--- a/integration-test/1873-backfill-aerodrome.py
+++ b/integration-test/1873-backfill-aerodrome.py
@@ -1,9 +1,12 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class AerodromeTest(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_sfo(self):
         # SFO should be international because the "aerodrome" tag is
         # international. that should override the "aerodrome:type=public" tag.

--- a/integration-test/1873-backfill-aerodrome.py
+++ b/integration-test/1873-backfill-aerodrome.py
@@ -1,12 +1,12 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class AerodromeTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_sfo(self):
         # SFO should be international because the "aerodrome" tag is
         # international. that should override the "aerodrome:type=public" tag.

--- a/integration-test/1873-backfill-aerodrome.py
+++ b/integration-test/1873-backfill-aerodrome.py
@@ -2,11 +2,11 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class AerodromeTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_sfo(self):
         # SFO should be international because the "aerodrome" tag is
         # international. that should override the "aerodrome:type=public" tag.

--- a/integration-test/1979-shield-text-length.py
+++ b/integration-test/1979-shield-text-length.py
@@ -3,8 +3,8 @@ import unittest
 
 import dsl
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 z, x, y = (16, 10470, 25340)
 
@@ -56,7 +56,7 @@ rel23Bus = {
 
 
 class ShieldTextLengthTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_create_shield_text_length(self):
         self.generate_fixtures(
             # https://www.openstreetmap.org/way/417097119
@@ -99,7 +99,7 @@ class ShieldTextLengthTest(FixtureTest):
             })
 
     # empty strings and route refs over 6 chars in length don't report length
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_lengths_over_6_or_empty_are_not_reported(self):
 
         rel123456 = rel35.copy()

--- a/integration-test/1979-shield-text-length.py
+++ b/integration-test/1979-shield-text-length.py
@@ -4,7 +4,7 @@ import unittest
 import dsl
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 z, x, y = (16, 10470, 25340)
 
@@ -56,7 +56,7 @@ rel23Bus = {
 
 
 class ShieldTextLengthTest(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_create_shield_text_length(self):
         self.generate_fixtures(
             # https://www.openstreetmap.org/way/417097119
@@ -99,7 +99,7 @@ class ShieldTextLengthTest(FixtureTest):
             })
 
     # empty strings and route refs over 6 chars in length don't report length
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_lengths_over_6_or_empty_are_not_reported(self):
 
         rel123456 = rel35.copy()

--- a/integration-test/1979-shield-text-length.py
+++ b/integration-test/1979-shield-text-length.py
@@ -1,7 +1,10 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 z, x, y = (16, 10470, 25340)
 
@@ -53,7 +56,7 @@ rel23Bus = {
 
 
 class ShieldTextLengthTest(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_create_shield_text_length(self):
         self.generate_fixtures(
             # https://www.openstreetmap.org/way/417097119
@@ -96,6 +99,7 @@ class ShieldTextLengthTest(FixtureTest):
             })
 
     # empty strings and route refs over 6 chars in length don't report length
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_lengths_over_6_or_empty_are_not_reported(self):
 
         rel123456 = rel35.copy()

--- a/integration-test/1995-medium-sized-parks.py
+++ b/integration-test/1995-medium-sized-parks.py
@@ -3,12 +3,12 @@ import unittest
 
 import dsl
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class MediumSizedParks(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_alamo_square_min_zoom_12(self):
 
         z, x, y = (12, 654, 1583)

--- a/integration-test/1995-medium-sized-parks.py
+++ b/integration-test/1995-medium-sized-parks.py
@@ -1,11 +1,14 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class MediumSizedParks(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_alamo_square_min_zoom_12(self):
 
         z, x, y = (12, 654, 1583)

--- a/integration-test/1995-medium-sized-parks.py
+++ b/integration-test/1995-medium-sized-parks.py
@@ -4,11 +4,11 @@ import unittest
 import dsl
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class MediumSizedParks(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_alamo_square_min_zoom_12(self):
 
         z, x, y = (12, 654, 1583)

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -4,7 +4,7 @@ import unittest
 import dsl
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class DisputedBoundariesTest(FixtureTest):
@@ -326,7 +326,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:xx': None,  # invalid viewpoint not exported
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundary_administrative_has_dispute_id(self):
         z, x, y = (16, 53533, 28559)
 
@@ -390,7 +390,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'dispute_id': 'AAAA_2222',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_ne_unrecognized_region_boundary_has_dispute_id(self):
         z, x, y = 8, 0, 0
 

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -1,7 +1,10 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class DisputedBoundariesTest(FixtureTest):
@@ -323,6 +326,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:xx': None,  # invalid viewpoint not exported
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundary_administrative_has_dispute_id(self):
         z, x, y = (16, 53533, 28559)
 
@@ -386,6 +390,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'dispute_id': 'AAAA_2222',
             })
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_ne_unrecognized_region_boundary_has_dispute_id(self):
         z, x, y = 8, 0, 0
 

--- a/integration-test/2022-disputed-borders.py
+++ b/integration-test/2022-disputed-borders.py
@@ -3,8 +3,8 @@ import unittest
 
 import dsl
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class DisputedBoundariesTest(FixtureTest):
@@ -326,7 +326,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'kind:xx': None,  # invalid viewpoint not exported
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundary_administrative_has_dispute_id(self):
         z, x, y = (16, 53533, 28559)
 
@@ -390,7 +390,7 @@ class DisputedBoundariesTest(FixtureTest):
                 'dispute_id': 'AAAA_2222',
             })
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_ne_unrecognized_region_boundary_has_dispute_id(self):
         z, x, y = 8, 0, 0
 

--- a/integration-test/404-toys-not-found.py
+++ b/integration-test/404-toys-not-found.py
@@ -3,7 +3,7 @@ import unittest
 import dsl
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class ToysNotFound(FixtureTest):
@@ -82,7 +82,7 @@ class ToysNotFound(FixtureTest):
         self._run_test(16, 19300, 24630,
                        'https://www.openstreetmap.org/node/1429062988')
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_10(self):
         self._run_test(16, 19300, 24629,
                        'https://www.openstreetmap.org/node/1058296287')

--- a/integration-test/404-toys-not-found.py
+++ b/integration-test/404-toys-not-found.py
@@ -2,8 +2,8 @@ import unittest
 
 import dsl
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class ToysNotFound(FixtureTest):
@@ -82,7 +82,7 @@ class ToysNotFound(FixtureTest):
         self._run_test(16, 19300, 24630,
                        'https://www.openstreetmap.org/node/1429062988')
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_10(self):
         self._run_test(16, 19300, 24629,
                        'https://www.openstreetmap.org/node/1058296287')

--- a/integration-test/404-toys-not-found.py
+++ b/integration-test/404-toys-not-found.py
@@ -1,6 +1,9 @@
+import unittest
+
 import dsl
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class ToysNotFound(FixtureTest):
@@ -79,6 +82,7 @@ class ToysNotFound(FixtureTest):
         self._run_test(16, 19300, 24630,
                        'https://www.openstreetmap.org/node/1429062988')
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_10(self):
         self._run_test(16, 19300, 24629,
                        'https://www.openstreetmap.org/node/1058296287')

--- a/integration-test/440-zoos-and-other-attractions-tourism.py
+++ b/integration-test/440-zoos-and-other-attractions-tourism.py
@@ -1,11 +1,11 @@
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class ZoosAndOtherAttractionsTourism(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_tourism(self):
         # Sinclair Oil Apatosaurus, Windsor
         self._run_test(16, 17645, 24251, 786994983, 'artwork')

--- a/integration-test/440-zoos-and-other-attractions-tourism.py
+++ b/integration-test/440-zoos-and-other-attractions-tourism.py
@@ -1,11 +1,11 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class ZoosAndOtherAttractionsTourism(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_tourism(self):
         # Sinclair Oil Apatosaurus, Windsor
         self._run_test(16, 17645, 24251, 786994983, 'artwork')

--- a/integration-test/440-zoos-and-other-attractions-tourism.py
+++ b/integration-test/440-zoos-and-other-attractions-tourism.py
@@ -1,7 +1,11 @@
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class ZoosAndOtherAttractionsTourism(FixtureTest):
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_tourism(self):
         # Sinclair Oil Apatosaurus, Windsor
         self._run_test(16, 17645, 24251, 786994983, 'artwork')

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -1,7 +1,7 @@
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class LanduseTier(FixtureTest):
@@ -49,7 +49,7 @@ class LanduseTier(FixtureTest):
             {'kind': 'national_park', 'id': -1453306, 'tier': 1,
              'min_zoom': 5})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_national_park(self):
         import dsl
 
@@ -80,7 +80,7 @@ class LanduseTier(FixtureTest):
             {'kind': 'national_park', 'id': -921675, 'tier': 1,
              'min_zoom': 8})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_national_forest(self):
         # this is USFS, so demoted to tier 2 :-(
         # area 86685400

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -1,4 +1,7 @@
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class LanduseTier(FixtureTest):
@@ -46,6 +49,7 @@ class LanduseTier(FixtureTest):
             {'kind': 'national_park', 'id': -1453306, 'tier': 1,
              'min_zoom': 5})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_national_park(self):
         import dsl
 
@@ -76,6 +80,7 @@ class LanduseTier(FixtureTest):
             {'kind': 'national_park', 'id': -921675, 'tier': 1,
              'min_zoom': 8})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_national_forest(self):
         # this is USFS, so demoted to tier 2 :-(
         # area 86685400

--- a/integration-test/473-landuse-tier.py
+++ b/integration-test/473-landuse-tier.py
@@ -1,7 +1,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class LanduseTier(FixtureTest):
@@ -49,7 +49,7 @@ class LanduseTier(FixtureTest):
             {'kind': 'national_park', 'id': -1453306, 'tier': 1,
              'min_zoom': 5})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_national_park(self):
         import dsl
 
@@ -80,7 +80,7 @@ class LanduseTier(FixtureTest):
             {'kind': 'national_park', 'id': -921675, 'tier': 1,
              'min_zoom': 8})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_national_forest(self):
         # this is USFS, so demoted to tier 2 :-(
         # area 86685400

--- a/integration-test/489-keep-ref-for-major-roads.py
+++ b/integration-test/489-keep-ref-for-major-roads.py
@@ -1,6 +1,10 @@
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
+@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
 class KeepRefForMajorRoads(FixtureTest):
     def test_I495(self):
         # just checks that there is at least one major_road with a ref set.

--- a/integration-test/489-keep-ref-for-major-roads.py
+++ b/integration-test/489-keep-ref-for-major-roads.py
@@ -1,10 +1,10 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+@unittest.skip(SKIP_UNIT_TEST_REASON)
 class KeepRefForMajorRoads(FixtureTest):
     def test_I495(self):
         # just checks that there is at least one major_road with a ref set.

--- a/integration-test/489-keep-ref-for-major-roads.py
+++ b/integration-test/489-keep-ref-for-major-roads.py
@@ -1,10 +1,10 @@
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
-@unittest.skip(SKIP_UNIT_TEST_REASON)
+@unittest.skip(BROKEN)
 class KeepRefForMajorRoads(FixtureTest):
     def test_I495(self):
         # just checks that there is at least one major_road with a ref set.

--- a/integration-test/593-early-path.py
+++ b/integration-test/593-early-path.py
@@ -1,4 +1,7 @@
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class EarlyPath(FixtureTest):
@@ -37,6 +40,7 @@ class EarlyPath(FixtureTest):
             {'walking_network': 'nwn',
              'walking_shield_text': 'PCT'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_merced_pass_trail(self):
         # highway=path, with route regional (Merced Pass Trail)
         self.load_fixtures(
@@ -58,6 +62,7 @@ class EarlyPath(FixtureTest):
             12, 688, 1584, 'roads',
             {'kind_detail': 'path', 'name': None, 'walking_network': None})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_upper_yosemite_falls_trail(self):
         # highway=path, no route, but has name (Upper Yosemite Falls Trail)
         self.load_fixtures(['https://www.openstreetmap.org/way/162322353'])

--- a/integration-test/593-early-path.py
+++ b/integration-test/593-early-path.py
@@ -1,7 +1,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class EarlyPath(FixtureTest):
@@ -40,7 +40,7 @@ class EarlyPath(FixtureTest):
             {'walking_network': 'nwn',
              'walking_shield_text': 'PCT'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_merced_pass_trail(self):
         # highway=path, with route regional (Merced Pass Trail)
         self.load_fixtures(
@@ -62,7 +62,7 @@ class EarlyPath(FixtureTest):
             12, 688, 1584, 'roads',
             {'kind_detail': 'path', 'name': None, 'walking_network': None})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_upper_yosemite_falls_trail(self):
         # highway=path, no route, but has name (Upper Yosemite Falls Trail)
         self.load_fixtures(['https://www.openstreetmap.org/way/162322353'])

--- a/integration-test/593-early-path.py
+++ b/integration-test/593-early-path.py
@@ -1,7 +1,7 @@
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class EarlyPath(FixtureTest):
@@ -40,7 +40,7 @@ class EarlyPath(FixtureTest):
             {'walking_network': 'nwn',
              'walking_shield_text': 'PCT'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_merced_pass_trail(self):
         # highway=path, with route regional (Merced Pass Trail)
         self.load_fixtures(
@@ -62,7 +62,7 @@ class EarlyPath(FixtureTest):
             12, 688, 1584, 'roads',
             {'kind_detail': 'path', 'name': None, 'walking_network': None})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_upper_yosemite_falls_trail(self):
         # highway=path, no route, but has name (Upper Yosemite Falls Trail)
         self.load_fixtures(['https://www.openstreetmap.org/way/162322353'])

--- a/integration-test/596-add-hiking-routes.py
+++ b/integration-test/596-add-hiking-routes.py
@@ -3,7 +3,7 @@ import unittest
 import dsl
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class AddHikingRoutes(FixtureTest):
@@ -39,7 +39,7 @@ class AddHikingRoutes(FixtureTest):
             15, 5234, 12667, 'roads',
             {'kind': 'path', 'kind_detail': 'footway'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_minor_road_nwn(self):
         # Baker River Road - residential - part of Pacific Northwest
         # Trail (nwn)
@@ -67,7 +67,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'residential',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_major_road_nwn(self):
         # Mount Baker Highway - secondary - part of Pacific Northwest
         # Trail (nwn)
@@ -82,7 +82,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'secondary',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_unclassified_nwn(self):
         # Whiskey Bend Road - unclassified - part of Pacific Northwest
         # Trail (nwn)
@@ -97,7 +97,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'unclassified',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_service_nwn(self):
         # Matz Road - service - part of Ice Age National Scenic Trail
         # (nwn)
@@ -128,7 +128,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'service',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_driveway_nwn(self):
         # Dogbane - service=driveway - part of American Discovery Trail
         # (nwn)

--- a/integration-test/596-add-hiking-routes.py
+++ b/integration-test/596-add-hiking-routes.py
@@ -2,8 +2,8 @@ import unittest
 
 import dsl
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class AddHikingRoutes(FixtureTest):
@@ -39,7 +39,7 @@ class AddHikingRoutes(FixtureTest):
             15, 5234, 12667, 'roads',
             {'kind': 'path', 'kind_detail': 'footway'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_minor_road_nwn(self):
         # Baker River Road - residential - part of Pacific Northwest
         # Trail (nwn)
@@ -67,7 +67,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'residential',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_major_road_nwn(self):
         # Mount Baker Highway - secondary - part of Pacific Northwest
         # Trail (nwn)
@@ -82,7 +82,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'secondary',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_unclassified_nwn(self):
         # Whiskey Bend Road - unclassified - part of Pacific Northwest
         # Trail (nwn)
@@ -97,7 +97,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'unclassified',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_service_nwn(self):
         # Matz Road - service - part of Ice Age National Scenic Trail
         # (nwn)
@@ -128,7 +128,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'service',
              'walking_network': 'nwn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_driveway_nwn(self):
         # Dogbane - service=driveway - part of American Discovery Trail
         # (nwn)

--- a/integration-test/596-add-hiking-routes.py
+++ b/integration-test/596-add-hiking-routes.py
@@ -1,7 +1,9 @@
+import unittest
+
 import dsl
-from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class AddHikingRoutes(FixtureTest):
@@ -37,6 +39,7 @@ class AddHikingRoutes(FixtureTest):
             15, 5234, 12667, 'roads',
             {'kind': 'path', 'kind_detail': 'footway'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_minor_road_nwn(self):
         # Baker River Road - residential - part of Pacific Northwest
         # Trail (nwn)
@@ -64,6 +67,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'residential',
              'walking_network': 'nwn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_major_road_nwn(self):
         # Mount Baker Highway - secondary - part of Pacific Northwest
         # Trail (nwn)
@@ -78,6 +82,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'major_road', 'kind_detail': 'secondary',
              'walking_network': 'nwn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_unclassified_nwn(self):
         # Whiskey Bend Road - unclassified - part of Pacific Northwest
         # Trail (nwn)
@@ -92,6 +97,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'unclassified',
              'walking_network': 'nwn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_service_nwn(self):
         # Matz Road - service - part of Ice Age National Scenic Trail
         # (nwn)
@@ -122,6 +128,7 @@ class AddHikingRoutes(FixtureTest):
             {'kind': 'minor_road', 'kind_detail': 'service',
              'walking_network': 'nwn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_driveway_nwn(self):
         # Dogbane - service=driveway - part of American Discovery Trail
         # (nwn)

--- a/integration-test/647-cycle-route.py
+++ b/integration-test/647-cycle-route.py
@@ -4,7 +4,7 @@ import unittest
 import dsl
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class CycleRoute(FixtureTest):
@@ -87,7 +87,7 @@ class CycleRoute(FixtureTest):
             16, 32209, 22024, 'roads',
             {'id': 315261543, 'kind': 'path', 'bicycle_network': 'ncn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_path_rcn(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/44422697'])
 

--- a/integration-test/647-cycle-route.py
+++ b/integration-test/647-cycle-route.py
@@ -1,7 +1,10 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class CycleRoute(FixtureTest):
@@ -84,6 +87,7 @@ class CycleRoute(FixtureTest):
             16, 32209, 22024, 'roads',
             {'id': 315261543, 'kind': 'path', 'bicycle_network': 'ncn'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_path_rcn(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/44422697'])
 

--- a/integration-test/647-cycle-route.py
+++ b/integration-test/647-cycle-route.py
@@ -3,8 +3,8 @@ import unittest
 
 import dsl
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class CycleRoute(FixtureTest):
@@ -87,7 +87,7 @@ class CycleRoute(FixtureTest):
             16, 32209, 22024, 'roads',
             {'id': 315261543, 'kind': 'path', 'bicycle_network': 'ncn'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_path_rcn(self):
         self.load_fixtures(['http://www.openstreetmap.org/way/44422697'])
 
@@ -229,6 +229,7 @@ class CycleRoute(FixtureTest):
             16, 10484, 25327, 'roads',
             {'id': 28841123, 'is_bicycle_related': True})
 
+    @unittest.skip(BROKEN)
     def test_is_bicycle_related(self):
         # Way: 301442215
         self.load_fixtures(['http://www.openstreetmap.org/way/301442215'])

--- a/integration-test/653-unify-building-part.py
+++ b/integration-test/653-unify-building-part.py
@@ -1,7 +1,7 @@
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 def _tile_centre(z, x, y):
@@ -11,7 +11,7 @@ def _tile_centre(z, x, y):
 
 
 class UnifyBuildingPart(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_one_madison(self):
         # Way: One Madison
         self.load_fixtures([
@@ -32,7 +32,7 @@ class UnifyBuildingPart(FixtureTest):
             16, 19298, 24633, 'buildings',
             {'id': 160967739, 'kind': 'building_part', 'root_id': 264768910})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_ferry_building(self):
         import dsl
         from shapely.wkt import loads as wkt_loads

--- a/integration-test/653-unify-building-part.py
+++ b/integration-test/653-unify-building-part.py
@@ -1,4 +1,7 @@
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 def _tile_centre(z, x, y):
@@ -8,6 +11,7 @@ def _tile_centre(z, x, y):
 
 
 class UnifyBuildingPart(FixtureTest):
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_one_madison(self):
         # Way: One Madison
         self.load_fixtures([
@@ -28,6 +32,7 @@ class UnifyBuildingPart(FixtureTest):
             16, 19298, 24633, 'buildings',
             {'id': 160967739, 'kind': 'building_part', 'root_id': 264768910})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_ferry_building(self):
         import dsl
         from shapely.wkt import loads as wkt_loads

--- a/integration-test/653-unify-building-part.py
+++ b/integration-test/653-unify-building-part.py
@@ -1,7 +1,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 def _tile_centre(z, x, y):
@@ -11,7 +11,7 @@ def _tile_centre(z, x, y):
 
 
 class UnifyBuildingPart(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_one_madison(self):
         # Way: One Madison
         self.load_fixtures([
@@ -32,7 +32,7 @@ class UnifyBuildingPart(FixtureTest):
             16, 19298, 24633, 'buildings',
             {'id': 160967739, 'kind': 'building_part', 'root_id': 264768910})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_ferry_building(self):
         import dsl
         from shapely.wkt import loads as wkt_loads

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -1,7 +1,11 @@
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class WalkingRouteRefs(FixtureTest):
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_single_route(self):
         # walking route constituent ways should have the walking route
         # properties projected onto them.

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -1,11 +1,11 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class WalkingRouteRefs(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_single_route(self):
         # walking route constituent ways should have the walking route
         # properties projected onto them.

--- a/integration-test/775-walking-route-refs.py
+++ b/integration-test/775-walking-route-refs.py
@@ -1,11 +1,11 @@
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class WalkingRouteRefs(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_single_route(self):
         # walking route constituent ways should have the walking route
         # properties projected onto them.

--- a/integration-test/829-garden-pois.py
+++ b/integration-test/829-garden-pois.py
@@ -1,11 +1,15 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class GardenPois(FixtureTest):
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_garden_with_area(self):
         # update gardens in pois
         # garden with area in pois

--- a/integration-test/829-garden-pois.py
+++ b/integration-test/829-garden-pois.py
@@ -5,11 +5,11 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class GardenPois(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_garden_with_area(self):
         # update gardens in pois
         # garden with area in pois

--- a/integration-test/829-garden-pois.py
+++ b/integration-test/829-garden-pois.py
@@ -4,12 +4,12 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class GardenPois(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_garden_with_area(self):
         # update gardens in pois
         # garden with area in pois

--- a/integration-test/896-ne-shield-enums-2.py
+++ b/integration-test/896-ne-shield-enums-2.py
@@ -5,7 +5,7 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 # I think we should remove for v1 (and never should be been included at zoom
@@ -41,7 +41,7 @@ class NeShieldEnums2(FixtureTest):
             {'source': 'naturalearthdata.com', 'kind': 'highway',
              'namealtt': None})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_network_and_shield(self):
         # network & shield text should stay on highways at lower zooms.
         # E30 (M4) in UK

--- a/integration-test/896-ne-shield-enums-2.py
+++ b/integration-test/896-ne-shield-enums-2.py
@@ -4,8 +4,8 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 # I think we should remove for v1 (and never should be been included at zoom
@@ -41,7 +41,7 @@ class NeShieldEnums2(FixtureTest):
             {'source': 'naturalearthdata.com', 'kind': 'highway',
              'namealtt': None})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_network_and_shield(self):
         # network & shield text should stay on highways at lower zooms.
         # E30 (M4) in UK

--- a/integration-test/896-ne-shield-enums-2.py
+++ b/integration-test/896-ne-shield-enums-2.py
@@ -1,8 +1,11 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 # I think we should remove for v1 (and never should be been included at zoom
@@ -38,6 +41,7 @@ class NeShieldEnums2(FixtureTest):
             {'source': 'naturalearthdata.com', 'kind': 'highway',
              'namealtt': None})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_network_and_shield(self):
         # network & shield text should stay on highways at lower zooms.
         # E30 (M4) in UK

--- a/integration-test/896-ne-shield-enums.py
+++ b/integration-test/896-ne-shield-enums.py
@@ -4,8 +4,8 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class NeShieldEnums(FixtureTest):
@@ -29,7 +29,7 @@ class NeShieldEnums(FixtureTest):
             {'source': 'naturalearthdata.com', 'network': 'US:I',
              'kind': 'highway', 'shield_text': '20'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_us76(self):
         # US-76
         self.assert_has_feature(
@@ -44,7 +44,7 @@ class NeShieldEnums(FixtureTest):
             {'source': 'naturalearthdata.com', 'network': 'MX',
              'kind': 'highway', 'shield_text': '49'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_mex54(self):
         # MEX 54 (federal)
         self.assert_has_feature(

--- a/integration-test/896-ne-shield-enums.py
+++ b/integration-test/896-ne-shield-enums.py
@@ -5,7 +5,7 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class NeShieldEnums(FixtureTest):
@@ -29,7 +29,7 @@ class NeShieldEnums(FixtureTest):
             {'source': 'naturalearthdata.com', 'network': 'US:I',
              'kind': 'highway', 'shield_text': '20'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_us76(self):
         # US-76
         self.assert_has_feature(
@@ -44,7 +44,7 @@ class NeShieldEnums(FixtureTest):
             {'source': 'naturalearthdata.com', 'network': 'MX',
              'kind': 'highway', 'shield_text': '49'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_mex54(self):
         # MEX 54 (federal)
         self.assert_has_feature(

--- a/integration-test/896-ne-shield-enums.py
+++ b/integration-test/896-ne-shield-enums.py
@@ -1,8 +1,11 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class NeShieldEnums(FixtureTest):
@@ -26,6 +29,7 @@ class NeShieldEnums(FixtureTest):
             {'source': 'naturalearthdata.com', 'network': 'US:I',
              'kind': 'highway', 'shield_text': '20'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_us76(self):
         # US-76
         self.assert_has_feature(
@@ -40,6 +44,7 @@ class NeShieldEnums(FixtureTest):
             {'source': 'naturalearthdata.com', 'network': 'MX',
              'kind': 'highway', 'shield_text': '49'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_mex54(self):
         # MEX 54 (federal)
         self.assert_has_feature(

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -3,11 +3,11 @@ import unittest
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class FractionalPois(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_apple_store(self):
         import dsl
         # Apple Store, SF
@@ -64,7 +64,7 @@ class FractionalPois(FixtureTest):
              'source': 'openstreetmap.org',
              'name': 'New Jersey - New York'})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_major_road_route(self):
         self.load_fixtures([
             'http://www.openstreetmap.org/relation/568499',
@@ -130,7 +130,7 @@ class FractionalPoisNe(FixtureTest):
 
         self.load_fixtures(fixtures)
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundaries(self):
         # Test that source and min_zoom are set properly for boundaries, roads,
         # transit, and water

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -1,9 +1,13 @@
+import unittest
+
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class FractionalPois(FixtureTest):
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_apple_store(self):
         import dsl
         # Apple Store, SF
@@ -60,6 +64,7 @@ class FractionalPois(FixtureTest):
              'source': 'openstreetmap.org',
              'name': 'New Jersey - New York'})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_major_road_route(self):
         self.load_fixtures([
             'http://www.openstreetmap.org/relation/568499',
@@ -125,6 +130,7 @@ class FractionalPoisNe(FixtureTest):
 
         self.load_fixtures(fixtures)
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundaries(self):
         # Test that source and min_zoom are set properly for boundaries, roads,
         # transit, and water

--- a/integration-test/976-fractional-pois.py
+++ b/integration-test/976-fractional-pois.py
@@ -2,12 +2,12 @@ import unittest
 
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class FractionalPois(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_apple_store(self):
         import dsl
         # Apple Store, SF
@@ -64,7 +64,7 @@ class FractionalPois(FixtureTest):
              'source': 'openstreetmap.org',
              'name': 'New Jersey - New York'})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_major_road_route(self):
         self.load_fixtures([
             'http://www.openstreetmap.org/relation/568499',
@@ -130,7 +130,7 @@ class FractionalPoisNe(FixtureTest):
 
         self.load_fixtures(fixtures)
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundaries(self):
         # Test that source and min_zoom are set properly for boundaries, roads,
         # transit, and water

--- a/integration-test/977-min-zoom-from-ne-join.py
+++ b/integration-test/977-min-zoom-from-ne-join.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class MinZoomFromNETest(FixtureTest):
@@ -63,7 +63,7 @@ class MinZoomFromNETest(FixtureTest):
 
 
 class MinZoomFromAdminAreaBasedDefault(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_united_kingdom(self):
         # in the absence of data joined from NE, we should fall back to a
         # default based on the country that the label point is in.

--- a/integration-test/977-min-zoom-from-ne-join.py
+++ b/integration-test/977-min-zoom-from-ne-join.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class MinZoomFromNETest(FixtureTest):
@@ -60,7 +63,7 @@ class MinZoomFromNETest(FixtureTest):
 
 
 class MinZoomFromAdminAreaBasedDefault(FixtureTest):
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_united_kingdom(self):
         # in the absence of data joined from NE, we should fall back to a
         # default based on the country that the label point is in.

--- a/integration-test/977-min-zoom-from-ne-join.py
+++ b/integration-test/977-min-zoom-from-ne-join.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class MinZoomFromNETest(FixtureTest):
@@ -63,7 +63,7 @@ class MinZoomFromNETest(FixtureTest):
 
 
 class MinZoomFromAdminAreaBasedDefault(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_united_kingdom(self):
         # in the absence of data joined from NE, we should fall back to a
         # default based on the country that the label point is in.

--- a/integration-test/982-remove-unstyled-localities.py
+++ b/integration-test/982-remove-unstyled-localities.py
@@ -1,8 +1,11 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class RemoveUnstyledLocalities(FixtureTest):
@@ -20,6 +23,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'town', 'name': 'Arcata',
              'id': 141029389, 'min_zoom': 8})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_zoom_9_10(self):
         # zoom 9 and 10:
         # include only those localities with name and kind_detail IN
@@ -40,6 +44,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'town', 'name': 'Hoopa',
              'id': 4270230299, 'min_zoom': 9})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_zoom_11(self):
         # zoom 11:
         # include only those localities with name and kind_detail IN
@@ -62,6 +67,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'village', 'name': 'Fairfax',
              'id': 150949805, 'min_zoom': 11})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_zoom_12(self):
         # zoom 12:
         # include only those localities with name and kind_detail IN
@@ -85,6 +91,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'hamlet',
              'name': 'Duncans Mills', 'id': 150966610, 'min_zoom': 12})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_zoom_13_and_up(self):
         # example: http://www.openstreetmap.org/node/150973394 - Inverness
         # hamlet with NO population should NOT show up at zoom 12

--- a/integration-test/982-remove-unstyled-localities.py
+++ b/integration-test/982-remove-unstyled-localities.py
@@ -4,8 +4,8 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class RemoveUnstyledLocalities(FixtureTest):
@@ -23,7 +23,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'town', 'name': 'Arcata',
              'id': 141029389, 'min_zoom': 8})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_zoom_9_10(self):
         # zoom 9 and 10:
         # include only those localities with name and kind_detail IN
@@ -44,7 +44,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'town', 'name': 'Hoopa',
              'id': 4270230299, 'min_zoom': 9})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_zoom_11(self):
         # zoom 11:
         # include only those localities with name and kind_detail IN
@@ -67,7 +67,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'village', 'name': 'Fairfax',
              'id': 150949805, 'min_zoom': 11})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_zoom_12(self):
         # zoom 12:
         # include only those localities with name and kind_detail IN
@@ -91,7 +91,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'hamlet',
              'name': 'Duncans Mills', 'id': 150966610, 'min_zoom': 12})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_zoom_13_and_up(self):
         # example: http://www.openstreetmap.org/node/150973394 - Inverness
         # hamlet with NO population should NOT show up at zoom 12

--- a/integration-test/982-remove-unstyled-localities.py
+++ b/integration-test/982-remove-unstyled-localities.py
@@ -5,7 +5,7 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class RemoveUnstyledLocalities(FixtureTest):
@@ -23,7 +23,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'town', 'name': 'Arcata',
              'id': 141029389, 'min_zoom': 8})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_zoom_9_10(self):
         # zoom 9 and 10:
         # include only those localities with name and kind_detail IN
@@ -44,7 +44,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'town', 'name': 'Hoopa',
              'id': 4270230299, 'min_zoom': 9})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_zoom_11(self):
         # zoom 11:
         # include only those localities with name and kind_detail IN
@@ -67,7 +67,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'village', 'name': 'Fairfax',
              'id': 150949805, 'min_zoom': 11})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_zoom_12(self):
         # zoom 12:
         # include only those localities with name and kind_detail IN
@@ -91,7 +91,7 @@ class RemoveUnstyledLocalities(FixtureTest):
             {'kind': 'locality', 'kind_detail': 'hamlet',
              'name': 'Duncans Mills', 'id': 150966610, 'min_zoom': 12})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_zoom_13_and_up(self):
         # example: http://www.openstreetmap.org/node/150973394 - Inverness
         # hamlet with NO population should NOT show up at zoom 12

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -1,11 +1,15 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class NationalForests(FixtureTest):
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundary_national_park(self):
         # Example Stanislaus National Forest in California near Yosemite
         # should be kind:forest.
@@ -16,6 +20,7 @@ class NationalForests(FixtureTest):
             11, 340, 788, 'landuse',
             {'kind': 'forest', 'id': -972008})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_protect_class_5(self):
         # But this other Humboldt forest in Nevada has protect_class 5 so
         # that's not guaranteed, should be kind:forest.
@@ -36,6 +41,7 @@ class NationalForests(FixtureTest):
             14, 2559, 6099, 'landuse',
             {'kind': 'forest', 'id': -6213964})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_operator_usnps_not_forest(self):
         # Counter example is Mojave National Preserve which is operated by
         # United States National Park Service so we don't want it to become
@@ -77,7 +83,7 @@ class NationalForests(FixtureTest):
     # to say forest, and it's not a national park. Alternatively
     # boundary:type=protected_area could give us kind: protected_area
     # instead.
-
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_protection_title_national_forest(self):
         # This feature also has protection_title=National Forest, and the
         # name is "Arapaho National Forest", so it should probably be classed
@@ -89,6 +95,7 @@ class NationalForests(FixtureTest):
             13, 1683, 3103, 'landuse',
             {'kind': 'forest', 'id': -396026})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_nature_reserve_protected_area(self):
         # leisure=nature_reserve in North Farallon Islands State Marine
         # Reserve has boundary=protected_area with protect_class=4 in tile
@@ -101,6 +108,7 @@ class NationalForests(FixtureTest):
             11, 323, 791, 'landuse',
             {'kind': 'nature_reserve', 'id': 436801947})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_nature_reserve_national_park(self):
         # leisure=nature_reserve in Mount Tamalpais Watershed has
         # boundary=national_park with boundary:type=protected_area and
@@ -125,6 +133,7 @@ class NationalForests(FixtureTest):
             15, 5229, 12648, 'landuse',
             {'kind': 'common', 'id': 297452972})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_nature_reserve_boundary_type(self):
         # leisure=nature_reserve in Glen Canyon National Recreation Area with
         # boundary=national_park and boundary:type=protected_area and
@@ -137,6 +146,7 @@ class NationalForests(FixtureTest):
             12, 784, 1585, 'landuse',
             {'kind': 'nature_reserve', 'id': -5273153})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_plain_nature_reserve(self):
         # leisure=nature_reserve in Parque Natural Sierra de Andújar with
         # finally kind:nature_reserve.
@@ -147,6 +157,7 @@ class NationalForests(FixtureTest):
             13, 4003, 3151, 'landuse',
             {'kind': 'nature_reserve', 'id': 373769670})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_protected_area_protect_class_5(self):
         # boundary=protected_area in Naturpark Steigerwald with
         # protect_class=5 should end up with kind: protected_area
@@ -168,6 +179,7 @@ class NationalForests(FixtureTest):
             16, 10452, 25302, 'landuse',
             {'kind': 'national_park', 'id': -6229828})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_park_protect_class_5(self):
         # leisure=park in Henry W. Coe State Park with boundary=protected_area
         # and protect_class=5 should end up with kind:park.
@@ -178,6 +190,7 @@ class NationalForests(FixtureTest):
             13, 1332, 3184, 'landuse',
             {'kind': 'park', 'id': -318202})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_nature_reserve_plus_operator_national_park_service(self):
         # operator=United States National Park Service and protect_class=2 in
         # Yosemite National Park with boundary=national_park and
@@ -189,6 +202,7 @@ class NationalForests(FixtureTest):
             13, 1371, 3164, 'landuse',
             {'kind': 'national_park', 'id': -1643367})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundary_national_park_plus_operator_usnps_redwood(self):
         # operator=United States National Park Service and protect_class=2 in
         # Redwood National Park with boundary=national_park and
@@ -200,6 +214,7 @@ class NationalForests(FixtureTest):
             13, 1274, 3066, 'landuse',
             {'kind': 'national_park', 'id': -215231})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundary_national_park_plus_operator_usnps_yellowstone(self):
         # operator=United States National Park Service and protect_class=2 in
         # Yellowstone National Park with boundary=national_park and
@@ -211,6 +226,7 @@ class NationalForests(FixtureTest):
             13, 1591, 2972, 'landuse',
             {'kind': 'national_park', 'id': -1453306})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundary_national_park_adirondack(self):
         # boundary=national_park in Adirondack Park should end up with
         # kind:park.
@@ -221,6 +237,7 @@ class NationalForests(FixtureTest):
             13, 2410, 3001, 'landuse',
             {'kind': 'park', 'id': -1695394})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_boundary_national_park_plus_operator_usnps_shenandoah(self):
         # operator=United States National Park Service and protect_class=2 in
         # Shenandoah National Park with boundary=national_park and
@@ -232,6 +249,7 @@ class NationalForests(FixtureTest):
             13, 2313, 3142, 'landuse',
             {'kind': 'national_park', 'id': -5548542})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_designation_national_park(self):
         # designation=national_park in Cairngorms National Park with
         # boundary=national_park should end up with kind:national_park.
@@ -242,6 +260,7 @@ class NationalForests(FixtureTest):
             13, 4014, 2512, 'landuse',
             {'kind': 'national_park', 'id': -1947603})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_designation_aonb(self):
         # boundary=national_park in North Wessex Downs AONB with
         # designation=area_of_outstanding_natural_beauty should end up with
@@ -253,6 +272,7 @@ class NationalForests(FixtureTest):
             13, 4054, 2728, 'landuse',
             {'kind': 'park', 'id': -2904192})
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_parks_canada(self):
         # operator:en=Parks Canada and boundary=national_park in Riding
         # Mountain National Park with leisure=nature_reserve.

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -5,11 +5,11 @@ import dsl
 from shapely.wkt import loads as wkt_loads
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class NationalForests(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundary_national_park(self):
         # Example Stanislaus National Forest in California near Yosemite
         # should be kind:forest.
@@ -20,7 +20,7 @@ class NationalForests(FixtureTest):
             11, 340, 788, 'landuse',
             {'kind': 'forest', 'id': -972008})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_protect_class_5(self):
         # But this other Humboldt forest in Nevada has protect_class 5 so
         # that's not guaranteed, should be kind:forest.
@@ -41,7 +41,7 @@ class NationalForests(FixtureTest):
             14, 2559, 6099, 'landuse',
             {'kind': 'forest', 'id': -6213964})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_operator_usnps_not_forest(self):
         # Counter example is Mojave National Preserve which is operated by
         # United States National Park Service so we don't want it to become
@@ -83,7 +83,7 @@ class NationalForests(FixtureTest):
     # to say forest, and it's not a national park. Alternatively
     # boundary:type=protected_area could give us kind: protected_area
     # instead.
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_protection_title_national_forest(self):
         # This feature also has protection_title=National Forest, and the
         # name is "Arapaho National Forest", so it should probably be classed
@@ -95,7 +95,7 @@ class NationalForests(FixtureTest):
             13, 1683, 3103, 'landuse',
             {'kind': 'forest', 'id': -396026})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_nature_reserve_protected_area(self):
         # leisure=nature_reserve in North Farallon Islands State Marine
         # Reserve has boundary=protected_area with protect_class=4 in tile
@@ -108,7 +108,7 @@ class NationalForests(FixtureTest):
             11, 323, 791, 'landuse',
             {'kind': 'nature_reserve', 'id': 436801947})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_nature_reserve_national_park(self):
         # leisure=nature_reserve in Mount Tamalpais Watershed has
         # boundary=national_park with boundary:type=protected_area and
@@ -133,7 +133,7 @@ class NationalForests(FixtureTest):
             15, 5229, 12648, 'landuse',
             {'kind': 'common', 'id': 297452972})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_nature_reserve_boundary_type(self):
         # leisure=nature_reserve in Glen Canyon National Recreation Area with
         # boundary=national_park and boundary:type=protected_area and
@@ -146,7 +146,7 @@ class NationalForests(FixtureTest):
             12, 784, 1585, 'landuse',
             {'kind': 'nature_reserve', 'id': -5273153})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_plain_nature_reserve(self):
         # leisure=nature_reserve in Parque Natural Sierra de Andújar with
         # finally kind:nature_reserve.
@@ -157,7 +157,7 @@ class NationalForests(FixtureTest):
             13, 4003, 3151, 'landuse',
             {'kind': 'nature_reserve', 'id': 373769670})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_protected_area_protect_class_5(self):
         # boundary=protected_area in Naturpark Steigerwald with
         # protect_class=5 should end up with kind: protected_area
@@ -179,7 +179,7 @@ class NationalForests(FixtureTest):
             16, 10452, 25302, 'landuse',
             {'kind': 'national_park', 'id': -6229828})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_park_protect_class_5(self):
         # leisure=park in Henry W. Coe State Park with boundary=protected_area
         # and protect_class=5 should end up with kind:park.
@@ -190,7 +190,7 @@ class NationalForests(FixtureTest):
             13, 1332, 3184, 'landuse',
             {'kind': 'park', 'id': -318202})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_nature_reserve_plus_operator_national_park_service(self):
         # operator=United States National Park Service and protect_class=2 in
         # Yosemite National Park with boundary=national_park and
@@ -202,7 +202,7 @@ class NationalForests(FixtureTest):
             13, 1371, 3164, 'landuse',
             {'kind': 'national_park', 'id': -1643367})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundary_national_park_plus_operator_usnps_redwood(self):
         # operator=United States National Park Service and protect_class=2 in
         # Redwood National Park with boundary=national_park and
@@ -214,7 +214,7 @@ class NationalForests(FixtureTest):
             13, 1274, 3066, 'landuse',
             {'kind': 'national_park', 'id': -215231})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundary_national_park_plus_operator_usnps_yellowstone(self):
         # operator=United States National Park Service and protect_class=2 in
         # Yellowstone National Park with boundary=national_park and
@@ -226,7 +226,7 @@ class NationalForests(FixtureTest):
             13, 1591, 2972, 'landuse',
             {'kind': 'national_park', 'id': -1453306})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundary_national_park_adirondack(self):
         # boundary=national_park in Adirondack Park should end up with
         # kind:park.
@@ -237,7 +237,7 @@ class NationalForests(FixtureTest):
             13, 2410, 3001, 'landuse',
             {'kind': 'park', 'id': -1695394})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_boundary_national_park_plus_operator_usnps_shenandoah(self):
         # operator=United States National Park Service and protect_class=2 in
         # Shenandoah National Park with boundary=national_park and
@@ -249,7 +249,7 @@ class NationalForests(FixtureTest):
             13, 2313, 3142, 'landuse',
             {'kind': 'national_park', 'id': -5548542})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_designation_national_park(self):
         # designation=national_park in Cairngorms National Park with
         # boundary=national_park should end up with kind:national_park.
@@ -260,7 +260,7 @@ class NationalForests(FixtureTest):
             13, 4014, 2512, 'landuse',
             {'kind': 'national_park', 'id': -1947603})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_designation_aonb(self):
         # boundary=national_park in North Wessex Downs AONB with
         # designation=area_of_outstanding_natural_beauty should end up with
@@ -272,7 +272,7 @@ class NationalForests(FixtureTest):
             13, 4054, 2728, 'landuse',
             {'kind': 'park', 'id': -2904192})
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_parks_canada(self):
         # operator:en=Parks Canada and boundary=national_park in Riding
         # Mountain National Park with leisure=nature_reserve.

--- a/integration-test/987-national-forests.py
+++ b/integration-test/987-national-forests.py
@@ -4,12 +4,12 @@ import unittest
 import dsl
 from shapely.wkt import loads as wkt_loads
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class NationalForests(FixtureTest):
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundary_national_park(self):
         # Example Stanislaus National Forest in California near Yosemite
         # should be kind:forest.
@@ -20,7 +20,7 @@ class NationalForests(FixtureTest):
             11, 340, 788, 'landuse',
             {'kind': 'forest', 'id': -972008})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_protect_class_5(self):
         # But this other Humboldt forest in Nevada has protect_class 5 so
         # that's not guaranteed, should be kind:forest.
@@ -41,7 +41,7 @@ class NationalForests(FixtureTest):
             14, 2559, 6099, 'landuse',
             {'kind': 'forest', 'id': -6213964})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_operator_usnps_not_forest(self):
         # Counter example is Mojave National Preserve which is operated by
         # United States National Park Service so we don't want it to become
@@ -83,7 +83,7 @@ class NationalForests(FixtureTest):
     # to say forest, and it's not a national park. Alternatively
     # boundary:type=protected_area could give us kind: protected_area
     # instead.
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_protection_title_national_forest(self):
         # This feature also has protection_title=National Forest, and the
         # name is "Arapaho National Forest", so it should probably be classed
@@ -95,7 +95,7 @@ class NationalForests(FixtureTest):
             13, 1683, 3103, 'landuse',
             {'kind': 'forest', 'id': -396026})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_nature_reserve_protected_area(self):
         # leisure=nature_reserve in North Farallon Islands State Marine
         # Reserve has boundary=protected_area with protect_class=4 in tile
@@ -108,7 +108,7 @@ class NationalForests(FixtureTest):
             11, 323, 791, 'landuse',
             {'kind': 'nature_reserve', 'id': 436801947})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_nature_reserve_national_park(self):
         # leisure=nature_reserve in Mount Tamalpais Watershed has
         # boundary=national_park with boundary:type=protected_area and
@@ -133,7 +133,7 @@ class NationalForests(FixtureTest):
             15, 5229, 12648, 'landuse',
             {'kind': 'common', 'id': 297452972})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_nature_reserve_boundary_type(self):
         # leisure=nature_reserve in Glen Canyon National Recreation Area with
         # boundary=national_park and boundary:type=protected_area and
@@ -146,7 +146,7 @@ class NationalForests(FixtureTest):
             12, 784, 1585, 'landuse',
             {'kind': 'nature_reserve', 'id': -5273153})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_plain_nature_reserve(self):
         # leisure=nature_reserve in Parque Natural Sierra de Andújar with
         # finally kind:nature_reserve.
@@ -157,7 +157,7 @@ class NationalForests(FixtureTest):
             13, 4003, 3151, 'landuse',
             {'kind': 'nature_reserve', 'id': 373769670})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_protected_area_protect_class_5(self):
         # boundary=protected_area in Naturpark Steigerwald with
         # protect_class=5 should end up with kind: protected_area
@@ -179,7 +179,7 @@ class NationalForests(FixtureTest):
             16, 10452, 25302, 'landuse',
             {'kind': 'national_park', 'id': -6229828})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_park_protect_class_5(self):
         # leisure=park in Henry W. Coe State Park with boundary=protected_area
         # and protect_class=5 should end up with kind:park.
@@ -190,7 +190,7 @@ class NationalForests(FixtureTest):
             13, 1332, 3184, 'landuse',
             {'kind': 'park', 'id': -318202})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_nature_reserve_plus_operator_national_park_service(self):
         # operator=United States National Park Service and protect_class=2 in
         # Yosemite National Park with boundary=national_park and
@@ -202,7 +202,7 @@ class NationalForests(FixtureTest):
             13, 1371, 3164, 'landuse',
             {'kind': 'national_park', 'id': -1643367})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundary_national_park_plus_operator_usnps_redwood(self):
         # operator=United States National Park Service and protect_class=2 in
         # Redwood National Park with boundary=national_park and
@@ -214,7 +214,7 @@ class NationalForests(FixtureTest):
             13, 1274, 3066, 'landuse',
             {'kind': 'national_park', 'id': -215231})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundary_national_park_plus_operator_usnps_yellowstone(self):
         # operator=United States National Park Service and protect_class=2 in
         # Yellowstone National Park with boundary=national_park and
@@ -226,7 +226,7 @@ class NationalForests(FixtureTest):
             13, 1591, 2972, 'landuse',
             {'kind': 'national_park', 'id': -1453306})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundary_national_park_adirondack(self):
         # boundary=national_park in Adirondack Park should end up with
         # kind:park.
@@ -237,7 +237,7 @@ class NationalForests(FixtureTest):
             13, 2410, 3001, 'landuse',
             {'kind': 'park', 'id': -1695394})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_boundary_national_park_plus_operator_usnps_shenandoah(self):
         # operator=United States National Park Service and protect_class=2 in
         # Shenandoah National Park with boundary=national_park and
@@ -249,7 +249,7 @@ class NationalForests(FixtureTest):
             13, 2313, 3142, 'landuse',
             {'kind': 'national_park', 'id': -5548542})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_designation_national_park(self):
         # designation=national_park in Cairngorms National Park with
         # boundary=national_park should end up with kind:national_park.
@@ -260,7 +260,7 @@ class NationalForests(FixtureTest):
             13, 4014, 2512, 'landuse',
             {'kind': 'national_park', 'id': -1947603})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_designation_aonb(self):
         # boundary=national_park in North Wessex Downs AONB with
         # designation=area_of_outstanding_natural_beauty should end up with
@@ -272,7 +272,7 @@ class NationalForests(FixtureTest):
             13, 4054, 2728, 'landuse',
             {'kind': 'park', 'id': -2904192})
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_parks_canada(self):
         # operator:en=Parks Canada and boundary=national_park in Riding
         # Mountain National Park with leisure=nature_reserve.

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -2,7 +2,7 @@
 import unittest
 
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_MESSAGE
+from . import SKIP_UNIT_TEST_REASON
 
 
 class PopulationRankTest(FixtureTest):
@@ -210,7 +210,7 @@ class CountryTest(FixtureTest):
 
         self.assertLess(rank1, rank2)
 
-    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
+    @unittest.skip(SKIP_UNIT_TEST_REASON)
     def test_country_collision_rank(self):
         rank1 = self._rank('country', 5000000)
         rank2 = self._rank('country', 1000000)

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -1,5 +1,8 @@
 # -*- encoding: utf-8 -*-
+import unittest
+
 from . import FixtureTest
+from . import SKIP_UNIT_TEST_MESSAGE
 
 
 class PopulationRankTest(FixtureTest):
@@ -207,6 +210,7 @@ class CountryTest(FixtureTest):
 
         self.assertLess(rank1, rank2)
 
+    @unittest.skip(SKIP_UNIT_TEST_MESSAGE)
     def test_country_collision_rank(self):
         rank1 = self._rank('country', 5000000)
         rank2 = self._rank('country', 1000000)

--- a/integration-test/988-add-population-to-collision-rank.py
+++ b/integration-test/988-add-population-to-collision-rank.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
+from . import BROKEN
 from . import FixtureTest
-from . import SKIP_UNIT_TEST_REASON
 
 
 class PopulationRankTest(FixtureTest):
@@ -210,7 +210,7 @@ class CountryTest(FixtureTest):
 
         self.assertLess(rank1, rank2)
 
-    @unittest.skip(SKIP_UNIT_TEST_REASON)
+    @unittest.skip(BROKEN)
     def test_country_collision_rank(self):
         rank1 = self._rank('country', 5000000)
         rank2 = self._rank('country', 1000000)

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -49,7 +49,7 @@ from vectordatasource.meta.python import output_min_zoom
 from vectordatasource.meta.python import parse_layers
 
 
-SKIP_UNIT_TEST_MESSAGE = 'Test failed please fix and re-enable'
+SKIP_UNIT_TEST_REASON = 'Test failed please fix and re-enable'
 
 # the Overpass server is used to download data about OSM elements. the
 # environment allows us to override the default public Overpass server to take

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -39,6 +39,7 @@ from tilequeue.tile import coord_to_bounds
 from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import reproject_lnglat_to_mercator
 from tilequeue.tile import reproject_mercator_to_lnglat
+from yaml import load as load_yaml
 
 from vectordatasource.meta import find_yaml_path
 from vectordatasource.meta.python import make_function_name_min_zoom
@@ -46,8 +47,9 @@ from vectordatasource.meta.python import make_function_name_props
 from vectordatasource.meta.python import output_kind
 from vectordatasource.meta.python import output_min_zoom
 from vectordatasource.meta.python import parse_layers
-from yaml import load as load_yaml
 
+
+SKIP_UNIT_TEST_MESSAGE = 'Test failed please fix and re-enable'
 
 # the Overpass server is used to download data about OSM elements. the
 # environment allows us to override the default public Overpass server to take

--- a/integration-test/__init__.py
+++ b/integration-test/__init__.py
@@ -49,7 +49,7 @@ from vectordatasource.meta.python import output_min_zoom
 from vectordatasource.meta.python import parse_layers
 
 
-SKIP_UNIT_TEST_REASON = 'Test failed please fix and re-enable'
+BROKEN = 'Test failed please fix and re-enable'
 
 # the Overpass server is used to download data about OSM elements. the
 # environment allows us to override the default public Overpass server to take


### PR DESCRIPTION
Currently there are many integ tests are failing, these sometimes actually would let people ignore checking the integ tests results when they making changes. So we temporarily disable those changes and this gives us an opportunity to not allow merges that break the test job.


- [x] Update tests
- [x] Update docs
