### PR TITLE
Fix missing boundary property for water layer

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -947,7 +947,6 @@ post_process:
       properties:
         - id
         - area
-        - boundary
         - layer
         - wikidata_id
         - osm_relation


### PR DESCRIPTION
Fix missing boundary property for water layer which caused that water boundary lines was not shown in Mapzen map styles